### PR TITLE
Fix TodoWrite under Claude code & permit nested tool call markers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vllm-rs"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 default-run = "vllm-rs"
 

--- a/src/server/claude_server.rs
+++ b/src/server/claude_server.rs
@@ -1531,28 +1531,14 @@ pub async fn messages(
                                 stream_tool_schemas.as_ref(),
                             );
                             if !invalid.is_empty() {
-                                crate::log_warn!(
+                                crate::log_error!(
                                     "[Seq {}] Found {} invalid tool call(s)",
                                     seq_id,
                                     invalid.len()
                                 );
                             }
-                            let strict_mode = std::env::var("VLLM_RS_STRICT_TOOL_CALL")
-                                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                                .unwrap_or(false);
 
                             if !invalid.is_empty() {
-                                if strict_mode {
-                                    crate::log_warn!(
-                                        "[Seq {}] Strict mode enabled, dropping invalid calls",
-                                        seq_id
-                                    );
-                                } else {
-                                    crate::log_warn!(
-                                        "[Seq {}] Strict mode disabled, but still dropping invalid calls to avoid malformed tool payloads",
-                                        seq_id
-                                    );
-                                }
                                 log_tool_calls("Invalid", seq_id, &invalid);
                                 if let Some(ref l) = stream_logger {
                                     l.log_tool_calls("Invalid", &invalid);
@@ -1854,24 +1840,10 @@ pub async fn messages(
             .await;
         let (validated_calls, invalid_calls) =
             filter_tool_calls(&parsed_calls, tool_schemas.as_ref());
-
         if !invalid_calls.is_empty() {
-            crate::log_warn!("Found {} invalid tool call(s)", invalid_calls.len());
+            crate::log_error!("Found {} invalid tool call(s)", invalid_calls.len());
         }
 
-        let strict_mode = std::env::var("VLLM_RS_STRICT_TOOL_CALL")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
-
-        if !invalid_calls.is_empty() {
-            if strict_mode {
-                crate::log_warn!("Strict mode enabled, dropping invalid calls");
-            } else {
-                crate::log_warn!(
-                    "Strict mode disabled, but still dropping invalid calls to avoid malformed tool payloads"
-                );
-            }
-        }
         let valid_calls = validated_calls;
 
         if !valid_calls.is_empty() {

--- a/src/server/parser.rs
+++ b/src/server/parser.rs
@@ -5,7 +5,7 @@
 use crate::server::{ChatChoiceChunk, ChatCompletionChunk, Delta};
 use crate::tools::{Tool, ToolCall};
 use crate::utils::config::ModelType;
-use serde_json::Value;
+use serde_json::{Map, Value};
 use std::collections::HashSet;
 use tokenizers::Tokenizer;
 use tool_parser::{
@@ -226,6 +226,8 @@ pub struct StreamToolParser {
     in_code_block: bool,
     // Set when incremental parsing found ToolCallItem(s) for the latest processed token.
     saw_buffer_parse_activity: bool,
+    // Candidate end marker seen while buffering; used to avoid false end hits inside content.
+    pending_end_marker_candidate: bool,
 }
 
 /// Reasoning marker pairs: (start, end)
@@ -305,6 +307,7 @@ impl StreamToolParser {
             active_reasoning_end: None,
             in_code_block: false,
             saw_buffer_parse_activity: false,
+            pending_end_marker_candidate: false,
         }
     }
 
@@ -385,12 +388,20 @@ impl StreamToolParser {
                     self.buffer.clear();
                     self.buffer.push_str(token_text);
                     self.streaming_calls.clear();
-                    if let Ok(result) = self.parser.parse_incremental(token_text, &self.tools).await
-                    {
-                        if !result.calls.is_empty() {
-                            self.saw_buffer_parse_activity = true;
+                    self.pending_end_marker_candidate = false;
+                    match self.parser.parse_incremental(token_text, &self.tools).await {
+                        Ok(result) => {
+                            if !result.calls.is_empty() {
+                                self.saw_buffer_parse_activity = true;
+                            }
+                            self.apply_streaming_result(&result);
                         }
-                        self.apply_streaming_result(&result);
+                        Err(err) => {
+                            crate::log_warn!(
+                                "Incremental tool parse failed at start tag: {:?}",
+                                err
+                            );
+                        }
                     }
 
                     crate::log_info!(
@@ -405,35 +416,76 @@ impl StreamToolParser {
             }
             ParserState::Buffering => {
                 self.buffer.push_str(token_text);
-                if let Ok(result) = self.parser.parse_incremental(token_text, &self.tools).await {
-                    if !result.calls.is_empty() {
-                        self.saw_buffer_parse_activity = true;
-                        crate::log_info!("Stream parsing: {:?}", result.calls);
+                let nested_start_marker = !self.config.start_token_str.is_empty()
+                    && token_text.contains(&self.config.start_token_str);
+                if nested_start_marker {
+                    crate::log_warn!(
+                        "Ignoring nested tool-call start marker while buffering: {:?}",
+                        token_text
+                    );
+                } else {
+                    match self.parser.parse_incremental(token_text, &self.tools).await {
+                        Ok(result) => {
+                            if !result.calls.is_empty() {
+                                self.saw_buffer_parse_activity = true;
+                                crate::log_info!("Stream parsing: {:?}", result.calls);
+                            }
+                            self.apply_streaming_result(&result);
+                        }
+                        Err(err) => {
+                            crate::log_warn!(
+                                "Incremental tool parse failed while buffering: {:?}",
+                                err
+                            );
+                        }
                     }
-                    self.apply_streaming_result(&result);
                 }
                 let end_reached = self.is_end_token(token_id, token_text)
                     || self.buffer_has_end_tag()
                     || self.maybe_complete_mistral_list();
+                if !end_reached && self.pending_end_marker_candidate {
+                    self.pending_end_marker_candidate = false;
+                }
                 if end_reached {
+                    let strict_complete = self.has_strict_complete_tool_call().await;
+                    if !strict_complete && !self.pending_end_marker_candidate {
+                        self.pending_end_marker_candidate = true;
+                        crate::log_warn!(
+                            "Tool-call end marker seen before payload completion; waiting for confirmation"
+                        );
+                        return StreamResult::Buffering;
+                    }
+                    self.pending_end_marker_candidate = false;
                     crate::log_info!(
                         "Tool call buffering end, reached {} ({})",
                         token_text,
                         token_id
                     );
 
+                    let had_partial_calls = !self.streaming_calls.is_empty();
                     let tool_calls = self.build_tool_calls_with_fallback().await;
                     let result = if tool_calls.is_empty() {
-                        // Parse failed - return buffered content
-                        crate::log_error!("Unable to parse tool call buffer: {}", self.buffer,);
-                        StreamResult::FlushBuffer(self.buffer.clone())
+                        if had_partial_calls {
+                            crate::log_warn!(
+                                "End marker seen but tool call is still incomplete; continuing buffering"
+                            );
+                            StreamResult::Buffering
+                        } else {
+                            // False positive - flush buffered content as normal text.
+                            crate::log_error!("Unable to parse tool call buffer: {}", self.buffer,);
+                            StreamResult::FlushBuffer(self.buffer.clone())
+                        }
                     } else {
                         StreamResult::ToolCalls(tool_calls)
                     };
+                    if matches!(result, StreamResult::Buffering) {
+                        return result;
+                    }
                     self.parser.reset();
                     self.buffer.clear();
                     self.state = ParserState::Normal;
                     self.streaming_calls.clear();
+                    self.pending_end_marker_candidate = false;
                     return result;
                 }
 
@@ -458,6 +510,7 @@ impl StreamToolParser {
         self.buffer.clear();
         self.state = ParserState::Normal;
         self.streaming_calls.clear();
+        self.pending_end_marker_candidate = false;
 
         if tool_calls.is_empty() {
             crate::log_warn!("Buffered tool call could not be finalized; flushing buffered text");
@@ -474,6 +527,7 @@ impl StreamToolParser {
     /// Drain the buffer and reset parser state.
     pub fn take_buffer(&mut self) -> String {
         self.state = ParserState::Normal;
+        self.pending_end_marker_candidate = false;
         std::mem::take(&mut self.buffer)
     }
 
@@ -553,12 +607,41 @@ impl StreamToolParser {
         if let Some(unstreamed) = self.parser.get_unstreamed_tool_args() {
             self.apply_stream_items(&unstreamed);
         }
-        let mut tool_calls = self.build_tool_calls_from_streaming();
-        if tool_calls.is_empty() {
+        self.recover_streaming_arguments_from_buffer();
+        let streaming_calls = self.build_tool_calls_from_streaming();
+        if streaming_calls.is_empty() {
             crate::log_info!("Fallback to non-stream parsing for buffer: {}", self.buffer);
-            tool_calls = self.parse_complete_with_fallback(&self.buffer).await;
+            return self.parse_complete_with_fallback(&self.buffer).await;
         }
-        tool_calls
+
+        streaming_calls
+    }
+
+    async fn has_strict_complete_tool_call(&self) -> bool {
+        if self.streaming_calls.iter().any(|call| call.name.is_none()) {
+            return false;
+        }
+        if !self.streaming_calls.is_empty()
+            && self
+                .streaming_calls
+                .iter()
+                .all(|call| call.arguments.trim().is_empty())
+        {
+            return true;
+        }
+        if !self.streaming_calls.is_empty()
+            && self
+                .streaming_calls
+                .iter()
+                .all(|call| serde_json::from_str::<Value>(call.arguments.trim()).is_ok())
+        {
+            return true;
+        }
+
+        !self
+            .parse_complete_with_fallback(&self.buffer)
+            .await
+            .is_empty()
     }
 
     pub async fn parse_complete_with_fallback(&self, text: &str) -> Vec<ToolCall> {
@@ -699,6 +782,101 @@ impl StreamToolParser {
         }
         // Default minimum for tags without underscore.
         start_tag.find('>').map_or(6, |idx| idx).clamp(2, 6)
+    }
+
+    fn recover_streaming_arguments_from_buffer(&mut self) {
+        if self.streaming_calls.is_empty() || !self.buffer.contains("<parameter=") {
+            return;
+        }
+
+        for state in &mut self.streaming_calls {
+            let Some(name) = state.name.as_deref() else {
+                continue;
+            };
+
+            let recovered = Self::extract_xml_parameters_for_function(&self.buffer, name);
+            if recovered.is_empty() {
+                continue;
+            }
+
+            let mut args_obj = match serde_json::from_str::<Value>(state.arguments.trim()) {
+                Ok(Value::Object(map)) => map,
+                _ => Map::new(),
+            };
+
+            let mut merged_any = false;
+            for (key, value) in recovered {
+                if !args_obj.contains_key(&key) && !value.is_empty() {
+                    args_obj.insert(key, Value::String(value));
+                    merged_any = true;
+                }
+            }
+
+            if merged_any {
+                state.arguments = Value::Object(args_obj).to_string();
+                crate::log_warn!("Recovered missing parameter(s) from buffered tool-call content");
+            }
+        }
+    }
+
+    fn extract_xml_parameters_for_function(
+        buffer: &str,
+        function_name: &str,
+    ) -> std::collections::HashMap<String, String> {
+        let mut recovered = std::collections::HashMap::new();
+        let function_tag = format!("<function={}>", function_name);
+        let alt_function_tag = format!("<function=\"{}\">", function_name);
+
+        let Some(func_start) = buffer
+            .rfind(&function_tag)
+            .or_else(|| buffer.rfind(&alt_function_tag))
+        else {
+            return recovered;
+        };
+
+        let section = &buffer[func_start..];
+        let mut cursor = 0usize;
+        const PARAM_PREFIX: &str = "<parameter=";
+        const PARAM_END: &str = "</parameter>";
+
+        while let Some(rel) = section[cursor..].find(PARAM_PREFIX) {
+            let tag_start = cursor + rel;
+            let name_start = tag_start + PARAM_PREFIX.len();
+            let Some(name_end_rel) = section[name_start..].find('>') else {
+                break;
+            };
+            let name_end = name_start + name_end_rel;
+            let parameter_name = section[name_start..name_end]
+                .trim()
+                .trim_matches('"')
+                .trim_matches('\'')
+                .to_string();
+            if parameter_name.is_empty() {
+                break;
+            }
+
+            let value_start = name_end + 1;
+            if value_start > section.len() {
+                break;
+            }
+
+            if let Some(value_end_rel) = section[value_start..].find(PARAM_END) {
+                let value_end = value_start + value_end_rel;
+                let value = section[value_start..value_end]
+                    .trim_matches(|c| c == '\n' || c == '\r')
+                    .to_string();
+                recovered.insert(parameter_name, value);
+                cursor = value_end + PARAM_END.len();
+            } else {
+                let value = section[value_start..]
+                    .trim_matches(|c| c == '\n' || c == '\r')
+                    .to_string();
+                recovered.insert(parameter_name, value);
+                break;
+            }
+        }
+
+        recovered
     }
 
     // --- Chunk creation helpers (for use by server.rs) ---
@@ -1057,5 +1235,83 @@ mod tests {
         assert!(matches!(parser.state, ParserState::Normal));
         assert!(parser.buffer.is_empty());
         assert!(parser.streaming_calls.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_nested_start_marker_is_ignored_while_buffering() {
+        let tools = vec![crate::tools::function_tool("Write", "desc").build()];
+        let mut parser = StreamToolParser::new_with_config(
+            &ModelType::Phi,
+            "phi".to_string(),
+            ToolConfig::for_model_type(&ModelType::Phi),
+            tools,
+            None,
+        );
+
+        parser.state = ParserState::Buffering;
+        parser.buffer = "<tool_call><function=Write>".to_string();
+        parser.streaming_calls = vec![StreamingToolCallState {
+            name: Some("Write".to_string()),
+            arguments: String::new(),
+        }];
+
+        let result = parser.process_token(0, "<tool_call>").await;
+        assert!(matches!(result, StreamResult::Buffering));
+        assert!(matches!(parser.state, ParserState::Buffering));
+    }
+
+    #[tokio::test]
+    async fn test_false_end_marker_inside_arguments_requires_confirmation() {
+        let tools = vec![crate::tools::function_tool("Write", "desc").build()];
+        let mut parser = StreamToolParser::new_with_config(
+            &ModelType::Phi,
+            "phi".to_string(),
+            ToolConfig::for_model_type(&ModelType::Phi),
+            tools,
+            None,
+        );
+
+        parser.state = ParserState::Buffering;
+        parser.buffer = "<tool_call>".to_string();
+        parser.streaming_calls = vec![StreamingToolCallState {
+            name: Some("Write".to_string()),
+            arguments: r#"{"file_path":"/tmp/a.rs","content":"text with "#.to_string(),
+        }];
+
+        let first = parser.process_token(0, "</tool_call>").await;
+        assert!(matches!(first, StreamResult::Buffering));
+        assert!(matches!(parser.state, ParserState::Buffering));
+        assert!(parser.pending_end_marker_candidate);
+    }
+
+    #[tokio::test]
+    async fn test_finalize_recovers_unclosed_xml_parameter_content() {
+        let tools = vec![crate::tools::function_tool("Write", "desc").build()];
+        let mut parser = StreamToolParser::new_with_config(
+            &ModelType::Qwen3,
+            "qwen3".to_string(),
+            ToolConfig::for_model_type(&ModelType::Qwen3),
+            tools,
+            None,
+        );
+
+        parser.state = ParserState::Buffering;
+        parser.buffer = "<tool_call>\n<function=Write>\n<parameter=file_path>\n/tmp/a.md\n</parameter>\n<parameter=content>\n# Title\n".to_string();
+        parser.streaming_calls = vec![StreamingToolCallState {
+            name: Some("Write".to_string()),
+            arguments: r#"{"file_path":"/tmp/a.md"}"#.to_string(),
+        }];
+
+        let finalized = parser.finalize_buffered_tool_calls().await;
+        match finalized {
+            Some(BufferedFinalizeResult::ToolCalls(calls)) => {
+                assert_eq!(calls.len(), 1);
+                let args = calls[0].function.arguments.as_ref().unwrap();
+                let parsed: Value = serde_json::from_str(args).unwrap();
+                assert_eq!(parsed["file_path"], "/tmp/a.md");
+                assert_eq!(parsed["content"], "# Title");
+            }
+            other => panic!("Expected recovered tool calls, got {:?}", other),
+        }
     }
 }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -464,7 +464,7 @@ pub async fn chat_completion(
                             filter_tool_calls(&pending_tool_calls, stream_tool_schemas.as_ref());
 
                         if !invalid_calls.is_empty() {
-                            crate::log_warn!(
+                            crate::log_error!(
                                 "[Seq {}] Found {} invalid tool call(s)",
                                 current_seq_id,
                                 invalid_calls.len()
@@ -725,18 +725,6 @@ pub async fn chat_completion(
                     log_tool_calls("Invalid", &invalid_calls);
                 }
 
-                let strict_mode = std::env::var("VLLM_RS_STRICT_TOOL_CALL")
-                    .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                    .unwrap_or(false);
-                if !invalid_calls.is_empty() {
-                    if strict_mode {
-                        crate::log_warn!("Strict mode enabled, dropping invalid calls");
-                    } else {
-                        crate::log_warn!(
-                            "Strict mode disabled, but still dropping invalid calls to avoid malformed tool payloads"
-                        );
-                    }
-                }
                 let valid_calls = validated_calls;
                 if valid_calls.is_empty() {
                     if tool_choice_required {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -162,10 +162,17 @@ pub fn new_tool_call(
     }
 }
 
+/// Generate a compact tool call ID with required `call_` prefix.
+/// Uses 16 hex chars (64 bits) from UUIDv4 for low collision risk and shorter payloads.
+pub fn generate_tool_call_id() -> String {
+    let raw = Uuid::new_v4().simple().to_string();
+    format!("call_{}", &raw[..16])
+}
+
 /// Convert a parsed tool call into an OpenAI-compatible ToolCall.
 pub fn tool_call_from_parser(parsed: tool_parser::ToolCall) -> ToolCall {
     ToolCall {
-        id: format!("call_{}", Uuid::new_v4().simple()),
+        id: generate_tool_call_id(),
         tool_type: "function".to_string(),
         function: FunctionCall {
             name: parsed.function.name,

--- a/src/tools/parser.rs
+++ b/src/tools/parser.rs
@@ -227,7 +227,7 @@ impl ToolParser {
 
         *call_id += 1;
         Some(new_tool_call(
-            format!("call_{}", call_id),
+            super::generate_tool_call_id(),
             name.to_string(),
             args_str,
         ))


### PR DESCRIPTION
**This PR addresses two major issues related to tool call.** 

### Translate `TodoWrite` into `TaskCreate`

Modern LLMs traind for working with Claude code, they tend to produce `TodoWrite` tool call for remembering subtasks, while, this tool call is not enabled by default in Claude code, making it failed in tool call validation, e.g., `TodoWrite` not found in tool call schema map. 

Related issue reported in Claude code: https://github.com/anthropics/claude-code/issues/5332

### Permits tool call markers inside tool call

Tool call markers like <tool_call> and </too_call> can be appeared anywhere even within a tool call, this PR changed the logic into:

1) In buffering mode, when an end marker is seen, we now first check if the tool call looks structurally complete
2) If complete, we finalize immediately on that first end marker (so real end is not delayed).
3) If not complete, we treat it as suspicious (likely marker inside content), keep buffering, and require confirmation 
4) Nested start markers inside buffered content are ignored

