### PR TITLE
Restore F32 datatype before passing to sampler

### DIFF
--- a/src/models/glm4.rs
+++ b/src/models/glm4.rs
@@ -345,7 +345,9 @@ impl GLM4ForCausalLM {
         } else if self.is_qvar_builder {
             self.lm_head.forward(&xs)
         } else {
-            self.lm_head.forward(&xs.to_dtype(self.dtype)?)
+            self.lm_head
+                .forward(&xs.to_dtype(self.dtype)?)?
+                .to_dtype(DType::F32)
         }
     }
 

--- a/src/models/llama.rs
+++ b/src/models/llama.rs
@@ -313,7 +313,9 @@ impl LLaMaForCausalLM {
         } else if self.is_qvar_builder {
             self.lm_head.forward(&xs)
         } else {
-            self.lm_head.forward(&xs.to_dtype(self.dtype)?)
+            self.lm_head
+                .forward(&xs.to_dtype(self.dtype)?)?
+                .to_dtype(DType::F32)
         }
     }
 

--- a/src/models/phi4.rs
+++ b/src/models/phi4.rs
@@ -635,7 +635,9 @@ impl Phi4ForCausalLM {
         } else if self.is_qvar_builder {
             self.lm_head.forward(&xs)
         } else {
-            self.lm_head.forward(&xs.to_dtype(self.dtype)?)
+            self.lm_head
+                .forward(&xs.to_dtype(self.dtype)?)?
+                .to_dtype(DType::F32)
         }
     }
 

--- a/src/models/qwen3.rs
+++ b/src/models/qwen3.rs
@@ -363,7 +363,9 @@ impl Qwen3ForCausalLM {
         } else if self.is_qvar_builder {
             self.lm_head.forward(&xs)
         } else {
-            self.lm_head.forward(&xs.to_dtype(self.dtype)?)
+            self.lm_head
+                .forward(&xs.to_dtype(self.dtype)?)?
+                .to_dtype(DType::F32)
         }
     }
 

--- a/src/models/qwen3_moe.rs
+++ b/src/models/qwen3_moe.rs
@@ -487,7 +487,9 @@ impl Qwen3MoEForCausalLM {
         } else if self.is_qvar_builder {
             self.lm_head.forward(&xs)
         } else {
-            self.lm_head.forward(&xs.to_dtype(self.dtype)?)
+            self.lm_head
+                .forward(&xs.to_dtype(self.dtype)?)?
+                .to_dtype(DType::F32)
         }
     }
 


### PR DESCRIPTION
Testing on 60k+ context sizes in recent days revealed models being unable to evaluate an ordered list of tasks about the context in the session. Models start iterating the list and make it through 2-3 elements before digression. This was observed berfore the topp 256k change made in d4f3a52a8.

In conjunction with #9 in attention.rs, the restoration of F32 data types appears to help stabilize the concern. Further testing is needed, however performance of the two changes appears to be neglibile even on V100s.