### PR TITLE
Higher precision for RMSNorm/RoPE in quantized models & flash-attn disable option

### DIFF
--- a/ReadMe-CN.md
+++ b/ReadMe-CN.md
@@ -28,7 +28,7 @@
 |------------------|---------------|----------|------------------------|
 | Llama-3.1-8B | ISQ (BF16->Q4K) | 8B | **90.19** tokens/s |
 | DeepSeek-R1-Distill-Llama-8B | Q2_K | 8B | **94.47** tokens/s |
-| DeepSeek-R1-0528-Qwen3-8B | Q4_K_M | 8B | **82.14** tokens/s |
+| DeepSeek-R1-0528-Qwen3-8B | Q4_K_M | 8B | **95** tokens/s |
 | GLM-4-9B-0414 | Q4_K_M | 9B | **70.38** tokens/s |
 | QwQ-32B | Q4_K_M | 32B | **35.69** tokens/s |
 | **Qwen3-30B-A3B** | Q4_K_M | **30B (MoE)** | **75.91** tokens/s  |
@@ -131,7 +131,7 @@ python -m vllm_rs.server --f /path/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf --d 0
 python -m vllm_rs.server --w /path/Qwen3-30B-A3B-Instruct-2507 --d 0,1 --host 0.0.0.0 --port 8000 --isq q4k --max-model-len 262144 --max-num-seqs 1
 
 # GGUF模型多GPU推理+上下文缓存 (缓存上下文，通过OpenAI API发起请求时在`extra_body`字段里传入`session_id`，`session_id`在对话过程中保持不变，新对话需要启用新的`session_id`，无需改变其它设置)
