### PR TITLE
Optimize ISQ GGUF/MoE models with Tensor Core kernels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 default-run = "vllm-rs"
 
 [dependencies]
-candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "ed18596" }
-candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "ed18596" }
+candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "82901c5" }
+candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "82901c5" }
 serde = { version = "1.0.190", features = ["serde_derive"] }
 tokenizers = {version = "0.21.2", features = ["http"] }
 hf-hub = "0.4.1"
@@ -35,7 +35,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.1.4", rev = "c7d683f" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.1.5", rev = "8beeb18" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"

--- a/src/models/layers/linear.rs
+++ b/src/models/layers/linear.rs
@@ -322,16 +322,16 @@ impl QLinear {
     pub fn from_linear_x(linear: Linear, quant: String, dtype: DType) -> Result<Self> {
         use quantized::GgmlDType;
         let ggml_dtype = match quant.as_str() {
-            "q4_0" => GgmlDType::Q4_0,
-            "q4_1" => GgmlDType::Q4_1,
-            "q5_0" => GgmlDType::Q5_0,
-            "q5_1" => GgmlDType::Q5_1,
-            "q8_0" => GgmlDType::Q8_0,
-            "q2k" => GgmlDType::Q2K,
-            "q3k" => GgmlDType::Q3K,
-            "q4k" => GgmlDType::Q4K,
-            "q5k" => GgmlDType::Q5K,
-            "q6k" => GgmlDType::Q6K,
+            "q40" | "q4_0" => GgmlDType::Q4_0,
+            "q4" | "q41" | "q4_1" => GgmlDType::Q4_1,
+            "q50" | "q5_0" => GgmlDType::Q5_0,
+            "q5" | "q51" | "q5_1" => GgmlDType::Q5_1,
+            "q8" | "q80" | "q8_0" => GgmlDType::Q8_0,
+            "q2k" | "q2_k" => GgmlDType::Q2K,
+            "q3k" | "q3_k" => GgmlDType::Q3K,
+            "q4k" | "q4_k" => GgmlDType::Q4K,
+            "q5k" | "q5_k" => GgmlDType::Q5K,
+            "q6k" | "q6_k" => GgmlDType::Q6K,
             _ => panic!("Unsupported GGML data type!"),
         };
         let weight = linear.weight();

--- a/src/models/qwen3_moe.rs
+++ b/src/models/qwen3_moe.rs
@@ -33,7 +33,7 @@ impl MoeOrMlp {
             Self::Mlp(m) => m.forward(xs),
             Self::FusedMoe(m) => m.forward(xs, is_prefill),
             Self::FusedMoeGGUF(m) => m.forward(xs),
-            Self::FusedMoeISQ(m) => m.forward(xs),
+            Self::FusedMoeISQ(m) => m.forward(xs, is_prefill),
         }
     }
 }

--- a/src/utils/heartbeat.rs
+++ b/src/utils/heartbeat.rs
@@ -46,7 +46,7 @@ pub fn heartbeat_worker(
                 if !flag_clone.load(Ordering::Relaxed) {
                     crate::log_warn!("{:?}", alive_result);
                 }
-                if heartbeat_error_count > 10 {
+                if heartbeat_error_count > 5 {
                     crate::log_error!(
                         "heartbeat detection failed, exit the current process because of {:?}",
                         alive_result


### PR DESCRIPTION
This PR uses the optimized gguf MoE kernels recently developed in attention.rs https://github.com/guoqingbao/attention.rs/commit/8beeb1898bddbe09918134f3e35bd026b0b94c2a

Tested cases:


_A100-40G PCIE, ISQ Q4K (2 gpus) with ~32K inputs, max output tokens 1000_
```
./run.sh --features cuda,nccl,graph,flash-attn --release --w /data/shared/Qwen3-30B-A3B-Instruct-250
7 --isq q6_k --d 0,1 --i --max-tokens 1000
```

```
2025-11-04T08:23:06.191250Z  INFO vllm_rs: --- Performance Metrics ---
2025-11-04T08:23:06.191266Z  INFO vllm_rs: ⏱️ Prompt tokens: 31263 in 26.67s (1172.44 tokens/s)
2025-11-04T08:23:06.191274Z  INFO vllm_rs: ⏱️ Decoded tokens: 1000 in 20.95s (47.74 tokens/s)
```