### PR TITLE
Aarch64 Native 8b is i8 not u8

### DIFF
--- a/src/transfer/cuda_remote.rs
+++ b/src/transfer/cuda_remote.rs
@@ -43,6 +43,9 @@ pub(super) fn open_ipc_handle<T: WithDType + candle_core::cuda_backend::CudaDTyp
     if handle.0.len() != 64 {
         candle_core::bail!("Invalid CUipcMemHandle handle!");
     }
+    #[cfg(target_arch = "aarch64")]
+    let raw_array: [u8; 64] = handle.0.clone().try_into().expect("length checked");
+    #[cfg(not(target_arch = "aarch64"))]
     let raw_array: [i8; 64] = handle.0.clone().try_into().expect("length checked");
     let handle_raw = CUipcMemHandle {
         reserved: raw_array.map(|b| b as c_char),

--- a/src/transfer/mod.rs
+++ b/src/transfer/mod.rs
@@ -70,6 +70,9 @@ pub struct PdConfig {
 /// Serializable handle for a CUDA IPC memory region.
 /// This is a wrapper around the `cudaIpcMemHandle_t` struct.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg(target_arch = "aarch64")]
+pub struct CudaIpcMemHandle(Vec<u8>, Vec<usize>, SerializableDType); // Simplified as bytes. See cuda.rs for real impl.
+#[cfg(not(target_arch = "aarch64"))]
 pub struct CudaIpcMemHandle(Vec<i8>, Vec<usize>, SerializableDType); // Simplified as bytes. See cuda.rs for real impl.
 
 /// A handle abstracting *how* to get the KV cache data.


### PR DESCRIPTION
Address the vllm.rs side of #139 - should allow building on DGX Spark

Need to do the same for upstream libraries (cutlass IIRC) if NCCL is used