### PR TITLE
Add Dockerfile for both server and CLI outputs

### DIFF
--- a/ReadMe-CN.md
+++ b/ReadMe-CN.md
@@ -75,6 +75,7 @@
 ---
 ## 📚 文档
 - [快速开始](docs/get_started.md)
+- [Docker构建](docs/docker.md)
 - [MCP集成与工具调用](docs/mcp_tool_calling.md)
 - [Claude Code使用vLLM.rs后端](docs/claude_code.md)
 - [Goose AI Agent使用vLLM.rs后端](docs/goose.md)

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -76,6 +76,7 @@ Supports both **Safetensor** (including GPTQ and AWQ formats) and **GGUF** forma
 ---
 ## 📚 Guides
 - [Get Started](docs/get_started.md)
+- [Docker Build](docs/docker.md)
 - [MCP Integration and Tool Calling](docs/mcp_tool_calling.md)
 - [Work with Claude Code](docs/claude_code.md)
 - [Work with Goose AI Agent](docs/goose.md)


### PR DESCRIPTION
Build the server Rust and Python components, build the Rust CLI. Copy both to the runtime container, install the wheel, and wrap the python server invocation in a shell script. Follows the usage pattern from candle-vllm and mistral.rs. Provides system agnostic build environment since CUDA is now past 12.8 but 12.9 may have adverse effects on graphs and 13 outright drops pre-BF16 devices.