-python -m vllm_rs.server --m unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF --f Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf --d 0,1 --host 0.0.0.0 --port 8000 --max-model-len 64000 --max-num-seqs 8 
+python -m vllm_rs.server --m unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF --f Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf --d 0,1 --host 0.0.0.0 --port 8000 --max-model-len 64000 --max-num-seqs 8 --context-cache
 ```
 
 ### 🤖 客户端使用上下文缓存特性
@@ -215,6 +215,8 @@ for token in stream:
 ## 🔨 从源代码编译安装（可选）
 
 > ⚠️ 启用 Flash Attention（CUDA）时，首次编译可能需要较长时间。
+
+> ⚠️ 启用 上下文缓存或多GPU推理时，需要同时编译`Runner`（使用`build.sh` 或 `run.sh`）
 
 ### 🛠️ 环境要求
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -28,7 +28,7 @@ A blazing-fast ⚡, lightweight **Rust** 🦀 implementation of vLLM.
 |------------------|---------------|----------|------------------------|
 | Llama-3.1-8B | ISQ (BF16->Q4K) | 8B | **90.19** tokens/s |
 | DeepSeek-R1-Distill-Llama-8B | Q2_K | 8B | **94.47** tokens/s |
-| DeepSeek-R1-0528-Qwen3-8B | Q4_K_M | 8B | **82.14** tokens/s |
+| DeepSeek-R1-0528-Qwen3-8B | Q4_K_M | 8B | **95** tokens/s |
 | GLM-4-9B-0414 | Q4_K_M | 9B | **70.38** tokens/s |
 | QwQ-32B | Q4_K_M | 32B | **35.69** tokens/s |
 | **Qwen3-30B-A3B** | Q4_K_M | **30B (MoE)**| **75.91** tokens/s  |
@@ -216,6 +216,9 @@ for token in stream:
 ## 🔨 Build Python Package from source (Optional)
 
 > ⚠️ The first build may take time if `Flash Attention` is enabled.
+
+> ⚠️ When enabling context caching or multi-GPU inference, you also need to compile `Runner` (using `build.sh` or `run.sh`).
+
 
 ### 🛠️ Prerequisites
 

--- a/example/chat.py
+++ b/example/chat.py
@@ -63,6 +63,7 @@ def build_engine_config(args, num_of_prompts):
         isq=args.isq,
         device_ids=[int(d) for d in args.d.split(",")],
         generation_cfg=generation_cfg,
+        flash_context=args.context_cache,
     )
 
 def show_tokens_left(tokens_left: int, total_tokens: int):

--- a/example/completion.py
+++ b/example/completion.py
@@ -52,6 +52,7 @@ def run(args):
         isq=args.isq,
         device_ids=[int(d) for d in args.d.split(",")],
         generation_cfg=generation_cfg,
+        flash_context=args.context_cache,
     )
 
 
@@ -115,6 +116,7 @@ if __name__ == "__main__":
     parser.add_argument("--top-p", type=float, default=None)
     parser.add_argument("--top-k", type=int, default=None)
     parser.add_argument("--penalty", type=float, default=None)
+    parser.add_argument("--context-cache", action="store_true")
 
     args = parser.parse_args()
     if not os.path.exists(args.w):

--- a/example/server.py
+++ b/example/server.py
@@ -160,6 +160,7 @@ def parse_args():
     parser.add_argument("--top-p", type=float, default=None)
     parser.add_argument("--top-k", type=int, default=None)
     parser.add_argument("--penalty", type=float, default=None)
+    parser.add_argument("--context-cache", action="store_true")
 
     return parser.parse_args()
 
@@ -192,6 +193,7 @@ def main():
         isq=args.isq,
         device_ids=[int(d) for d in args.d.split(",")],
         generation_cfg=generation_cfg,
+        flash_context=args.context_cache,
     )
 
     app = create_app(cfg, args.dtype)

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -4,7 +4,9 @@ use super::scheduler::Scheduler;
 use super::sequence::Sequence;
 use crate::core::sequence::DecodeSequence;
 use crate::core::GenerationOutput;
-use crate::models::layers::distributed::{Comm, Id};
+use crate::models::layers::distributed::Comm;
+#[cfg(feature = "nccl")]
+use crate::models::layers::distributed::Id;
 use crate::models::layers::VarBuilderX;
 use crate::runner::{receive_local, send_local, MessageType, RunnerInitRequest};
 use crate::utils::chat_template::Message;

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -178,7 +178,15 @@ impl LLMEngine {
         );
 
         #[cfg(all(feature = "nccl", feature = "flash-decoding"))]
-        let use_runner = true;
+        let use_runner = if num_shards > 1 {
+            if !econfig.flash_context.unwrap_or(false) {
+                crate::log_warn!("Context cache is forced to be enabled under multi-rank inference if flash-decoding/flash-context feature built-in!");
+                econfig.flash_context = Some(true);
+            }
+            true
+        } else {
+            econfig.flash_context.unwrap_or(false)
+        };
 
         #[cfg(not(all(feature = "nccl", feature = "flash-decoding")))]
         let use_runner = num_shards > 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,6 +193,7 @@ async fn main() -> Result<()> {
         args.device_ids.clone(),
         generation_cfg,
         args.seed,
+        Some(args.context_cache),
     );
 
     let engine = LLMEngine::new(&econfig, dtype)?;

--- a/src/models/glm4.rs
+++ b/src/models/glm4.rs
@@ -192,7 +192,7 @@ impl GLM4ForCausalLM {
             dtype,
         )?;
         let rotary_emb = Arc::new(ScalingRotaryEmbedding::new(
-            dtype,
+            if is_qvar_builder { DType::F32} else { dtype },
             config,
             &vb.device(),
             is_rope_i,

--- a/src/models/glm4.rs
+++ b/src/models/glm4.rs
@@ -3,14 +3,14 @@ use crate::models::layers::attention::Attention;
 use crate::models::layers::distributed::{Comm, ReplicatedLinear};
 use crate::models::layers::mask::get_attention_casual_mask;
 use crate::models::layers::mlp::MLP;
-use crate::models::layers::others::{embedding, rms_norm};
+use crate::models::layers::others::{embedding, rms_norm, NormX};
 use crate::models::layers::rotary_emb::ScalingRotaryEmbedding;
 use crate::models::layers::VarBuilderX;
 use crate::utils::config::Config;
 use crate::utils::progress::ProgressLike;
 use attention_rs::InputMetadata;
 use candle_core::{DType, Device, Result, Tensor};
-use candle_nn::{Module, RmsNorm};
+use candle_nn::Module;
 use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::iter::zip;
@@ -20,10 +20,10 @@ use std::sync::Arc;
 pub struct GLM4DecoderLayer {
     self_attn: Attention,
     mlp: MLP,
-    input_layernorm: RmsNorm,
-    post_attention_layernorm: RmsNorm,
-    post_self_attn_layernorm: RmsNorm,
-    post_mlp_layernorm: RmsNorm,
+    input_layernorm: NormX,
+    post_attention_layernorm: NormX,
+    post_self_attn_layernorm: NormX,
+    post_mlp_layernorm: NormX,
 }
 
 impl GLM4DecoderLayer {
@@ -59,7 +59,6 @@ impl GLM4DecoderLayer {
             true, //gate and up merged
             dtype,
         )?;
-        let is_qvar_builder = vb.is_qvar_builder();
 
         let key_map: HashMap<&str, &str> = [
             ("input_layernorm", "attn_norm"),
@@ -151,7 +150,7 @@ impl GLM4DecoderLayer {
 pub struct GLM4ForCausalLM {
     embed_tokens: candle_nn::Embedding,
     layers: Vec<GLM4DecoderLayer>,
-    norm: RmsNorm,
+    norm: NormX,
     lm_head: ReplicatedLinear,
     device: Device,
     config: Config,
@@ -192,7 +191,11 @@ impl GLM4ForCausalLM {
             dtype,
         )?;
         let rotary_emb = Arc::new(ScalingRotaryEmbedding::new(
-            if is_qvar_builder { DType::F32} else { dtype },
+            if is_qvar_builder || config.quant.is_some() {
+                DType::F32
+            } else {
+                dtype
+            },
             config,
             &vb.device(),
             is_rope_i,
@@ -314,7 +317,7 @@ impl GLM4ForCausalLM {
         }
 
         if !seqlens.is_empty() {
-            let indices: Vec<_> = seqlens.iter().map(|x| x - 1).collect();
+            let indices: Vec<_> = seqlens.iter().map(|x| x - 1 as u32).collect();
             let batch = indices.len();
             xs = xs.index_select(&Tensor::from_vec(indices, (batch,), xs.device())?, 0)?;
         }

--- a/src/models/layers/attention.rs
+++ b/src/models/layers/attention.rs
@@ -1,13 +1,12 @@
 use crate::models::layers::distributed::{
     Comm, TensorParallelColumnLinear, TensorParallelRowLinear,
 };
-use crate::models::layers::others::rms_norm;
+use crate::models::layers::others::{rms_norm, NormX};
 use crate::models::layers::rotary_emb::ScalingRotaryEmbedding;
 use crate::models::layers::VarBuilderX;
 use crate::utils::config::Config;
 use attention_rs::{InputMetadata, PagedAttention};
-use candle_core::{DType, Module, Result, Tensor};
-use candle_nn::RmsNorm;
+use candle_core::{DType, Result, Tensor};
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -17,8 +16,8 @@ pub struct Attention {
     k_proj: TensorParallelColumnLinear,
     v_proj: TensorParallelColumnLinear,
     o_proj: TensorParallelRowLinear,
-    q_norm: Option<RmsNorm>,
-    k_norm: Option<RmsNorm>,
+    q_norm: Option<NormX>,
+    k_norm: Option<NormX>,
     num_heads: usize,
     num_kv_heads: usize,
     head_dim: usize,
@@ -120,7 +119,7 @@ impl Attention {
             } else {
                 vb.pp("q_norm")
             },
-            if config.quant.is_some() { DType::F32 } else { dtype },
+            dtype,
         );
         let q_norm = if q_norm.is_ok() {
             Some(q_norm.unwrap())
@@ -136,7 +135,7 @@ impl Attention {
             } else {
                 vb.pp("k_norm")
             },
-            if config.quant.is_some() { DType::F32 } else { dtype },
+            dtype,
         );
         let k_norm = if k_norm.is_ok() {
             Some(k_norm.unwrap())
@@ -214,13 +213,18 @@ impl Attention {
         // Apply rotary embeddings
         let (q, k) = self.rotary_emb.apply_rotary_emb_qkv(&q, &k, positions)?;
 
-        let (q, k, v) = if q.dtype() != self.dtype {
+        let (q, k) = if q.dtype() != self.dtype {
             let q = q.to_dtype(self.dtype)?;
             let k = k.to_dtype(self.dtype)?;
-            let v = v.to_dtype(self.dtype)?;
-            (q, k, v)
+            (q, k)
         } else {
-            (q, k, v)
+            (q, k)
+        };
+
+        let v = if v.dtype() != self.dtype {
+            v.to_dtype(self.dtype)?
+        } else {
+            v
         };
 
         let y = self
@@ -237,6 +241,6 @@ impl Attention {
             )?
             .reshape((seq_len, ()))?;
 
-        self.o_proj.forward(&y.to_dtype(xs.dtype())?)
+        self.o_proj.forward(&y)?.to_dtype(self.dtype)
     }
 }

--- a/src/models/layers/linear.rs
+++ b/src/models/layers/linear.rs
@@ -224,7 +224,7 @@ impl QLinear {
         let inner = candle_core::quantized::QMatMul::from_arc(ws)?;
         let b = vb.get(out_dim, "bias");
         let bias = if b.is_ok() {
-            let bw = b.unwrap().dequantize(vb.device())?.to_dtype(dtype)?;
+            let bw = b.unwrap().dequantize(vb.device())?;
             if shards.world_size > 1 {
                 let bw_chunk = bw.dim(0)? / shards.world_size;
                 Some(
@@ -240,8 +240,8 @@ impl QLinear {
         Ok(Self {
             inner,
             bias,
-            dtype,
             wdtype,
+            dtype,
         })
     }
 
@@ -277,7 +277,7 @@ impl QLinear {
         let inner = candle_core::quantized::QMatMul::from_arc(ws)?;
         let b = vb.get(out_dim, "bias");
         let bias = if b.is_ok() {
-            let bw = b.unwrap().dequantize(vb.device())?.to_dtype(dtype)?;
+            let bw = b.unwrap().dequantize(vb.device())?;
             if shards.world_size > 1 {
                 let bw_chunk = bw.dim(0)? / shards.world_size;
                 Some(
@@ -301,11 +301,7 @@ impl QLinear {
     pub fn from_qparts_x(w: QTensor, b: Option<Tensor>, dtype: DType) -> Self {
         let bx = match b {
             Some(b_) => {
-                if b_.dtype() != dtype {
-                    Some(b_.to_dtype(dtype).unwrap())
-                } else {
-                    Some(b_)
-                }
+                Some(b_.to_dtype(DType::F32).unwrap())
             }
             _ => None,
         };
@@ -411,7 +407,6 @@ impl Module for QLinear {
             _ => QMatMul::forward(&self.inner, &xs)?,
         };
 
-        let xs = xs.to_dtype(self.dtype)?;
         if let Some(bias) = &self.bias {
             xs.broadcast_add(bias)
         } else {
@@ -425,11 +420,10 @@ impl QLinear {
         let xs = self
             .inner
             .indexed_moe_forward(&x.to_dtype(DType::F32)?, ids)?;
-        let xs = xs.to_dtype(self.dtype)?;
         if let Some(bias) = &self.bias {
-            xs.broadcast_add(bias)
+            xs.broadcast_add(bias)?.to_dtype(self.dtype)
         } else {
-            Ok(xs)
+            xs.to_dtype(self.dtype)
         }
     }
 }

--- a/src/models/layers/mlp.rs
+++ b/src/models/layers/mlp.rs
@@ -114,7 +114,13 @@ impl MLP {
     pub fn forward(&self, xs: &Tensor) -> Result<Tensor> {
         let gate = self.gate_proj.forward(xs)?;
         let up = self.up_proj.forward(xs)?;
-        self.down_proj
-            .forward(&(candle_nn::ops::silu(&gate)? * up)?)
+        let out = self
+            .down_proj
+            .forward(&(candle_nn::ops::silu(&gate)? * up)?)?;
+        if out.dtype() != xs.dtype() {
+            out.to_dtype(xs.dtype())
+        } else {
+            Ok(out)
+        }
     }
 }

--- a/src/models/llama.rs
+++ b/src/models/llama.rs
@@ -162,7 +162,7 @@ impl LLaMaForCausalLM {
         )?;
 
         let rotary_emb = Arc::new(ScalingRotaryEmbedding::new(
-            dtype,
+            if is_qvar_builder { DType::F32} else { dtype },
             config,
             &vb.device(),
             is_rope_i,

--- a/src/models/llama.rs
+++ b/src/models/llama.rs
@@ -3,14 +3,14 @@ use crate::models::layers::attention::Attention;
 use crate::models::layers::distributed::{Comm, ReplicatedLinear};
 use crate::models::layers::mask::get_attention_casual_mask;
 use crate::models::layers::mlp::MLP;
-use crate::models::layers::others::{embedding, rms_norm};
+use crate::models::layers::others::{embedding, rms_norm, NormX};
 use crate::models::layers::rotary_emb::ScalingRotaryEmbedding;
 use crate::models::layers::VarBuilderX;
 use crate::utils::config::Config;
 use crate::utils::progress::ProgressLike;
 use attention_rs::InputMetadata;
 use candle_core::{DType, Device, Result, Tensor};
-use candle_nn::{Module, RmsNorm};
+use candle_nn::Module;
 use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::iter::zip;
@@ -20,8 +20,8 @@ use std::sync::Arc;
 pub struct LLaMaDecoderLayer {
     self_attn: Attention,
     mlp: MLP,
-    input_layernorm: RmsNorm,
-    post_attention_layernorm: RmsNorm,
+    input_layernorm: NormX,
+    post_attention_layernorm: NormX,
 }
 
 impl LLaMaDecoderLayer {
@@ -112,7 +112,6 @@ impl LLaMaDecoderLayer {
         let residual = &xs;
         let xs = self.post_attention_layernorm.forward(&xs)?;
         let mlp_output = self.mlp.forward(&xs)?;
-
         residual + mlp_output
     }
 }
@@ -120,7 +119,7 @@ impl LLaMaDecoderLayer {
 pub struct LLaMaForCausalLM {
     embed_tokens: candle_nn::Embedding,
     layers: Vec<LLaMaDecoderLayer>,
-    norm: RmsNorm,
+    norm: NormX,
     lm_head: ReplicatedLinear,
     device: Device,
     config: Config,
@@ -162,7 +161,11 @@ impl LLaMaForCausalLM {
         )?;
 
         let rotary_emb = Arc::new(ScalingRotaryEmbedding::new(
-            if is_qvar_builder { DType::F32} else { dtype },
+            if is_qvar_builder || config.quant.is_some() {
+                DType::F32
+            } else {
+                dtype
+            },
             config,
             &vb.device(),
             is_rope_i,
@@ -284,7 +287,7 @@ impl LLaMaForCausalLM {
         }
 
         if !seqlens.is_empty() {
-            let indices: Vec<_> = seqlens.iter().map(|x| x - 1).collect();
+            let indices: Vec<_> = seqlens.iter().map(|x| x - 1 as u32).collect();
             let batch = indices.len();
             xs = xs.index_select(&Tensor::from_vec(indices, (batch,), xs.device())?, 0)?;
         }

--- a/src/models/qwen3_moe.rs
+++ b/src/models/qwen3_moe.rs
@@ -219,7 +219,7 @@ impl Qwen3MoEForCausalLM {
             dtype,
         )?;
         let rotary_emb = Arc::new(ScalingRotaryEmbedding::new(
-            dtype,
+            if is_qvar_builder { DType::F32} else { dtype },
             config,
             &vb.device(),
             is_rope_i,

--- a/src/models/qwen3_moe.rs
+++ b/src/models/qwen3_moe.rs
@@ -4,14 +4,14 @@ use crate::models::layers::distributed::{Comm, ReplicatedLinear};
 use crate::models::layers::mask::get_attention_casual_mask;
 use crate::models::layers::mlp::MLP;
 use crate::models::layers::moe::{FusedMoeGGUF, FusedMoeISQ, MoeNaive};
-use crate::models::layers::others::{embedding, rms_norm};
+use crate::models::layers::others::{embedding, rms_norm, NormX};
 use crate::models::layers::rotary_emb::ScalingRotaryEmbedding;
 use crate::models::layers::VarBuilderX;
 use crate::utils::config::Config;
 use crate::utils::progress::ProgressLike;
 use attention_rs::InputMetadata;
 use candle_core::{DType, Device, Result, Tensor};
-use candle_nn::{Module, RmsNorm};
+use candle_nn::Module;
 use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::iter::zip;
@@ -39,8 +39,8 @@ impl MoeOrMlp {
 pub struct Qwen3DecoderLayer {
     self_attn: Attention,
     mlp: MoeOrMlp,
-    input_layernorm: RmsNorm,
-    post_attention_layernorm: RmsNorm,
+    input_layernorm: NormX,
+    post_attention_layernorm: NormX,
 }
 
 impl Qwen3DecoderLayer {
@@ -80,13 +80,12 @@ impl Qwen3DecoderLayer {
         {
             if is_qvar_builder {
                 //experts weights packed
-                MoeOrMlp::FusedMoeGGUF(FusedMoeGGUF::new(config, vb.clone(), comm.clone(), dtype)?)
+                MoeOrMlp::FusedMoeGGUF(FusedMoeGGUF::new(config, vb.clone(), comm.clone())?)
             } else if config.quant.is_some() {
                 MoeOrMlp::FusedMoeISQ(FusedMoeISQ::new(
                     config,
                     vb.pp("mlp").clone(),
                     comm.clone(),
-                    dtype,
                 )?)
             } else {
                 MoeOrMlp::MoeNaive(MoeNaive::new(
@@ -112,8 +111,6 @@ impl Qwen3DecoderLayer {
 
             MoeOrMlp::Mlp(mlp)
         };
-
-        let is_qvar_builder = vb.is_qvar_builder();
 
         let key_map: HashMap<&str, &str> = [
             ("input_layernorm", "attn_norm"),
@@ -170,7 +167,6 @@ impl Qwen3DecoderLayer {
         let residual = &xs;
         let xs = self.post_attention_layernorm.forward(&xs)?;
         let mlp_output = self.mlp.forward(&xs)?;
-
         residual + mlp_output
     }
 }
@@ -178,7 +174,7 @@ impl Qwen3DecoderLayer {
 pub struct Qwen3MoEForCausalLM {
     embed_tokens: candle_nn::Embedding,
     layers: Vec<Qwen3DecoderLayer>,
-    norm: RmsNorm,
+    norm: NormX,
     lm_head: ReplicatedLinear,
     device: Device,
     config: Config,
@@ -219,7 +215,11 @@ impl Qwen3MoEForCausalLM {
             dtype,
         )?;
         let rotary_emb = Arc::new(ScalingRotaryEmbedding::new(
-            if is_qvar_builder { DType::F32} else { dtype },
+            if is_qvar_builder || config.quant.is_some() {
+                DType::F32
+            } else {
+                dtype
+            },
             config,
             &vb.device(),
             is_rope_i,
@@ -342,7 +342,7 @@ impl Qwen3MoEForCausalLM {
         }
 
         if !seqlens.is_empty() {
-            let indices: Vec<_> = seqlens.iter().map(|x| x - 1).collect();
+            let indices: Vec<_> = seqlens.iter().map(|x| x - 1 as u32).collect();
             let batch = indices.len();
             xs = xs.index_select(&Tensor::from_vec(indices, (batch,), xs.device())?, 0)?;
         }

--- a/vllm_rs.pyi
+++ b/vllm_rs.pyi
@@ -45,6 +45,7 @@ class EngineConfig:
     device_id: Optional[int]
     generation_cfg: Optional[GenerationConfig]
     seed: Optional[int]
+    flash_context: Optional[bool]
 
 @dataclass
 class SamplingParams:


### PR DESCRIPTION
This PR brings **three key improvements & fixes** :

1. 🧮 **Higher precision** – RMSNorm/RoPE now use `F32` weight formats for quantized and ISQ (in-situ quantization) models.
2. ⚡ **Configurable Flash-Attn** – Decoding with flash-attn can now be disabled even when both `flash-decoding` and `flash-context` are enabled.
3. 🚀 **Performance fix** – Resolved batch performance degradation issue.

### 🔧 Sample Usage

**Context-cache serving for larger concurrent requests:**

```shell
python -m vllm_rs.server --f /path/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf --context-cache --d 0,1
```

**Simple chat CLI without context-cache:**

```shell
python -m vllm_rs.chat --f /path/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf --port 2000
```

**Chat completion (for benchmarking):**

```shell
python -m vllm_rs.completion --w /home/Qwen3-0.6B/ --batch 256 --max-tokens 1024 --max-model-len 1024
```

### 🛠️ Install and Build

**Install with:**

```shell
pip install vllm_rs --force-reinstall
```

**Or package build from source:**

```shell
# CUDA
./build.sh --release --features cuda,nccl,flash-decoding,flash-context,python
#Metal
./build.sh --release --features metal,python
```

