### PR TITLE
Add fingerprint-based context-cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vllm-rs"
-version = "0.6.12"
+version = "0.6.13"
 edition = "2021"
 default-run = "vllm-rs"
 

--- a/ReadMe-CN.md
+++ b/ReadMe-CN.md
@@ -98,11 +98,11 @@ python3 -m pip install vllm_rs
 ```
 
 ### 🌐✨ API Server + ChatGPT风格内置网页
-   💡你可以使用**任何兼容 OpenAI API 的客户端**进行交互
-   
    💡使用`--ui-server`会同时启动ChatGPT风格网页, 此时无需其它客户端。
 
    💡如长文本请求导致当前生成过程卡顿，请使用 **Rust PD Server**方案 （见**PD分离**）
+
+   💡当`context-cache`启用时，使用`--force-cache` 强制启用fingerprint对话检测，此时客户端无需提供 `session_id`
 
    ⚠️ 过度量化可能会在推理模型中触发 **“思考过程被截断”** 问题。建议采用 BF16 或 Q6K/Q8_0；GPTQ 或 AWQ 也可用于缓解该问题，也可以关闭`context-cache`或 通过`thinking=False` / `enable_thinking=False`关闭推理过程。
 
@@ -350,6 +350,7 @@ pip install target/wheels/vllm_rs-*-cp38-abi3-*.whl --force-reinstall
 | `--ui-server`       |  服务模式: 启动API服务，同时启动ChatGPT风格的内置对话网页服务 |
 | `--kv-fraction`       |  用于控制KVCache使用量 (模型加载后剩余可用GPU显存的百分比) |
 | `--context-cache`   | 启用上下文缓存，用于多轮对话 |
+| `--foce-cache`       | 启用Fingerprint对话标识检测，当 `--context-cache`同时启用时，自动进行上下文缓存，无需客户端显示传入 `session_id`  |
 
 ### MCP配置参数
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -102,11 +102,11 @@ python3 -m pip install vllm_rs
 
 ### 🌐✨ API Server + Built-in ChatGPT-like Web Server
 
-💡You can use **any client compatible with the OpenAI API** to interact
-
 💡Start with `--ui-server` will also start ChatGPT-like web server, no external chat client required in that case.
 
 💡Use the Rust PD Server (see **PD Disaggregation**) if decoding stalls during prefilling of long-context requests.
+
+💡When `context-cache` enabled, `--force-cache` enables fingerprint-based session detection if `session_id` not provided in the client side.
 
  ⚠️Low quantization may cause **"Thinking Process Truncated"** for reasoning models, use BF16, Q6K/Q8_0, GPTQ/AWQ can mitigate the problem, or disable `context-cache` or disable reasoning through `thinking=False` / `enable_thinking=False` might also help.
 
@@ -115,7 +115,7 @@ python3 -m pip install vllm_rs
 
 ```bash
 # CUDA
