### PR TITLE
Use optimized MoE gguf kernel for small batch & update perf results

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vllm-rs"
-version = "0.6.11"
+version = "0.6.12"
 edition = "2021"
 default-run = "vllm-rs"
 
@@ -38,7 +38,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.1.8", rev = "2d520c9" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.1.9", rev = "5602293" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"

--- a/ReadMe-CN.md
+++ b/ReadMe-CN.md
@@ -30,12 +30,15 @@
 
 | 模型 | 格式 | 大小 | 输出速度 |
 |------------------|---------------|----------|------------------------|
+| Ministral-3-3B (Multimodal) | BF16 | 3B | **118.49** tokens/s |
+| Ministral-3-3B (Multimodal) | ISQ (BF16->Q4K) | 3B | **171.92** tokens/s |
+| Qwen3-VL-8B-Instruct (**Multimodal**) | Q8_0 | 8B | **105.31** tokens/s |
 | Llama-3.1-8B | ISQ (BF16->Q4K) | 8B | **120.74** tokens/s |
 | DeepSeek-R1-Distill-Llama-8B | Q2_K | 8B | **126.89** tokens/s |
 | DeepSeek-R1-0528-Qwen3-8B | Q4_K_M | 8B | **124.87** tokens/s |
 | GLM-4-9B-0414 | Q4_K_M | 9B | **70.38** tokens/s |
 | QwQ-32B | Q4_K_M | 32B | **41.36** tokens/s |
-| **Qwen3-30B-A3B** | Q4_K_M | **30B (MoE)**| **90.05** tokens/s  |
+| **Qwen3-30B-A3B** | Q4_K_M | **30B (MoE)**| **97.16** tokens/s  |
 
 > vLLM.rs 在 **Metal (Apple Silicon, M4)** 上的性能
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -30,12 +30,15 @@ A blazing-fast ⚡, lightweight **Rust** 🦀 implementation of vLLM.
 
 | Model | Format | Size| Decoding Speed |
 |------------------|---------------|----------|------------------------|
+| Ministral-3-3B (Multimodal) | BF16 | 3B | **118.49** tokens/s |
+| Ministral-3-3B (Multimodal) | ISQ (BF16->Q4K) | 3B | **171.92** tokens/s |
+| Qwen3-VL-8B-Instruct (**Multimodal**) | Q8_0 | 8B | **105.31** tokens/s |
 | Llama-3.1-8B | ISQ (BF16->Q4K) | 8B | **120.74** tokens/s |
 | DeepSeek-R1-Distill-Llama-8B | Q2_K | 8B | **126.89** tokens/s |
 | DeepSeek-R1-0528-Qwen3-8B | Q4_K_M | 8B | **124.87** tokens/s |
 | GLM-4-9B-0414 | Q4_K_M | 9B | **70.38** tokens/s |
 | QwQ-32B | Q4_K_M | 32B | **41.36** tokens/s |
-| **Qwen3-30B-A3B** | Q4_K_M | **30B (MoE)**| **90.05** tokens/s  |
+| **Qwen3-30B-A3B** | Q4_K_M | **30B (MoE)**| **97.16** tokens/s  |
 
 > **Metal (Apple Silicon, M4)**
   <details>


### PR DESCRIPTION
## Upgrade attention-rs with Optimized MoE GGUF Decode Kernel

### Summary

Upgrades `attention-rs` dependency to v0.1.9 which designed an optimized [MoE GGUF kernel](https://github.com/guoqingbao/attention.rs/blob/main/src/kernels/src/moe_gguf_small_m.cu) for small batch decode, achieving **~7% performance improvement** for GGUF-quantized MoE models during token generation.

### Changes

- Updated `attention-rs` from v0.1.8 to v0.1.9

### What's in attention-rs v0.1.9

A new specialized `moe_gemm_gguf_small_m` kernel optimized for small batch sizes (M ≤ 8):

| Before (v0.1.8) | After (v0.1.9) |
|-----------------|----------------|
| Weight caching in shared memory | Input caching in shared memory |
| Suboptimal for small M decode | Optimized for small M decode |

**Key optimization**: During decode, batch size is typically 1-8 tokens. The new kernel caches the small input tensor in shared memory and streams weights from L2 cache, which is more efficient than the previous weight-caching approach.

### Performance Impact

- **~7% faster decode** for GGUF MoE models (tested with Qwen3-MoE Q4_K)
- No impact on prefill performance (uses existing kernel)

### Dispatch Logic (in attention-rs)

```rust
// Decode path
if size_m <= 8 {
    moe_gemm_gguf_small_m(...)  // New optimized kernel
} else {
    moe_gemm_gguf(...)          // Original kernel
}
```

### Testing

- Verified correctness with Qwen3-MoE 32B Q4_K/Q6_K models
- Confirmed decode throughput improvement
