### PR TITLE
Use fused MoE for unquantized Qwen3 MoE models

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vllm-rs"
-version = "0.3.13"
+version = "0.3.14"
 edition = "2021"
 default-run = "vllm-rs"
 
@@ -35,7 +35,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.1.3", rev = "0e2bb7a" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.1.4", rev = "340a919" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"

--- a/ReadMe-CN.md
+++ b/ReadMe-CN.md
@@ -224,6 +224,9 @@ cargo run --release --features cuda,nccl -- --i --d 0 --m unsloth/Qwen3-30B-A3B-
 # 多卡推理 CUDA + Flash Attention（使用run.sh生成独立runner）
 ./run.sh --release --features cuda,nccl,flash-attn -- --i --d 0,1 --f /path/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf --max-model-len 262144 --context-cache
 
+# 多卡推理 server 服务 (未量化模型)
+./run.sh --release --features cuda,nccl,flash-attn -- --d 0,1,2,3 --w /path/Qwen3-30B-A3B-Instruct-2507 --max-model-len 100000 --max-num-seqs 4 --server --port 8000
+
 # 多卡推理 server 服务 (可选`--fp8-kvcache` 或 `--context-cache`)
 ./run.sh --release --features cuda,nccl,flash-attn -- --d 0,1 --w /path/Qwen3-30B-A3B-Instruct-2507 --isq q4k --max-model-len 100000 --max-num-seqs 4 --server --port 8000 --fp8-kvcache
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -227,6 +227,9 @@ cargo run --release --features cuda,nccl -- --i --d 0 --m unsloth/Qwen3-30B-A3B-
 # Multi-GPU CUDA (+Flash Attention, this scirpt help build the runner)
 ./run.sh --release --features cuda,nccl,flash-attn -- --i --d 0,1 --w /path/Qwen3-30B-A3B-Instruct-2507 --isq q4k --max-model-len 262144 --context-cache
 
+# Multi-GPU CUDA (unquantized models)
+./run.sh --release --features cuda,nccl,flash-attn -- --d 0,1,2,3 --w /path/Qwen3-30B-A3B-Instruct-2507 --max-model-len 100000 --max-num-seqs 4 --server --port 8000
+
 # Multi-GPU server mode (with `--fp8-kvcache` or `--context-cache`)
 ./run.sh --release --features cuda,nccl,flash-attn -- --d 0,1 --w /path/Qwen3-30B-A3B-Instruct-2507 --isq q4k --max-model-len 100000 --max-num-seqs 4 --server --port 8000 --fp8-kvcache
 


### PR DESCRIPTION
This PR introduces **fused MoE** support for **unquantized** Qwen3 MoE models. Two dedicated CUDA kernels were developed in `attention.rs`: https://github.com/guoqingbao/attention.rs/commit/340a9193878cdf54fcb96aab4671ef6ca3b6e988

1) **Tiling-based [moe_gemm](https://github.com/guoqingbao/attention.rs/blob/main/src/kernels/src/moe_gemm.cu#L100)** – optimized for decoding, using vectorized GEMM with shared-memory tiling and per-token expert dispatch.

2) **WMMA-based [moe_gemm_wmma](https://github.com/guoqingbao/attention.rs/blob/main/src/kernels/src/moe_gemm_wmma.cu#L90)** – optimized for prefilling, leveraging NVIDIA’s WMMA API for efficient tensor core utilization.


### Usage

```bash
./run.sh --features cuda,nccl,flash-attn --release \
         --w /data/shared/Qwen3-30B-A3B-Instruct-2507 \
         --d 0,1 --server
```

### Observed Results

Tested on **Qwen3-30B-A3B (unquantized)** configuration:

```
--- Performance Metrics [seq_id 1]---
⏱️ Prompt tokens: 7530 in 6.51s (1156.15 tokens/s)
⏱️ Decoded tokens: 2441 in 61.40s (39.76 tokens/s)
```


