### PR TITLE
Tool call close tag always trips on mcp_mode

### DIFF
--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -168,9 +168,10 @@ pub async fn chat_completion(
 
     let tool_schemas = Arc::new(build_tool_schema_map(&resolved_tools));
     let has_tools = !resolved_tools.is_empty();
-    params.mcp_mode = if has_tools { Some(true) } else { None };
+    // Streaming tool parsing is handled in the StreamToolParser
+    params.mcp_mode = if !use_stream && has_tools { Some(true) } else { None };
 
-    if params.mcp_mode.is_some() {
+    if has_tools {
         crate::log_warn!("Tools enabled for request");
     }
 
@@ -258,7 +259,6 @@ pub async fn chat_completion(
 
         // Clone data needed for the async task
         let engine_clone = data.engine.clone();
-        let params_clone = params.clone();
         let _img_cfg_clone = img_cfg.clone();
 
         let tool_config = tool_config.clone();
@@ -288,7 +288,7 @@ pub async fn chat_completion(
 
             // Initialize the stream tool parser (handles all tool call detection internally)
             let mut tool_parser = tool_parser;
-            let should_parse_tools = params_clone.mcp_mode.is_some();
+            let should_parse_tools = has_tools.clone();
 
             let mut current_stream = stream;
             let current_seq_id = seq_id;


### PR DESCRIPTION
The current logic always sets mcp_mode = Some(true) when tools are made available to the model by the caller. This results in the Scheduler terminating the stream when `</tool_call>` is detected even if it's mid-stream, in a thinking or comment block, anything.

Resolve this by limiting mcp_mode to non-streaming connections where tools are enabled permitting sessions to continue streaming after the `</tool_call>` string is emitted.