### PR TITLE
Optimize fp8 gemm/matmul with cutlass kernels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.3.0", rev = "5ca7fe3" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.3.0", rev = "c53099d" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"

--- a/src/models/layers/linear.rs
+++ b/src/models/layers/linear.rs
@@ -725,7 +725,7 @@ impl Module for LnFp8 {
             &self.weight_scale,
             &self.weight_block_size,
         )?;
-        
+
         #[cfg(not(feature = "cutlass"))]
         let out = attention_rs::fp8_linear::fp8_matmul(
             &x_2d,


### PR DESCRIPTION
This PR adds support for fp8 gemm/matmul based on cutlass (sm_90+)

Usage:

Run the fp8 model (block wise compressed)

```shell
./run.sh --features cuda,nccl,graph,cutlass --release --m Qwen/Qwen3-4B-Instruct-2507-FP8 --ui-server --prefix-cache
```