### PR TITLE
Use fused topk kernel on CUDA

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,10 @@ edition = "2021"
 default-run = "vllm-rs"
 
 [dependencies]
-candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "42c9b42" }
-candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "42c9b42" }
+candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "ed18596" }
+candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "ed18596" }
 serde = { version = "1.0.190", features = ["serde_derive"] }
 tokenizers = {version = "0.21.2", features = ["http"] }
-candle-transformers = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "42c9b42" }
 hf-hub = "0.4.1"
 anyhow = "1.0.75"
 itertools = "0.13.0"
@@ -36,7 +35,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.1.3", rev = "011d215" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.1.3", rev = "45ae297" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"
@@ -56,12 +55,12 @@ path = "src/lib.rs"
 crate-type = ["rlib", "cdylib"]  # cdylib needed for python extension
 
 [features]
-cuda = ["candle-core/cuda", "candle-nn/cuda", "candle-transformers/cuda", "attention-rs/cuda", "attention-rs/no-marlin"]
+cuda = ["candle-core/cuda", "candle-nn/cuda", "attention-rs/cuda", "attention-rs/no-marlin"]
 nccl = ["candle-core/nccl"]
 graph = ["cuda", "attention-rs/graph", "candle-core/graph"]
 flash-attn = ["attention-rs/flash-attn", "attention-rs/no-marlin"]
 flash-context = ["attention-rs/flash-attn", "attention-rs/flash-decoding", "attention-rs/flash-context", "attention-rs/no-marlin", "attention-rs/no-fp8-kvcache"]
-metal = ["candle-core/metal", "candle-nn/metal", "candle-transformers/metal", "attention-rs/metal"]
+metal = ["candle-core/metal", "candle-nn/metal", "attention-rs/metal"]
 python = ["pyo3"]
 
 [[bin]]


### PR DESCRIPTION
Topk can be a bottleneck especially for large context, this PR adds support for fused topk (uses recent feature from underlying attention.rs).

```
./run.sh --features cuda,nccl --release -- --f /data/shared/Qwen3-30B-A3B-Instruct-2507-Q4_
K_M.gguf --d 0,1 --max-model-len 128000 --server
```

Tested case (**w/o fused topk**):

```
2025-10-17T08:44:08.316220Z  WARN vllm_rs::core::scheduler: Seq 0 - chunk prefilled 8192 (remain 7809 tokens)
2025-10-17T08:44:26.605902Z  WARN vllm_rs::core::scheduler: Seq 0 - chunk prefill finished (16001 tokens)
2025-10-17T08:44:44.651327Z  INFO vllm_rs::core::scheduler: Kvcache Usage: free 1734 blocks (or 110976 tokens), used 13.30%
2025-10-17T08:45:02.758435Z  INFO vllm_rs::core::scheduler: Kvcache Usage: free 1718 blocks (or 109952 tokens), used 14.10%
2025-10-17T08:45:15.546810Z  INFO vllm_rs::server::server: --- Performance Metrics ---
2025-10-17T08:45:15.546827Z  INFO vllm_rs::server::server: [seq_id 0] ⏱️ Prompt tokens: 16001 in 32.16s (497.59 t/s)
2025-10-17T08:45:15.546835Z  INFO vllm_rs::server::server: [seq_id 0] ⏱️ Decoded tokens: 2704 in 48.94s (55.25 t/s)
```

Tested case (w **fused topk**):


```
2025-10-17T08:50:20.119895Z  WARN vllm_rs::core::scheduler: Seq 0 - chunk prefill finished (18715 tokens)
2025-10-17T08:50:25.331832Z  INFO vllm_rs::core::scheduler: Kvcache Usage: free 1703 blocks (or 108992 tokens), used 14.85%
2025-10-17T08:50:43.587513Z  INFO vllm_rs::core::scheduler: Kvcache Usage: free 1687 blocks (or 107968 tokens), used 15.65%
2025-10-17T08:51:01.948557Z  INFO vllm_rs::core::scheduler: Kvcache Usage: free 1671 blocks (or 106944 tokens), used 16.45%
2025-10-17T08:51:20.732902Z  INFO vllm_rs::core::scheduler: Kvcache Usage: free 1656 blocks (or 105984 tokens), used 17.20%
2025-10-17T08:51:39.617031Z  INFO vllm_rs::core::scheduler: Kvcache Usage: free 1640 blocks (or 104960 tokens), used 18.00%
2025-10-17T08:51:47.092842Z ERROR vllm_rs::server::server: [seq_id 0] Stream send to client error: "Disconnected(..)"
2025-10-17T08:51:47.092861Z  INFO vllm_rs::server::server: --- Performance Metrics ---
2025-10-17T08:51:47.092867Z  INFO vllm_rs::server::server: [Unfinished seq_id 0] ⏱️ Prompt tokens: 18715 in 32.00s (584.90 t/s)
2025-10-17T08:51:47.092872Z  INFO vllm_rs::server::server: [Unfinished seq_id 0] ⏱️ Decoded tokens: 4660 in 86.97s (53.58 t/s)
```

