### PR TITLE
Support mamba prefix eviction

### DIFF
--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -101,6 +101,7 @@ pub struct ModelRunner {
 }
 
 impl ModelRunner {
+    // Mamba slots track concurrent sequence states (not KV token blocks).
     const MAMBA_CACHE_FIXED_CAPACITY: usize = 64;
     const MAMBA_PREFIX_CACHE_SNAPSHOT_FACTOR: usize = 2;
     #[cfg(all(feature = "cuda", feature = "graph"))]
@@ -321,6 +322,15 @@ impl ModelRunner {
                 model.set_mamba_prefix_cache_capacity(mamba_prefix_capacity);
             }
             _ => {}
+        }
+
+        if is_hybrid_mamba_model {
+            crate::log_info!(
+                "Hybrid mamba slots preallocated: {} (max_num_seqs={}); prefix-state capacity={} entries",
+                mamba_cache_capacity,
+                econfig.max_num_seqs,
+                mamba_prefix_capacity
+            );
         }
 
         let (gpu_kv_cache, cpu_kv_cache) =

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -102,6 +102,7 @@ pub struct ModelRunner {
 
 impl ModelRunner {
     const MAMBA_CACHE_FIXED_CAPACITY: usize = 64;
+    const MAMBA_PREFIX_CACHE_SNAPSHOT_FACTOR: usize = 2;
     #[cfg(all(feature = "cuda", feature = "graph"))]
     const GRAPH_CAPTURE_MIN_BATCH: usize = 16;
     const DEFAULT_PREFIX_CACHE_RATIO: f32 = 0.5;
@@ -157,6 +158,18 @@ impl ModelRunner {
             Self::DEFAULT_PREFIX_CACHE_RATIO
         };
         ((econfig.num_blocks as f32) * ratio) as usize
+    }
+
+    fn effective_mamba_prefix_capacity(
+        requested_capacity: usize,
+        mamba_cache_capacity: usize,
+    ) -> usize {
+        if requested_capacity == 0 || mamba_cache_capacity == 0 {
+            return 0;
+        }
+
+        requested_capacity
+            .min(mamba_cache_capacity.saturating_mul(Self::MAMBA_PREFIX_CACHE_SNAPSHOT_FACTOR))
     }
 
     #[allow(unused)]
@@ -284,7 +297,20 @@ impl ModelRunner {
             }
         }
 
-        let mamba_prefix_capacity = Self::mamba_prefix_capacity_blocks(econfig);
+        let requested_mamba_prefix_capacity = Self::mamba_prefix_capacity_blocks(econfig);
+        let mamba_prefix_capacity = Self::effective_mamba_prefix_capacity(
+            requested_mamba_prefix_capacity,
+            mamba_cache_capacity,
+        );
+        if requested_mamba_prefix_capacity > 0
+            && requested_mamba_prefix_capacity != mamba_prefix_capacity
+        {
+            crate::log_warn!(
+                "Capping hybrid mamba prefix-state cache from {} to {} entries to avoid stale-state pollution and runaway memory use.",
+                requested_mamba_prefix_capacity,
+                mamba_prefix_capacity
+            );
+        }
         match &model {
             Model::Qwen3_5(model) => {
                 model.preallocate_mamba_cache(mamba_cache_capacity)?;


### PR DESCRIPTION
### Motivation
- The prior global-disable approach for mamba prefix snapshots was too blunt and risked losing useful mamba state when only part of the KV prefix cache was evicted. 
- Partial KV evictions can leave remaining KV blocks reusable while corresponding mamba snapshots for evicted blocks become stale, potentially causing cache mismatch and degraded prefill accuracy.

### Description
- Track mamba snapshot hashes per KV block in `BlockManager` by adding `mamba_prefix_hashes_by_block: HashMap<usize, HashSet<u64>>` and `valid_mamba_prefix_hashes: HashSet<u64>` and initialize them in the constructor. 
- Register captured mamba prefix snapshot hashes in `capture_mamba_prefix_state` and associate each hash with the terminal KV block for that prefix. 
- In all KV eviction/clear paths, remove only the mamba hashes tied to the evicted KV block(s) via `handle_mamba_prefix_evicted_blocks` instead of disabling all mamba prefix reuse. 
- Require candidate prefix hashes to be present in `valid_mamba_prefix_hashes` in `resolve_mamba_matched_blocks` before querying/using mamba snapshot state to prevent stale reuse. 
- Revert the previously introduced cross-runner `DisableMambaPrefixCache` RPC and related model-level `disable_mamba_prefix_cache` APIs, and add an effective mamba-prefix-cap computation in the runner to bound snapshot sizing with a warning log when capped. 

### Testing
- Ran `cargo fmt` on the modified files which completed successfully. 
- Ran the targeted unit test `cargo test --lib core::prefix_cache::tests::prefix_cache_evicts_leaf_blocks` which compiled and passed (`1 passed; 0 failed`). 
- Built and ran library tests for the touched workspace targets which completed successfully (unit test run above and workspace compile succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699173eaa7ec832e831d469d70e37a73)