### PR TITLE
Update prefill_paged_attn kernel for V100

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = {git = "https://github.com/guoqingbao/attention.rs.git", version="0.1.1", rev = "a48e3d8" }
+attention-rs = {git = "https://github.com/guoqingbao/attention.rs.git", version="0.1.1", rev = "a3b4049" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"


### PR DESCRIPTION
V100 has less FP32 compute units compared to Ampere+ hardware, therefore, this PR use updated `prefill_paged_attn` kernel which uses FP16 instead of FP32 for P*V acculation and dot product compute with v_cache, this will improve prefill speed in theory. `16%` tested on A100, but may comes with slightly accuracy degradation.

Update and run with on V100:

```shell
./run.sh --features cuda,nccl --release -- --i --w /data/shared/Qwen3-30B-A3B-Instruct-2507 --isq q4k --d 0,1 --max-model-len 155600 --context-cache
```

@sempervictus I'm not sure if this can help prefill speed on V100.