### PR TITLE
At 13, NV drops the -cudnn suffix from image names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1
 
-ARG CUDA_VERSION=12.9.0
+ARG CUDA_VERSION=12.9.0-cudnn
 ARG UBUNTU_VERSION=22.04
-FROM docker.io/nvidia/cuda:${CUDA_VERSION}-cudnn-devel-ubuntu${UBUNTU_VERSION}
+FROM docker.io/nvidia/cuda:${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION}
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
The `-cudnn` containers only go up to 12.9.1, 13+ does not use them. Update the CUDA_VERSION arg to hold the suffix