### PR TITLE
Switch to all-in-one flash-attn v2/v3 library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.3.0", rev = "b113409" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.3.0", rev = "7a540d8" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.3.0", rev = "cae9e3a" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.3.0", rev = "66f034c" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.3.0", rev = "38b58f3" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.3.0", rev = "7e249b6" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.3.0", rev = "7a540d8" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.3.0", rev = "2ca00eb" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.3.0", rev = "66f034c" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.3.0", rev = "b113409" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.3.0", rev = "626a256" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.3.0", rev = "38b58f3" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.3.0", rev = "5e18fb6" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.3.0", rev = "626a256" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.3.0", rev = "0934ec1" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.3.0", rev = "5e18fb6" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"


### PR DESCRIPTION
This PR uses the new all-in-one flash-attn v2/v3 crate, aiming at supporting both flash attention v2 and v3 on SM80+ and SM90+.

Note: the underlying flash-attn library is not optimized (split is disabled by default for faster build).