### PR TITLE
Add Rust crate API (Engine wrapper), multimodal support, docs and examples

### DIFF
--- a/ReadMe-CN.md
+++ b/ReadMe-CN.md
@@ -79,6 +79,115 @@
 
 支持 **Safetensor** (包含GPTQ, AWQ量化格式) 和 **GGUF** 格式。
 
+## 🦀 Rust Crate API 使用
+
+在 `Cargo.toml` 中添加依赖：
+
+```toml
+[dependencies]
+vllm-rs = { path = "/path/to/vllm.rs", features = ["cuda"] }
+```
+
+### ✅ 直接生成（文本）
+
+```rust
+use vllm_rs::{ChatMessage, Engine, EngineConfig, SamplingParams, get_dtype};
+
+fn main() -> candle_core::Result<()> {
+    let econfig = EngineConfig::new(
+        Some("Qwen/Qwen2.5-7B-Instruct".to_string()),
+        None,
+        None,
+        None,
+        None,
+        Some(4),
+        None,
+        Some(8192),
+        Some(512),
+        None,
+        None,
+        Some(vec![0]),
+        None,
+        None,
+        Some(false),
+        None,
+        Some(true),
+        None,
+        None,
+        None,
+    );
+
+    let engine = Engine::new(econfig, get_dtype(Some("bf16".to_string())))?;
+    let params = SamplingParams::new_with_max_tokens(128);
+    let messages = vec![ChatMessage::text("user", "请用一句话解释 KV Cache")];
+    let output = engine.generate(params, messages)?;
+    println!("{}", output.decode_output);
+    Ok(())
+}
+```
+
+### 🖼️ 多模态输入（图片 URL / base64）
+
+```rust
+use vllm_rs::{ChatMessage, Engine, MessageContent, SamplingParams, get_dtype};
+
+let engine = Engine::new(econfig, get_dtype(Some("bf16".to_string())))?;
+let params = SamplingParams::new_with_max_tokens(256);
+let messages = vec![ChatMessage::multimodal(
+    "user",
+    vec![
+        MessageContent::Text {
+            text: "描述这张图片：".to_string(),
+        },
+        MessageContent::ImageUrl {
+            image_url: "https://example.com/demo.png".to_string(),
+        },
+    ],
+)];
+let output = engine.generate(params, messages)?;
+```
+
+### 🌐 用 Rust 启动 API 服务
+
+```rust
+let engine = Engine::new(econfig, get_dtype(Some("bf16".to_string())))?;
+engine.start_server(8000, true)?;
+```
+
+### 🧩 多卡 / 多 rank
+设置 `device_ids` 并启用 `nccl`：
+
+```toml
+vllm-rs = { path = "/path/to/vllm.rs", features = ["cuda", "nccl"] }
+```
+
+```rust
+let econfig = EngineConfig::new(
+    Some("Qwen/Qwen3-30B-A3B-Instruct-2507".to_string()),
+    None,
+    None,
+    None,
+    None,
+    Some(2),
+    None,
+    Some(65536),
+    Some(1024),
+    None,
+    Some(2),
+    Some(vec![0, 1]),
+    None,
+    None,
+    Some(false),
+    None,
+    Some(true),
+    None,
+    None,
+    None,
+);
+```
+
+更多示例见 `examples/rust_basic.rs` 和 `examples/rust_multimodal.rs`。
+
 ## 📘 使用方法（Python）
 ### 📦 从pip安装
    💡 1. CUDA compute capability < 8.0 GPU设备（例如V100，不支持flash-attn特性）上需要手动编译安装（或直接使用Rust方式）

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -88,6 +88,116 @@ Supports both **Safetensor** (including GPTQ and AWQ formats) and **GGUF** forma
 - [Context cache](docs/context-cache.md)
 - [Get started (run modes, formats, PD, multi-rank)](docs/get_started.md)
 