-python3 -m vllm_rs.server --m unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF --f Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf --kv-fraction 0.6 --ui-server --context-cache
+python3 -m vllm_rs.server --m unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF --f Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf --kv-fraction 0.6 --ui-server --context-cache --force-cache
 # Metal/MacOS (response can be seriously degradated on MacOS pre-Tahoe, use a smaller `--max-model-len` or `--kv-fraction` parameter)
 python3 -m vllm_rs.server --m unsloth/Qwen3-4B-GGUF --f Qwen3-4B-Q4_K_M.gguf --ui-server --max-model-len 32768 --context-cache
 ```
@@ -376,6 +376,7 @@ pip install target/wheels/vllm_rs-*-cp38-abi3-*.whl --force-reinstall
 | `--ui-server`       |  server mode: start the API server and also start the ChatGPT-like web server |
 | `--kv-fraction`       |  control kvcache usage (percentage of remaining gpu memory after model loading) |
 | `--context-cache`   | Enable context caching for multi-turn conversations |
+| `--foce-cache`       | Enable fingerprint-based session detection when `--context-cache` also enabled, no `session_id` needed in this case for context cache |
 
 ### MCP Configuration
 

--- a/example/server.py
+++ b/example/server.py
@@ -36,6 +36,7 @@ def parse_args():
     parser.add_argument("--mcp_config", type=str, default=None)
     parser.add_argument("--mcp_command", type=str, default=None)
     parser.add_argument("--mcp_args", type=str, default=None)
+    parser.add_argument("--force-cache", action="store_true")
 
     return parser.parse_args()
 
@@ -78,6 +79,7 @@ def run_server(args):
         mcp_config=args.mcp_config,
         mcp_command=args.mcp_command,
         mcp_args=args.mcp_args,
+        force_cache=args.force_cache,
     )
 
     engine = Engine(cfg, args.dtype)

--- a/src/api.rs
+++ b/src/api.rs
@@ -123,6 +123,7 @@ impl EngineBuilder {
             None,
             None,
             disable_flash_attn,
+            None, // force_cache - not exposed in simple API
         );
 
         let dtype = self.dtype.clone().map(dtype_to_str);

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -1,4 +1,5 @@
 //src/core/engine.rs
+use super::fingerprint::FingerprintManager;
 use super::runner::{ModelRunner, RunnerType, Seqs};
 use super::scheduler::{Scheduler, KVCACHE_SWAP_THRESHOLD};
 use super::sequence::Sequence;
@@ -102,6 +103,8 @@ pub struct LLMEngine {
     has_vision: bool,
     model_name: String,
     pub img_cfg: Option<ImageProcessConfig>,
+    /// Fingerprint manager for automatic session detection
+    fingerprint_manager: FingerprintManager,
 }
 
 impl LLMEngine {
@@ -429,6 +432,7 @@ impl LLMEngine {
             has_vision: config.is_multi_model.unwrap_or(false),
             img_cfg,
             model_name,
+            fingerprint_manager: FingerprintManager::new(),
         }));
         Self::start_engine(engine.clone());
         Ok(engine)
@@ -821,6 +825,21 @@ impl LLMEngine {
                             }
                         }
                     }
+
+                    // Extend fingerprint for auto-sessions when sequence completes
+                    // This allows subsequent requests to match the conversation
+                    if let Some((_, session_id)) =
+                        self.active_sessions.iter().find(|(id, _)| *id == seq_id)
+                    {
+                        if session_id.starts_with("auto_session_") {
+                            // Decode the output to get the assistant response text
+                            if let Ok(decoded_text) = self.tokenizer.decode(&s.output_ids, true) {
+                                self.fingerprint_manager
+                                    .extend_session_fingerprint(&session_id.clone(), &decoded_text);
+                            }
+                        }
+                    }
+
                     self.stream_senders.remove(&seq_id);
                     self.stream_decoders.remove(&seq_id);
                     if let Some(_) = self.active_requests.get(&seq_id) {
@@ -942,6 +961,10 @@ impl LLMEngine {
             if self.scheduler.get_cached_status(&session_id) == SequenceStatus::Cached {
                 if !self.scheduler.try_swap_out_by_id(seq_id, false) {
                     self.scheduler.release_cache(seq_id);
+                    // Also remove fingerprint for auto-sessions
+                    if session_id.starts_with("auto_session_") {
+                        self.fingerprint_manager.remove_session(&session_id);
+                    }
                     if self.econfig.server_mode.unwrap_or(true) {
                         crate::log_warn!(
                             "🗑️ Seq {} - cache removed (session id {})!\n",
@@ -1163,9 +1186,28 @@ impl LLMEngine {
         }
         let mut receivers = Vec::new();
         for (param, messages) in params.iter().zip(message_list.iter()) {
-            let (prompt, image_idx) = self.apply_chat_template(param, messages, false);
+            // Fingerprint-based automatic session detection
+            let mut param = param.clone();
+            if param.session_id.is_none()
+                && self.econfig.flash_context.unwrap_or(false)
+                && self.econfig.force_cache.unwrap_or(false)
+            {
+                // Build messages as (role, content) tuples for fingerprint computation
+                let msg_tuples: Vec<(String, String)> = messages
+                    .iter()
+                    .map(|m| (m.role.clone(), m.content.clone()))
+                    .collect();
+
+                let fingerprint = FingerprintManager::compute_fingerprint(&msg_tuples);
+                let session_id = self
+                    .fingerprint_manager
+                    .find_or_create_session(fingerprint, &msg_tuples);
+                param.session_id = Some(session_id);
+            }
+
+            let (prompt, image_idx) = self.apply_chat_template(&param, messages, false);
             if let Ok((seq_id, prompt_length, rx)) =
-                self.add_request(param, &prompt, RequestType::Completion, &images, image_idx)
+                self.add_request(&param, &prompt, RequestType::Completion, &images, image_idx)
             {
                 receivers.push((seq_id, prompt_length, rx));
             }
@@ -1341,6 +1383,8 @@ impl LLMEngine {
         self.scheduler.clear_finished();
         self.scheduler.release_waitings();
         self.active_sessions.clear();
+        // Reset fingerprint manager when all resources are freed
+        self.fingerprint_manager = FingerprintManager::new();
     }
 
     pub fn generate_stream(
@@ -1349,8 +1393,27 @@ impl LLMEngine {
         messages: &Vec<Message>,
         images: Option<ImageData>, //collection of images of the full conversation
     ) -> Result<(usize, usize, mpsc::Receiver<StreamItem>)> {
-        let (prompt, image_idx) = self.apply_chat_template(params, messages, false);
-        match self.add_request(params, &prompt, RequestType::Stream, &images, image_idx) {
+        // Fingerprint-based automatic session detection
+        let mut params = params.clone();
+        if params.session_id.is_none()
+            && self.econfig.flash_context.unwrap_or(false)
+            && self.econfig.force_cache.unwrap_or(false)
+        {
+            // Build messages as (role, content) tuples for fingerprint computation
+            let msg_tuples: Vec<(String, String)> = messages
+                .iter()
+                .map(|m| (m.role.clone(), m.content.clone()))
+                .collect();
+
+            let fingerprint = FingerprintManager::compute_fingerprint(&msg_tuples);
+            let session_id = self
+                .fingerprint_manager
+                .find_or_create_session(fingerprint, &msg_tuples);
+            params.session_id = Some(session_id);
+        }
+
+        let (prompt, image_idx) = self.apply_chat_template(&params, messages, false);
+        match self.add_request(&params, &prompt, RequestType::Stream, &images, image_idx) {
             Ok((seq_id, prompt_length, rx)) => Ok((seq_id, prompt_length, rx)),
             Err(e) => {
                 candle_core::bail!("{:?}", e)

--- a/src/core/fingerprint.rs
+++ b/src/core/fingerprint.rs
@@ -1,0 +1,322 @@
+//! Fingerprint-based session detection for context-cache
+//!
+//! When `force-cache` is enabled alongside `context-cache`, this module allows
+//! automatic session detection through message fingerprinting. This enables
+//! transparent context reuse without requiring clients to provide session_id.
+
+use std::collections::HashMap;
+
+/// Number of characters to use for fingerprint prefix/suffix
+const FINGERPRINT_CHAR_LEN: usize = 32;
+
+/// Fingerprint for a single message (role + text characteristics)
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct MessageFingerprint {
+    pub role: String,
+    pub text_len: usize,
+    pub first_chars: String,
+    pub last_chars: String,
+}
+
+impl MessageFingerprint {
+    /// Create fingerprint from role and content text
+    pub fn from_text(role: &str, content: &str) -> Self {
+        let text_len = content.len();
+        let first_chars: String = content.chars().take(FINGERPRINT_CHAR_LEN).collect();
+        let last_chars: String = content
+            .chars()
+            .rev()
+            .take(FINGERPRINT_CHAR_LEN)
+            .collect::<String>()
+            .chars()
+            .rev()
+            .collect();
+        Self {
+            role: role.to_string(),
+            text_len,
+            first_chars,
+            last_chars,
+        }
+    }
+}
+
+/// Fingerprint vector for a conversation
+pub type FingerprintVec = Vec<MessageFingerprint>;
+
+/// Manager for fingerprint-based session detection
+pub struct FingerprintManager {
+    /// Map from fingerprint vector to session_id
+    fingerprint_to_session: HashMap<FingerprintVec, String>,
+    /// Reverse map: session_id to fingerprint (for updates)
+    session_to_fingerprint: HashMap<String, FingerprintVec>,
+    /// Pending response fingerprints: session_id -> (first_chars, last_chars)
+    /// Used to match assistant messages in subsequent requests
+    pending_responses: HashMap<String, (String, String)>,
+    /// Counter for generating unique session IDs
+    next_session_id: usize,
+}
+
+impl Default for FingerprintManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FingerprintManager {
+    pub fn new() -> Self {
+        Self {
+            fingerprint_to_session: HashMap::new(),
+            session_to_fingerprint: HashMap::new(),
+            pending_responses: HashMap::new(),
+            next_session_id: 0,
+        }
+    }
+
+    /// Compute fingerprint from messages (as role, content pairs)
+    /// - If last message is user AND there's at least one assistant message: exclude last user message
+    /// - Otherwise: include all messages (first request scenario)
+    pub fn compute_fingerprint(messages: &[(String, String)]) -> FingerprintVec {
+        if messages.is_empty() {
+            return vec![];
+        }
+
+        let has_assistant = messages.iter().any(|(role, _)| role == "assistant");
+        let last_is_user = messages
+            .last()
+            .map(|(role, _)| role == "user")
+            .unwrap_or(false);
+
+        let msgs_to_fingerprint = if has_assistant && last_is_user {
+            &messages[..messages.len() - 1]
+        } else {
+            messages
+        };
+
+        msgs_to_fingerprint
+            .iter()
+            .map(|(role, content)| MessageFingerprint::from_text(role, content))
+            .collect()
+    }
+
+    /// Try to find a matching session_id for the given fingerprint
+    pub fn find_session(&self, fingerprint: &FingerprintVec) -> Option<String> {
+        self.fingerprint_to_session.get(fingerprint).cloned()
+    }
+
+    /// Register a new fingerprint with a generated session_id
+    pub fn register_session(&mut self, fingerprint: FingerprintVec) -> String {
+        let session_id = format!("auto_session_{}", self.next_session_id);
+        self.next_session_id += 1;
+        self.fingerprint_to_session
+            .insert(fingerprint.clone(), session_id.clone());
+        self.session_to_fingerprint
+            .insert(session_id.clone(), fingerprint);
+        crate::log_info!("FingerprintManager: registered new session {}", session_id);
+        session_id
+    }
+
+    /// Track response text for a session (used to match assistant messages later)
+    pub fn track_response(&mut self, session_id: &str, response_text: &str) {
+        let first_chars: String = response_text.chars().take(FINGERPRINT_CHAR_LEN).collect();
+        let last_chars: String = response_text
+            .chars()
+            .rev()
+            .take(FINGERPRINT_CHAR_LEN)
+            .collect::<String>()
+            .chars()
+            .rev()
+            .collect();
+        self.pending_responses
+            .insert(session_id.to_string(), (first_chars, last_chars));
+    }
+
+    /// Update the fingerprint for a session after response is complete
+    /// This extends the fingerprint to include the new assistant message
+    pub fn extend_session_fingerprint(&mut self, session_id: &str, assistant_content: &str) {
+        if let Some(old_fp) = self.session_to_fingerprint.remove(session_id) {
+            // Remove old mapping
+            self.fingerprint_to_session.remove(&old_fp);
+
+            // Create extended fingerprint with the assistant response
+            let mut new_fp = old_fp;
+            new_fp.push(MessageFingerprint::from_text(
+                "assistant",
+                assistant_content,
+            ));
+
+            // Store new mapping
+            self.fingerprint_to_session
+                .insert(new_fp.clone(), session_id.to_string());
+            self.session_to_fingerprint
+                .insert(session_id.to_string(), new_fp);
+
+            crate::log_info!(
+                "FingerprintManager: extended session {} fingerprint with assistant response",
+                session_id
+            );
+        }
+        // Clear pending response since it's now part of the fingerprint
+        self.pending_responses.remove(session_id);
+    }
+
+    /// Remove a session's fingerprint (when cache is evicted)
+    pub fn remove_session(&mut self, session_id: &str) {
+        if let Some(fp) = self.session_to_fingerprint.remove(session_id) {
+            self.fingerprint_to_session.remove(&fp);
+            crate::log_info!("FingerprintManager: removed session {}", session_id);
+        }
+        self.pending_responses.remove(session_id);
+    }
+
+    /// Find or create session for given fingerprint
+    /// When matching, also updates the stored fingerprint to include new messages
+    pub fn find_or_create_session(
+        &mut self,
+        fingerprint_for_match: FingerprintVec,
+        full_messages: &[(String, String)],
+    ) -> String {
+        if let Some(sid) = self.find_session(&fingerprint_for_match) {
+            crate::log_info!("FingerprintManager: matched existing session {}", sid);
+            // Update stored fingerprint to include ALL current messages (including last user)
+            // This ensures the next turn can match after we extend with assistant response
+            self.update_session_fingerprint(&sid, full_messages);
+            sid
+        } else {
+            // For new sessions, store all messages as fingerprint
+            let full_fingerprint: FingerprintVec = full_messages
+                .iter()
+                .map(|(role, content)| MessageFingerprint::from_text(role, content))
+                .collect();
+            self.register_session(full_fingerprint)
+        }
+    }
+
+    /// Update a session's fingerprint with new messages (used when session is matched)
+    fn update_session_fingerprint(&mut self, session_id: &str, messages: &[(String, String)]) {
+        if let Some(old_fp) = self.session_to_fingerprint.remove(session_id) {
+            // Remove old mapping
+            self.fingerprint_to_session.remove(&old_fp);
+
+            // Create full fingerprint from current messages
+            let new_fp: FingerprintVec = messages
+                .iter()
+                .map(|(role, content)| MessageFingerprint::from_text(role, content))
+                .collect();
+
+            // Store new mapping
+            self.fingerprint_to_session
+                .insert(new_fp.clone(), session_id.to_string());
+            self.session_to_fingerprint
+                .insert(session_id.to_string(), new_fp);
+
+            crate::log_info!(
+                "FingerprintManager: updated session {} fingerprint with {} messages",
+                session_id,
+                messages.len()
+            );
+        }
+    }
+
+    /// Get the number of tracked sessions
+    pub fn session_count(&self) -> usize {
+        self.session_to_fingerprint.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_message_fingerprint() {
+        let fp = MessageFingerprint::from_text("user", "Hello, how are you?");
+        assert_eq!(fp.role, "user");
+        assert_eq!(fp.text_len, 19);
+        assert_eq!(fp.first_chars, "Hello, how are you?");
+        assert_eq!(fp.last_chars, "Hello, how are you?");
+    }
+
+    #[test]
+    fn test_long_message_fingerprint() {
+        let long_content = "a".repeat(100);
+        let fp = MessageFingerprint::from_text("assistant", &long_content);
+        assert_eq!(fp.text_len, 100);
+        assert_eq!(fp.first_chars.len(), FINGERPRINT_CHAR_LEN);
+        assert_eq!(fp.last_chars.len(), FINGERPRINT_CHAR_LEN);
+    }
+
+    #[test]
+    fn test_compute_fingerprint_first_request() {
+        // First request: system + user, no assistant
+        let messages = vec![
+            ("system".to_string(), "You are helpful.".to_string()),
+            ("user".to_string(), "Hello".to_string()),
+        ];
+        let fp = FingerprintManager::compute_fingerprint(&messages);
+        // Should include all messages (no assistant to trigger exclusion)
+        assert_eq!(fp.len(), 2);
+    }
+
+    #[test]
+    fn test_compute_fingerprint_multi_turn() {
+        // Multi-turn: has assistant, last is user
+        let messages = vec![
+            ("system".to_string(), "You are helpful.".to_string()),
+            ("user".to_string(), "Hello".to_string()),
+            ("assistant".to_string(), "Hi there!".to_string()),
+            ("user".to_string(), "How are you?".to_string()),
+        ];
+        let fp = FingerprintManager::compute_fingerprint(&messages);
+        // Should exclude last user message
+        assert_eq!(fp.len(), 3);
+        assert_eq!(fp[2].role, "assistant");
+    }
+
+    #[test]
+    fn test_session_lifecycle() {
+        let mut manager = FingerprintManager::new();
+
+        // First request creates session
+        let messages1 = vec![
+            ("system".to_string(), "You are helpful.".to_string()),
+            ("user".to_string(), "Hello".to_string()),
+        ];
+        let fp1 = FingerprintManager::compute_fingerprint(&messages1);
+        let session_id = manager.find_or_create_session(fp1.clone(), &messages1);
+        assert!(session_id.starts_with("auto_session_"));
+
+        // Same fingerprint should return same session
+        let session_id2 = manager.find_or_create_session(fp1, &messages1);
+        assert_eq!(session_id, session_id2);
+
+        // Extend with assistant response
+        manager.extend_session_fingerprint(&session_id, "Hi there!");
+
+        // Next turn (turn 2): should still match
+        let messages2 = vec![
+            ("system".to_string(), "You are helpful.".to_string()),
+            ("user".to_string(), "Hello".to_string()),
+            ("assistant".to_string(), "Hi there!".to_string()),
+            ("user".to_string(), "How are you?".to_string()),
+        ];
+        let fp2 = FingerprintManager::compute_fingerprint(&messages2);
+        let session_id3 = manager.find_or_create_session(fp2, &messages2);
+        assert_eq!(session_id, session_id3);
+
+        // Extend with turn 2 response
+        manager.extend_session_fingerprint(&session_id, "I'm doing great!");
+
+        // Turn 3: should still match
+        let messages3 = vec![
+            ("system".to_string(), "You are helpful.".to_string()),
+            ("user".to_string(), "Hello".to_string()),
+            ("assistant".to_string(), "Hi there!".to_string()),
+            ("user".to_string(), "How are you?".to_string()),
+            ("assistant".to_string(), "I'm doing great!".to_string()),
+            ("user".to_string(), "What's the weather?".to_string()),
+        ];
+        let fp3 = FingerprintManager::compute_fingerprint(&messages3);
+        let session_id4 = manager.find_or_create_session(fp3, &messages3);
+        assert_eq!(session_id, session_id4);
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,5 +1,6 @@
 pub mod block_manager;
 pub mod engine;
+pub mod fingerprint;
 pub mod runner;
 pub mod scheduler;
 pub mod sequence;

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,6 +179,7 @@ async fn main() -> Result<()> {
         args.mcp_config.clone(),
         args.mcp_args.clone(),
         Some(args.no_flash_attn),
+        Some(args.force_cache),
     );
 
     let engine = LLMEngine::new(&econfig, dtype)?;

--- a/src/py/mod.rs
+++ b/src/py/mod.rs
@@ -286,7 +286,7 @@ impl EngineConfig {
         generation_cfg=None, seed=None, flash_context = None, fp8_kvcache=None,
         server_mode=None, cpu_mem_fold=None, kv_fraction=None, pd_config=None,
         mcp_command=None, mcp_config=None, mcp_args=None,
-        disable_flash_attn=None))]
+        disable_flash_attn=None, force_cache=None))]
     pub fn new(
         model_id: Option<String>,
         weight_path: Option<String>,
@@ -312,6 +312,7 @@ impl EngineConfig {
         mcp_config: Option<String>,
         mcp_args: Option<String>,
         disable_flash_attn: Option<bool>,
+        force_cache: Option<bool>,
     ) -> Self {
         let mut device_ids = device_ids.unwrap_or_default();
         if device_ids.is_empty() {
@@ -362,6 +363,7 @@ impl EngineConfig {
             mcp_config,
             mcp_args,
             disable_flash_attn,
+            force_cache,
         }
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -473,6 +473,11 @@ pub struct Args {
     #[arg(long, default_value_t = false)]
     pub context_cache: bool,
 
+    /// Force fingerprint-based session detection when session_id is not provided
+    /// Requires --context-cache to be enabled
+    #[arg(long, default_value_t = false)]
+    pub force_cache: bool,
+
     #[arg(long, default_value_t = false)]
     pub server: bool, //server mode
 

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -245,6 +245,8 @@ pub struct EngineConfig {
     pub mcp_config: Option<String>,
     pub mcp_args: Option<Vec<String>>,
     pub disable_flash_attn: Option<bool>,
+    /// Force fingerprint-based session detection when session_id is not provided
+    pub force_cache: Option<bool>,
 }
 
 #[cfg(feature = "python")]
@@ -305,6 +307,9 @@ pub struct EngineConfig {
     #[pyo3(get, set)]
     pub mcp_args: Option<Vec<String>>,
     pub disable_flash_attn: Option<bool>,
+    /// Force fingerprint-based session detection when session_id is not provided
+    #[pyo3(get, set)]
+    pub force_cache: Option<bool>,
 }
 
 #[cfg(not(feature = "python"))]
@@ -334,6 +339,7 @@ impl EngineConfig {
         mcp_config: Option<String>,
         mcp_args: Option<Vec<String>>,
         disable_flash_attn: Option<bool>,
+        force_cache: Option<bool>,
     ) -> Self {
         let mut device_ids = device_ids.unwrap_or_default();
         if device_ids.is_empty() {
@@ -376,6 +382,7 @@ impl EngineConfig {
             mcp_config,
             mcp_args,
             disable_flash_attn,
+            force_cache,
         }
     }
 }

--- a/vllm_rs.pyi
+++ b/vllm_rs.pyi
@@ -73,6 +73,7 @@ class EngineConfig:
     mcp_config: Optional[str]
     mcp_command: Optional[str]
     mcp_args: Optional[str]
+    force_cache: Optional[bool]
 
 @dataclass
 class SamplingParams:


### PR DESCRIPTION
# Fingerprint-Based Automatic Session Detection for Context Cache

## Summary

This PR adds automatic session detection through message fingerprinting when both `--context-cache` and the new `--force-cache` flags are enabled. Clients no longer need to provide `session_id` manually - the system automatically detects and reuses cached sessions based on conversation fingerprints.

## Motivation

Currently, using context-cache requires clients to manage `session_id` themselves. This PR enables transparent context reuse for multi-turn conversations without any client-side changes.

## How It Works

1. First request `[sys, user1]` → creates `auto_session_0`, stores fingerprint
2. Response generated → extends fingerprint to `[sys, user1, assistant1]`
3. Next request `[sys, user1, assistant1, user2]` → computes fingerprint `[sys, user1, assistant1]` (excluding last user) → **matches** → reuses cached KV
4. Process repeats for subsequent turns

## Usage

```bash
# Server
cargo run --features cuda -- -m <model> --context-cache --force-cache --server

# Client (no session_id needed!)
curl -X POST http://localhost:8000/v1/chat/completions \
  -d '{"messages": [{"role": "user", "content": "Hello"}]}'
```
