### PR TITLE
Support kv heads replicate

### DIFF
--- a/src/models/phi4.rs
+++ b/src/models/phi4.rs
@@ -1,7 +1,7 @@
 // src/models/phi4.rs
 // This implementation is adapted from Phi-3, using the local Candle layers.
 use crate::models::layers::distributed::{
-    Comm, MergedParallelColumnLinear, ReplicatedLinear, TensorParallelRowLinear,
+    shard, Comm, MergedParallelColumnLinear, ReplicatedLinear, TensorParallelRowLinear,
 };
 use crate::models::layers::mask::get_attention_causal_mask;
 use crate::models::layers::mlp::MLP;
@@ -242,6 +242,32 @@ impl Phi4Attention {
             .unwrap_or(cfg.hidden_size / cfg.num_attention_heads);
         let op_size = num_heads * head_dim + 2 * num_kv_heads * head_dim;
         let is_qvar_builder = vb.is_qvar_builder();
+
+        let world_size = comm.world_size();
+        let attention_heads = num_heads / world_size;
+        // Align with vLLM behavior:
+        // - if total KV heads >= TP size: partition KV heads across ranks;
+        // - else: replicate KV heads across TP ranks.
+        let (kv_heads, kv_shard_rank, kv_shard_world_size) = if num_kv_heads >= world_size {
+            if num_kv_heads % world_size != 0 {
+                candle_core::bail!(
+                    "kv heads must be divisible by tensor parallel world_size when partitioned (num_kv_heads={}, world_size={})",
+                    num_kv_heads,
+                    world_size
+                );
+            }
+            (num_kv_heads / world_size, comm.rank(), world_size)
+        } else {
+            if world_size % num_kv_heads != 0 {
+                candle_core::bail!(
+                    "tensor parallel world_size must be divisible by kv heads when kv heads are replicated (num_kv_heads={}, world_size={})",
+                    num_kv_heads,
+                    world_size
+                );
+            }
+            (1, comm.rank() % num_kv_heads, num_kv_heads)
+        };
+
         let qkv_proj = MergedParallelColumnLinear::load_merged_chunks(
             cfg.hidden_size,
             op_size,
@@ -251,6 +277,11 @@ impl Phi4Attention {
                 num_kv_heads * head_dim,
                 num_kv_heads * head_dim,
             ],
+            Some(vec![
+                shard(0, comm.rank(), world_size),
+                shard(0, kv_shard_rank, kv_shard_world_size),
+                shard(0, kv_shard_rank, kv_shard_world_size),
+            ]),
             if is_qvar_builder {
                 vb.pp("attn_qkv")
             } else {
@@ -275,8 +306,6 @@ impl Phi4Attention {
             dtype,
         )?;
 
-        let attention_heads = num_heads / comm.world_size();
-        let kv_heads = num_kv_heads / comm.world_size();
         Ok(Self {
             qkv_proj,
             o_proj,


### PR DESCRIPTION
### Motivation
- Remove an accidental `chunk_shards` validation that caused a compile error in the merged-weight loader. 
- Ensure merged-chunk loading supports replication-aware slicing for shard-based tensor-parallel setups. 
- Make attention and Phi4 layer construction align with tensor-parallel KV head partitioning/replication semantics. 
- Improve KV cache sizing to correctly account for MQA/GQA cases and avoid invalid configurations.

### Description
- Remove the stray `chunk_shards` validation block from `MergedParallelColumnLinear::load_merged_with_hints` so the function no longer references an undefined identifier. 
- Add an optional `chunk_shards: Option<Vec<Shard>>` parameter to `MergedParallelColumnLinear::load_merged_chunks` and implement shard-aware slicing and validation when present, otherwise fall back to `comm.world_size()`-based slicing. 
- Update `attention.rs` and `phi4.rs` to compute `kv` partitioning logic consistent with vLLM-style behavior and call `load_with_shard` / `load_merged_chunks` with the appropriate `shard(...)` values; also add the `shard` import. 
- Enhance `KVCacheAllocator` by adding `kv_heads_per_shard()` helper, normalizing `num_shards` to be >=1 with a warning, switching per-block and block-shape computations to use `kv_heads_per_shard()`, and adding a defensive `per_block == 0` error path.

### Testing
- Ran `cargo fmt -- src/models/layers/distributed.rs`, which completed successfully. 
- Attempted `cargo check -q` to validate compilation, but the check could not complete due to a network fetch failure when pulling the `attention-rs` git dependency (CONNECT tunnel 403), so full compilation could not be verified in this environment. 
- No automated unit tests were executed as part of this change set due to the blocked dependency fetch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ddf03c348832e8e5e5f8ed63d2a4d)