+## 🦀 Usage in Rust (crate API)
+
+Add to `Cargo.toml`:
+
+```toml
+[dependencies]
+vllm-rs = { path = "/path/to/vllm.rs", features = ["cuda"] }
+```
+
+### ✅ Direct generation (text)
+
+```rust
+use vllm_rs::{ChatMessage, Engine, EngineConfig, SamplingParams, get_dtype};
+
+fn main() -> candle_core::Result<()> {
+    let econfig = EngineConfig::new(
+        Some("Qwen/Qwen2.5-7B-Instruct".to_string()),
+        None,
+        None,
+        None,
+        None,
+        Some(4),
+        None,
+        Some(8192),
+        Some(512),
+        None,
+        None,
+        Some(vec![0]),
+        None,
+        None,
+        Some(false),
+        None,
+        Some(true),
+        None,
+        None,
+        None,
+    );
+
+    let engine = Engine::new(econfig, get_dtype(Some("bf16".to_string())))?;
+    let params = SamplingParams::new_with_max_tokens(128);
+
+    let messages = vec![ChatMessage::text("user", "Explain KV cache in one sentence.")];
+    let output = engine.generate(params, messages)?;
+    println!("{}", output.decode_output);
+    Ok(())
+}
+```
+
+### 🖼️ Multimodal prompt (image URL / base64)
+
+```rust
+use vllm_rs::{ChatMessage, Engine, MessageContent, SamplingParams, get_dtype};
+
+let engine = Engine::new(econfig, get_dtype(Some("bf16".to_string())))?;
+let params = SamplingParams::new_with_max_tokens(256);
+let messages = vec![ChatMessage::multimodal(
+    "user",
+    vec![
+        MessageContent::Text {
+            text: "Describe this image:".to_string(),
+        },
+        MessageContent::ImageUrl {
+            image_url: "https://example.com/demo.png".to_string(),
+        },
+    ],
+)];
+let output = engine.generate(params, messages)?;
+```
+
+### 🌐 Start API server from Rust
+
+```rust
+let engine = Engine::new(econfig, get_dtype(Some("bf16".to_string())))?;
+engine.start_server(8000, true)?;
+```
+
+### 🧩 Multi-GPU / multi-rank
+Set `device_ids` in `EngineConfig` and compile with `nccl`:
+
+```toml
+vllm-rs = { path = "/path/to/vllm.rs", features = ["cuda", "nccl"] }
+```
+
+```rust
+let econfig = EngineConfig::new(
+    Some("Qwen/Qwen3-30B-A3B-Instruct-2507".to_string()),
+    None,
+    None,
+    None,
+    None,
+    Some(2),
+    None,
+    Some(65536),
+    Some(1024),
+    None,
+    Some(2),
+    Some(vec![0, 1]),
+    None,
+    None,
+    Some(false),
+    None,
+    Some(true),
+    None,
+    None,
+    None,
+);
+```
+
+See `examples/rust_basic.rs` and `examples/rust_multimodal.rs` for runnable snippets.
+
 
 ## 📘 Usage in Python
 

