### PR TITLE
Use faster MoE prefill kernel for unquantized models

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vllm-rs"
-version = "0.3.14"
+version = "0.3.15"
 edition = "2021"
 default-run = "vllm-rs"
 
@@ -35,7 +35,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.1.4", rev = "340a919" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.1.4", rev = "c7d683f" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"


### PR DESCRIPTION
This PR improves prefill performance for unquantized Qwen3 MoE models with a kernel specifically developed in `attention.rs` https://github.com/guoqingbao/attention.rs/commit/c7d683f64d9f1b0ef319df024c219320eb5daa5a

It is expected to achieve 2300 tokens/s prefill speed on Ampere+ hardware for long context, or around 2.5 times faster than previous kernel.

Tested case:

```
./run.sh --features cuda,nccl,flash-attn --release --w /data/shared/Qwen3-30B-A3B-Instruct-2507 --d 0,1 --i
```

```
2025-10-30T08:46:37.392164Z  INFO vllm_rs: --- Performance Metrics ---
2025-10-30T08:46:37.392186Z  INFO vllm_rs: ⏱️ Prompt tokens: 27264 in 12.07s (2258.64 tokens/s)
```

_The MoE gguf kernel is also under optimization which is intended to achive similar improvements._