### PR TITLE
Fix Qwen3 VL FP8 Model & flash-attn build with max sm_90 capability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vllm-rs"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 default-run = "vllm-rs"
 
@@ -38,7 +38,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.3.0", rev = "cafedc6" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.3.0", rev = "cae9e3a" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 default-run = "vllm-rs"
 
 [dependencies]
-candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "dfa48cd" }
-candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "dfa48cd" }
+candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "f430958" }
+candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "f430958" }
 serde = { version = "1.0.190", features = ["serde_derive"] }
 tokenizers = {version = "0.21.2", features = ["http"] }
 hf-hub = "0.4.1"
@@ -38,7 +38,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.3.0", rev = "11e5cc0" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.3.0", rev = "cafedc6" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"

--- a/src/models/qwen3_vl/mod.rs
+++ b/src/models/qwen3_vl/mod.rs
@@ -64,11 +64,17 @@ impl Qwen3VLForConditionalGeneration {
             .unwrap_or(vec!["Qwen3VLForConditionalGeneration".to_string()]);
         let arch = arch[0].as_str();
         crate::log_info!("Loading language model...");
+
+        let mut config_text = config.clone();
+        if cfg.quantization_config.is_some() {
+            config_text.quantization_config = cfg.quantization_config.clone();
+        }
+
         let text_model = if matches!(arch, "Qwen3VLMoeForConditionalGeneration") {
             Qwen3TextModel::MoE(Qwen3MoEForCausalLM::new_with_prefix(
                 &vb,
                 comm.clone(),
-                config,
+                &config_text,
                 dtype,
                 is_rope_i,
                 device,
@@ -79,7 +85,7 @@ impl Qwen3VLForConditionalGeneration {
             Qwen3TextModel::Dense(Qwen3ForCausalLM::new_with_prefix(
                 &vb,
                 comm.clone(),
-                config,
+                &config_text,
                 dtype,
                 is_rope_i,
                 device,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -965,7 +965,7 @@ pub async fn run_server(
         println!("{}", format!("   - POST /tokenize").yellow());
         println!("{}", format!("   - POST /detokenize").yellow());
         println!("");
-        println!("🛑 {}", format!("(EXIT: Press `Ctrl+C` or `Ctrl+P` then `Ctrl+Q`)").bold().red());
+        println!("🛑 {}", format!("EXIT: Ctrl+C to quit. If unresponsive: Ctrl+P → Ctrl+Q (last resort).").bold().red());
         println!("");
         format!("0.0.0.0:{}", port)
     };

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -965,7 +965,12 @@ pub async fn run_server(
         println!("{}", format!("   - POST /tokenize").yellow());
         println!("{}", format!("   - POST /detokenize").yellow());
         println!("");
-        println!("🛑 {}", format!("EXIT: Ctrl+C to quit. If unresponsive: Ctrl+P → Ctrl+Q (last resort).").bold().red());
+        println!(
+            "🛑 {}",
+            format!("EXIT: Ctrl+C to quit. If unresponsive: Ctrl+P → Ctrl+Q (last resort).")
+                .bold()
+                .red()
+        );
         println!("");
         format!("0.0.0.0:{}", port)
     };


### PR DESCRIPTION
This PR forces the FlashAttention CUDA build to target up to SM_90 (compute capability 9.0).

This avoids unsupported compilation paths on newer architectures and resolves FlashAttention v2 build/runtime compatibility issues observed on SM_120 and SM_121 GPUs.