--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -79,3 +79,44 @@ Common runtime knobs: `--max-model-len`, `--max-num-seqs`, `--kv-fraction` (CUDA
 - Use `--log` to view loading/progress; watch for “swap” messages (KV pressure).
 - If OOM on Metal, lower `--max-model-len` and batch; on CUDA, reduce `--kv-fraction` or `--max-num-seqs`.
 - For GGUF/ISQ, keep `--max-num-seqs` moderate to avoid bandwidth bottlenecks; consider `--fp8-kvcache` only on Ampere+.
+
+## 9) Rust crate API (direct embed)
+You can embed vLLM.rs directly inside a Rust application using the new API wrapper in `vllm_rs::Engine`.
+
+```toml
+[dependencies]
+vllm-rs = { path = "/path/to/vllm.rs", features = ["cuda"] }
+```
+
+```rust
+use vllm_rs::{ChatMessage, Engine, EngineConfig, SamplingParams, get_dtype};
+
+let econfig = EngineConfig::new(
+    Some("Qwen/Qwen2.5-7B-Instruct".to_string()),
+    None,
+    None,
+    None,
+    None,
+    Some(4),
+    None,
+    Some(8192),
+    Some(512),
+    None,
+    None,
+    Some(vec![0]),
+    None,
+    None,
+    Some(false),
+    None,
+    Some(true),
+    None,
+    None,
+    None,
+);
+
+let engine = Engine::new(econfig, get_dtype(Some("bf16".to_string())))?;
+let params = SamplingParams::new_with_max_tokens(128);
+let messages = vec![ChatMessage::text("user", "Summarize KV cache in one sentence.")];
+let output = engine.generate(params, messages)?;
+println!("{}", output.decode_output);
+```

--- a/examples/rust_basic.rs
+++ b/examples/rust_basic.rs
@@ -1,0 +1,33 @@
+use vllm_rs::{ChatMessage, Engine, EngineConfig, SamplingParams, get_dtype};
+
+fn main() -> candle_core::Result<()> {
+    let econfig = EngineConfig::new(
+        Some("Qwen/Qwen2.5-7B-Instruct".to_string()),
+        None,
+        None,
+        None,
+        None,
+        Some(4),
+        None,
+        Some(8192),
+        Some(256),
+        None,
+        None,
+        Some(vec![0]),
+        None,
+        None,
+        Some(false),
+        None,
+        Some(true),
+        None,
+        None,
+        None,
+    );
+
+    let engine = Engine::new(econfig, get_dtype(Some("bf16".to_string())))?;
+    let params = SamplingParams::new_with_max_tokens(128);
+    let messages = vec![ChatMessage::text("user", "Explain vLLM.rs in one sentence.")];
+    let output = engine.generate(params, messages)?;
+    println!("{}", output.decode_output);
+    Ok(())
+}

--- a/examples/rust_multimodal.rs
+++ b/examples/rust_multimodal.rs
@@ -1,0 +1,44 @@
+use vllm_rs::{ChatMessage, Engine, EngineConfig, MessageContent, SamplingParams, get_dtype};
+
+fn main() -> candle_core::Result<()> {
+    let econfig = EngineConfig::new(
+        Some("Qwen/Qwen3-VL-8B-Instruct".to_string()),
+        None,
+        None,
+        None,
+        None,
+        Some(2),
+        None,
+        Some(8192),
+        Some(256),
+        None,
+        None,
+        Some(vec![0]),
+        None,
+        None,
+        Some(false),
+        None,
+        Some(true),
+        None,
+        None,
+        None,
+    );
+
+    let engine = Engine::new(econfig, get_dtype(Some("bf16".to_string())))?;
+    let params = SamplingParams::new_with_max_tokens(128);
+    let messages = vec![ChatMessage::multimodal(
+        "user",
+        vec![
+            MessageContent::Text {
+                text: "Describe the image in one sentence.".to_string(),
+            },
+            MessageContent::ImageUrl {
+                image_url: "https://example.com/demo.png".to_string(),
+            },
+        ],
+    )];
+
+    let output = engine.generate(params, messages)?;
+    println!("{}", output.decode_output);
+    Ok(())
+}

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,337 @@
+use crate::core::engine::{LLMEngine, StreamItem, GLOBAL_RT};
+use crate::core::GenerationOutput;
+use crate::server::convert_chat_message;
+pub use crate::server::{ChatMessage, MessageContent, MessageContentType};
+use crate::server::{EmbeddingStrategy, ServerData};
+use crate::utils::chat_template::Message;
+use crate::utils::config::{EngineConfig, ModelType, SamplingParams};
+use crate::utils::image::{get_tensor_raw_data, ImageData, ImageProcessTrait, ImageProcessor};
+use axum::routing::{get, post};
+use axum::Json;
+use axum::Router;
+use candle_core::{DType, Result, Tensor};
+use parking_lot::RwLock;
+use rustchatui::start_ui_server;
+use serde_json::json;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tower_http::cors::{Any, CorsLayer};
+
+/// Rust-friendly engine wrapper for direct inference or API serving.
+pub struct Engine {
+    engine: Arc<RwLock<LLMEngine>>,
+    econfig: EngineConfig,
+}
+
+/// Stream response wrapper for direct generation.
+pub struct EngineStream {
+    pub seq_id: usize,
+    pub prompt_length: usize,
+    pub receiver: mpsc::Receiver<StreamItem>,
+}
+
+impl ChatMessage {
+    pub fn text(role: impl Into<String>, content: impl Into<String>) -> Self {
+        ChatMessage {
+            role: role.into(),
+            content: MessageContentType::PureText(content.into()),
+        }
+    }
+
+    pub fn multimodal(role: impl Into<String>, content: Vec<MessageContent>) -> Self {
+        ChatMessage {
+            role: role.into(),
+            content: MessageContentType::Multi(content),
+        }
+    }
+}
+
+impl Engine {
+    pub fn new(econfig: EngineConfig, dtype: DType) -> Result<Self> {
+        let engine = LLMEngine::new(&econfig, dtype)?;
+        Ok(Self { engine, econfig })
+    }
+
+    pub fn config(&self) -> &EngineConfig {
+        &self.econfig
+    }
+
+    pub fn engine(&self) -> Arc<RwLock<LLMEngine>> {
+        self.engine.clone()
+    }
+
+    pub fn get_model_info(&self) -> (bool, String) {
+        let engine = self.engine.read();
+        engine.get_model_info()
+    }
+
+    pub fn generate(
+        &self,
+        params: SamplingParams,
+        messages: Vec<ChatMessage>,
+    ) -> Result<GenerationOutput> {
+        let (messages, images) = self.prepare_messages(&messages)?;
+
+        let receivers = {
+            let mut engine = self.engine.write();
+            engine.generate_sync(&vec![params], &vec![messages], images)?
+        };
+
+        let tokenizer = {
+            let engine = self.engine.read();
+            Arc::new(engine.tokenizer.clone())
+        };
+
+        let results = tokio::task::block_in_place(|| {
+            GLOBAL_RT.block_on(async { LLMEngine::collect_sync_results(receivers, tokenizer).await })
+        })?;
+
+        results
+            .into_iter()
+            .next()
+            .ok_or_else(|| candle_core::Error::Msg("No generation output produced".into()))
+    }
+
+    pub fn generate_batch(
+        &self,
+        params: Vec<SamplingParams>,
+        messages: Vec<Vec<ChatMessage>>,
+    ) -> Result<Vec<GenerationOutput>> {
+        let message_list = messages
+            .iter()
+            .map(|batch| self.prepare_text_only(batch))
+            .collect::<Result<Vec<_>>>()?;
+
+        let receivers = {
+            let mut engine = self.engine.write();
+            engine.generate_sync(&params, &message_list, None)?
+        };
+
+        let tokenizer = {
+            let engine = self.engine.read();
+            Arc::new(engine.tokenizer.clone())
+        };
+
+        tokio::task::block_in_place(|| {
+            GLOBAL_RT.block_on(async { LLMEngine::collect_sync_results(receivers, tokenizer).await })
+        })
+    }
+
+    pub fn generate_stream(
+        &self,
+        params: SamplingParams,
+        messages: Vec<ChatMessage>,
+    ) -> Result<EngineStream> {
+        let (messages, images) = self.prepare_messages(&messages)?;
+        let (seq_id, prompt_length, receiver) = {
+            let mut engine = self.engine.write();
+            engine.generate_stream(&params, &messages, images)?
+        };
+        Ok(EngineStream {
+            seq_id,
+            prompt_length,
+            receiver,
+        })
+    }
+
+    pub fn embed(
+        &self,
+        inputs: &[String],
+        strategy: EmbeddingStrategy,
+    ) -> Result<(Vec<Vec<f32>>, usize)> {
+        let mut engine = self.engine.write();
+        engine.embed(inputs, strategy)
+    }
+
+    pub fn start_server(&self, port: usize, with_ui_server: bool) -> Result<()> {
+        let is_pd_server = if let Some(cfg) = &self.econfig.pd_config {
+            matches!(cfg.role, crate::transfer::PdRole::Server)
+        } else {
+            false
+        };
+
+        let server_data = ServerData {
+            engine: self.engine.clone(),
+            econfig: self.econfig.clone(),
+        };
+
+        let (has_vision, model_name) = {
+            let e = self.engine.read();
+            e.get_model_info()
+        };
+        let has_vision = Arc::new(has_vision);
+
+        let cors = CorsLayer::new()
+            .allow_origin(Any)
+            .allow_methods(Any)
+            .allow_headers(Any);
+
+        let app = Router::new()
+            .route(
+                "/v1/models",
+                get(|| async move {
+                    let m = if *has_vision {
+                        vec!["text", "image"]
+                    } else {
+                        vec!["text"]
+                    };
+                    Json(json!({
+                        "object": "list",
+                        "data": [
+                            {
+                                "id": model_name,
+                                "object": "model",
+                                "created": std::time::SystemTime::now()
+                                    .duration_since(std::time::UNIX_EPOCH)
+                                    .unwrap()
+                                    .as_millis() as i64,
+                                "owned_by": "vllm.rs",
+                                "permission": [],
+                                "modalities": m,
+                            }
+                        ]
+                    }))
+                }),
+            )
+            .route("/v1/chat/completions", post(crate::server::server::chat_completion))
+            .route("/v1/usage", get(crate::server::server::get_usage))
+            .layer(cors)
+            .with_state(Arc::new(server_data));
+
+        let addr = if is_pd_server {
+            crate::log_warn!("🚀 PD server started, waiting for prefill request(s)...",);
+            format!("0.0.0.0:{}", 0)
+        } else {
+            crate::log_warn!("🚀 Chat server listening on http://0.0.0.0:{}/v1/", port);
+            format!("0.0.0.0:{}", port)
+        };
+
+        GLOBAL_RT.block_on(async move {
+            let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
+
+            let mut tasks = Vec::new();
+            tasks.push(tokio::spawn(async move {
+                if let Err(e) = axum::serve(listener, app).await {
+                    eprintln!("Chat API server error: {e:?}");
+                }
+            }));
+
+            if with_ui_server {
+                tasks.push(tokio::spawn(async move {
+                    start_ui_server((port + 1) as u16, Some(port as u16), None, None)
+                        .await
+                        .unwrap();
+                }));
+            }
+
+            tokio::select! {
+                _ = futures::future::try_join_all(tasks) => {},
+                _ = tokio::signal::ctrl_c() => {
+                    println!("Received CTRL+C, shutting down server...");
+                },
+            }
+        });
+
+        Ok(())
+    }
+
+    fn prepare_messages(&self, messages: &[ChatMessage]) -> Result<(Vec<Message>, Option<ImageData>)> {
+        use crate::models::qwen3_vl::input::Qwen3VLImageProcessor;
+
+        let img_cfg = {
+            let engine = self.engine.read();
+            engine.img_cfg.clone()
+        };
+
+        if img_cfg.is_none() && Self::messages_have_images(messages) {
+            candle_core::bail!("Model does not support multimodal inputs.");
+        }
+
+        let mut processor: Option<Box<dyn ImageProcessTrait + Send>> = if let Some(cfg) = &img_cfg {
+            if matches!(cfg.model_type, ModelType::Qwen3VL) {
+                Some(Box::new(Qwen3VLImageProcessor::default(cfg)))
+            } else {
+                Some(Box::new(ImageProcessor::new(cfg)))
+            }
+        } else {
+            None
+        };
+
+        let mut images: Vec<(Tensor, Vec<(usize, usize)>)> = vec![];
+        let messages: Vec<Message> = messages
+            .iter()
+            .map(|m| convert_chat_message(m, &mut processor, &mut images))
+            .collect::<Result<Vec<_>>>()?;
+
+        let image_data = if !images.is_empty() && img_cfg.is_some() {
+            let mut image_sizes = Vec::new();
+            let mut image_tensors = Vec::new();
+            for (t, s) in &images {
+                image_tensors.push(t);
+                image_sizes.extend(s);
+            }
+            let images_tensor = Tensor::cat(&image_tensors, 0)?;
+            let (images_raw, images_shape) = get_tensor_raw_data(&images_tensor)?;
+            crate::log_info!(
+                "{} images detected in the chat message, combined image shape {:?}",
+                images_shape[0],
+                images_shape
+            );
+            Some(ImageData {
+                raw: images_raw,
+                shape: images_shape,
+                patches: image_sizes,
+                image_idx: 0,
+            })
+        } else {
+            None
+        };
+
+        Ok((messages, image_data))
+    }
+
+    fn prepare_text_only(&self, messages: &[ChatMessage]) -> Result<Vec<Message>> {
+        let mut output = Vec::with_capacity(messages.len());
+        for msg in messages {
+            let prompt = match &msg.content {
+                MessageContentType::PureText(text) => text.clone(),
+                MessageContentType::Multi(items) => {
+                    let mut combined = String::new();
+                    for item in items {
+                        match item {
+                            MessageContent::Text { text } => {
+                                combined.push_str(text);
+                                combined.push(' ');
+                            }
+                            MessageContent::ImageUrl { .. }
+                            | MessageContent::ImageBase64 { .. } => {
+                                candle_core::bail!(
+                                    "Batch generation only supports text; use generate/generate_stream for multimodal."
+                                );
+                            }
+                        }
+                    }
+                    combined.trim().to_string()
+                }
+            };
+            output.push(Message {
+                role: msg.role.clone(),
+                content: prompt,
+                num_images: 0,
+            });
+        }
+        Ok(output)
+    }
+
+    fn messages_have_images(messages: &[ChatMessage]) -> bool {
+        messages.iter().any(|msg| match &msg.content {
+            MessageContentType::PureText(_) => false,
+            MessageContentType::Multi(items) => items.iter().any(|item| {
+                matches!(
+                    item,
+                    MessageContent::ImageUrl { .. } | MessageContent::ImageBase64 { .. }
+                )
+            }),
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 pub mod core;
+pub mod api;
 pub mod models;
 #[cfg(feature = "python")]
 pub mod py;
@@ -18,6 +19,13 @@ use crate::transfer::{PdConfig, PdMethod, PdRole};
 use crate::utils::chat_template::Message;
 #[cfg(feature = "python")]
 use crate::utils::config::{EngineConfig, GenerationConfig, SamplingParams};
+
+pub use crate::api::{Engine, EngineStream};
+pub use crate::server::{ChatMessage, MessageContent, MessageContentType};
+pub use crate::utils::config::{EngineConfig, GenerationConfig, SamplingParams};
+pub use crate::utils::get_dtype;
+pub use core::engine::StreamItem;
+pub use core::GenerationOutput;
 /// A Python module implemented in Rust.
 #[cfg(feature = "python")]
 #[pymodule]


### PR DESCRIPTION
### Motivation

- Provide a first-class Rust crate API so users can import the project as a library and run LLM inference directly from Rust (single/multi-GPU and PD multi-rank scenarios) instead of only via the CLI/server.
- Expose a simple, safe surface for text and multimodal prompts (image URL/base64) and allow users to choose between embedding the engine directly or starting the HTTP service from their Rust app.
- Keep repository layout intact (no heavy restructuring of `src/`) and reuse existing core/server logic.

### Description

- Added a lightweight Rust-facing API wrapper in `src/api.rs`:
  - `Engine` with `new`, `generate`, `generate_batch`, `generate_stream`, `embed`, and `start_server` methods that wrap existing `LLMEngine` behavior.
  - `EngineStream` for streaming results.
  - `prepare_messages` and `prepare_text_only` helpers to handle multimodal and text-only inputs; `messages_have_images` detects image-containing prompts and rejects multimodal input if the loaded model doesn't support vision.
  - Uses existing server conversion (`convert_chat_message`) and image processing pipeline to build `ImageData` when needed.
- Re-exported crate API items from `lib.rs` to make them accessible after `use vllm_rs::*`:
  - `Engine`, `EngineStream`, `ChatMessage`, `MessageContent`, `MessageContentType`, `EngineConfig`, `GenerationConfig`, `SamplingParams`, `get_dtype`, `StreamItem`, and `GenerationOutput`.
- Added convenience constructors on `ChatMessage`: `ChatMessage::text` and `ChatMessage::multimodal` for building requests in Rust.
- Documentation updates: added Rust usage sections to `ReadMe.md`, `ReadMe-CN.md` and `docs/get_started.md` describing crate usage, multimodal inputs and multi-GPU notes.
- Examples: added `examples/rust_basic.rs` and `examples/rust_multimodal.rs` showing direct generation and multimodal usage.

Files added / modified (high level):
- Added: `src/api.rs`, `examples/rust_basic.rs`, `examples/rust_multimodal.rs`
- Updated: `src/lib.rs`, `ReadMe.md`, `ReadMe-CN.md`, `docs/get_started.md`

### Testing

- No automated tests were executed as part of this change (no CI/test run requested).
- Example programs were included under `examples/` to exercise the API manually (text and multimodal usage).
- The PR focuses on API surface, docs and examples; integration/CI test runs are recommended (build + unit/integration) before publishing crates or releasing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944d761113c832ebdb498f4a8f2685b)