### PR TITLE
Sparse mamba state capture & address false-positive tool calling

### DIFF
--- a/docs/prefix-cache.md
+++ b/docs/prefix-cache.md
@@ -23,6 +23,23 @@ If `--prefix-cache-max-tokens` is not set, defaults are:
 - PD server: ~75% of GPU KV blocks
 - PD client: ~35% of GPU KV blocks
 
+## Hybrid Mamba Snapshot Stride
+For hybrid Mamba models (for example Qwen3.5), prefix reuse also needs a
+compatible Mamba snapshot at the matched boundary.
+
+Use environment variable `VLLM_RS_MAMBA_SNAPSHOT_STRIDE_BLOCKS` to control
+sparse snapshot capture during decode:
+- Default: `8` blocks
+- Minimum valid value: `1` (capture every block)
+- Effective snapshot boundary in tokens: `block_size * stride`
+
+Example with default `block_size=64` and stride `8`:
+- Decode snapshot boundary is every `512` tokens.
+- Effective hybrid prefix reuse is aligned to the nearest captured boundary.
+
+This setting only sparsifies decode-time snapshot capture. Prompt/prefill
+snapshot capture remains dense.
+
 ## Notes
 - Prefix cache uses the same KV memory pool as active sequences. A larger cache
   reduces the maximum number of concurrent tokens available for new requests.

--- a/src/api.rs
+++ b/src/api.rs
@@ -226,7 +226,7 @@ impl Engine {
         let img_cfg = { self.engine.read().img_cfg.clone() };
         let (messages, image_data) = build_messages_and_images(&messages, img_cfg.as_ref())?;
 
-        let (seq_id, prompt_length, stream) = {
+        let (seq_id, prompt_length, _prefilled_reasoning_end, stream) = {
             let mut engine = self.engine.write();
             engine.generate_stream(&params, &messages, image_data, &tools, &None)?
         };

--- a/src/core/block_manager.rs
+++ b/src/core/block_manager.rs
@@ -4,6 +4,7 @@ use super::runner::RunnerType;
 use super::sequence::{Sequence, SequenceStatus};
 use crate::def_broadcast_message_to_runners;
 use crate::runner::{receive_local, send_local, MessageType};
+use crate::utils::env::{mamba_snapshot_block_stride_blocks, MAMBA_SNAPSHOT_BLOCK_STRIDE_ENV};
 use crate::utils::image::ImageData;
 use candle_core::Result;
 use interprocess::{local_socket::Stream as LocalStream, TryClone};
@@ -40,6 +41,7 @@ pub struct BlockManager {
     runners: Arc<RwLock<RunnerType>>,
     prefix_cache: Option<PrefixCache>,
     mamba_prefix_enabled: bool,
+    mamba_snapshot_block_stride_blocks: usize,
     mamba_prefix_hashes_by_block: HashMap<usize, HashSet<u64>>,
     mamba_prefix_block_by_hash: HashMap<u64, usize>,
     valid_mamba_prefix_hashes: HashSet<u64>,
@@ -80,6 +82,15 @@ impl BlockManager {
         } else {
             None
         };
+        let mamba_snapshot_block_stride_blocks = mamba_snapshot_block_stride_blocks();
+        if mamba_prefix_enabled {
+            crate::log_info!(
+                "Hybrid mamba snapshot capture stride: {} block(s) ({} tokens), configured by {}.",
+                mamba_snapshot_block_stride_blocks,
+                mamba_snapshot_block_stride_blocks.saturating_mul(block_size),
+                MAMBA_SNAPSHOT_BLOCK_STRIDE_ENV
+            );
+        }
 
         Self {
             blocks,
@@ -92,6 +103,7 @@ impl BlockManager {
             runners,
             prefix_cache,
             mamba_prefix_enabled,
+            mamba_snapshot_block_stride_blocks,
             mamba_prefix_hashes_by_block: HashMap::new(),
             mamba_prefix_block_by_hash: HashMap::new(),
             valid_mamba_prefix_hashes: HashSet::new(),
@@ -408,6 +420,15 @@ impl BlockManager {
         let processed_tokens = processed_tokens.min(seq.token_ids.len());
         let full_blocks = processed_tokens / self.block_size;
         if full_blocks == 0 {
+            return;
+        }
+        // Keep prompt/prefill captures dense, but sparsify decode-time captures.
+        // Decode tokens are reflected in output_ids, so this avoids overwriting
+        // useful prompt snapshots every block while preserving prompt reuse quality.
+        if !seq.output_ids.is_empty()
+            && self.mamba_snapshot_block_stride_blocks > 1
+            && full_blocks % self.mamba_snapshot_block_stride_blocks != 0
+        {
             return;
         }
         let seed = seq.images.as_ref().map(Self::image_prefix_seed);

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -13,7 +13,7 @@ use crate::runner::{
     receive_local, send_and_expect_ack, send_local, MessageType, RunnerInitRequest,
 };
 use crate::server::logger::ChatCompletionLogger;
-use crate::server::parser::ToolConfig;
+use crate::server::parser::{detect_prefilled_reasoning_end_marker, ToolConfig};
 use crate::server::{EmbeddingStrategy, UsageResponse};
 use crate::tools::Tool;
 use crate::transfer::PdRole;
@@ -90,6 +90,7 @@ pub struct LLMEngine {
     request_types: HashMap<usize, RequestType>,
     decode_start_times: HashMap<usize, usize>,
     decode_length: HashMap<usize, usize>,
+    seq_prefilled_reasoning_end: HashMap<usize, String>,
     last_check_throughput_time: usize,
     active_requests: HashSet<usize>,
     cancelled_sequences: Vec<usize>,
@@ -450,6 +451,7 @@ impl LLMEngine {
             request_types: HashMap::new(),
             decode_start_times: HashMap::new(),
             decode_length: HashMap::new(),
+            seq_prefilled_reasoning_end: HashMap::new(),
             last_check_throughput_time: 0,
             active_requests: HashSet::new(),
             cancelled_sequences: Vec::new(),
@@ -574,6 +576,9 @@ impl LLMEngine {
             );
         }
         let seq_id = self.scheduler.add(seq);
+        if let Some(end_marker) = detect_prefilled_reasoning_end_marker(prompt) {
+            self.seq_prefilled_reasoning_end.insert(seq_id, end_marker);
+        }
 
         if *request_type == RequestType::Stream {
             let tokenizer = self.tokenizer.clone();
@@ -812,6 +817,7 @@ impl LLMEngine {
                     }
                     self.decode_start_times.remove(&seq_id);
                     self.decode_length.remove(&seq_id);
+                    self.seq_prefilled_reasoning_end.remove(&seq_id);
                     let _ = self.notify_runner_finished(seq_id);
                     if self.econfig.server_mode.unwrap_or(true) {
                         self.scheduler.print_free_blocks();
@@ -949,6 +955,7 @@ impl LLMEngine {
             }
             self.stream_decoders.remove(&seq_id);
             self.decode_start_times.remove(&seq_id);
+            self.seq_prefilled_reasoning_end.remove(&seq_id);
             if let Some(r) = &reason {
                 if let Some(sender) = self.stream_senders.get_mut(&seq_id) {
                     if let Some(request_type) = self.request_types.get(&seq_id) {
@@ -1279,6 +1286,13 @@ impl LLMEngine {
         crate::log_error!("***Release all resources for future usage!");
         self.scheduler.clear_finished();
         self.scheduler.release_waitings();
+        self.seq_prefilled_reasoning_end.clear();
+    }
+
+    /// Returns the reasoning end marker when the prompt for this sequence
+    /// already ended with an opening think marker.
+    pub fn get_prefilled_reasoning_end_marker(&self, seq_id: usize) -> Option<String> {
+        self.seq_prefilled_reasoning_end.get(&seq_id).cloned()
     }
 
     pub fn generate_stream(

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -1302,13 +1302,16 @@ impl LLMEngine {
         images: Option<ImageData>, //collection of images of the full conversation
         tools: &Vec<Tool>,
         logger: &Option<Arc<ChatCompletionLogger>>,
-    ) -> Result<(usize, usize, mpsc::Receiver<StreamItem>)> {
+    ) -> Result<(usize, usize, Option<String>, mpsc::Receiver<StreamItem>)> {
         let (prompt, image_idx) = self.apply_chat_template(params, messages, tools, false);
         if let Some(ref l) = logger {
             l.log_prompt(&prompt);
         }
         match self.add_request(params, &prompt, RequestType::Stream, &images, image_idx) {
-            Ok((seq_id, prompt_length, rx)) => Ok((seq_id, prompt_length, rx)),
+            Ok((seq_id, prompt_length, rx)) => {
+                let prefilled_reasoning_end = self.get_prefilled_reasoning_end_marker(seq_id);
+                Ok((seq_id, prompt_length, prefilled_reasoning_end, rx))
+            }
             Err(e) => {
                 candle_core::bail!("{:?}", e)
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -319,7 +319,7 @@ async fn main() -> Result<()> {
 
         let mut outputs = {
             if interactive {
-                let (seq_id, prompt_length, stream) = {
+                let (seq_id, prompt_length, _prefilled_reasoning_end, stream) = {
                     let mut e = engine.write();
                     match e.generate_stream(
                         &request_params,
@@ -328,7 +328,9 @@ async fn main() -> Result<()> {
                         &Vec::new(),
                         &None,
                     ) {
-                        Ok((seq_id, prompt_length, stream)) => (seq_id, prompt_length, stream),
+                        Ok((seq_id, prompt_length, prefilled_reasoning_end, stream)) => {
+                            (seq_id, prompt_length, prefilled_reasoning_end, stream)
+                        }
                         Err(e) => {
                             tracing::error!("Session unexpectedly ended because: {:?}", e);
                             print!("\n🌀 Chat history cleared. Start a new conversation.\n");

--- a/src/py/mod.rs
+++ b/src/py/mod.rs
@@ -105,7 +105,7 @@ impl Engine {
         params: SamplingParams,
         messages: Vec<Message>,
     ) -> PyResult<(usize, usize, EngineStream)> {
-        let (seq_id, prompt_length, stream) = {
+        let (seq_id, prompt_length, _prefilled_reasoning_end, stream) = {
             let mut engine = self.engine.write();
             engine
                 .generate_stream(&params, &messages, None, &Vec::new(), &None)

--- a/src/server/claude_server.rs
+++ b/src/server/claude_server.rs
@@ -1459,10 +1459,12 @@ pub async fn messages(
     };
 
     if use_stream {
-        let (seq_id, prompt_length, stream) = {
+        let (seq_id, prompt_length, prefilled_reasoning_end, stream) = {
             let mut e = data.engine.write();
             match e.generate_stream(&params, &messages, image_data, &resolved_tools, &logger) {
-                Ok((seq_id, prompt_length, stream)) => (seq_id, prompt_length, stream),
+                Ok((seq_id, prompt_length, prefilled_reasoning_end, stream)) => {
+                    (seq_id, prompt_length, prefilled_reasoning_end, stream)
+                }
                 Err(err) => {
                     return ClaudeResponder::Error(
                         ClaudeErrorResponse {
@@ -1484,10 +1486,6 @@ pub async fn messages(
             .unwrap_or(256);
         let (response_tx, client_rx) = flume::bounded(buffer_size);
         let engine_clone = data.engine.clone();
-        let prefilled_reasoning_end = {
-            let e = data.engine.read();
-            e.get_prefilled_reasoning_end_marker(seq_id)
-        };
         let stream_model_id = model_id.clone();
         let stream_parser_model_id = parser_model_id.clone();
         let stream_model_type = model_type.clone();

--- a/src/server/claude_server.rs
+++ b/src/server/claude_server.rs
@@ -1484,6 +1484,10 @@ pub async fn messages(
             .unwrap_or(256);
         let (response_tx, client_rx) = flume::bounded(buffer_size);
         let engine_clone = data.engine.clone();
+        let prefilled_reasoning_end = {
+            let e = data.engine.read();
+            e.get_prefilled_reasoning_end_marker(seq_id)
+        };
         let stream_model_id = model_id.clone();
         let stream_parser_model_id = parser_model_id.clone();
         let stream_model_type = model_type.clone();
@@ -1607,6 +1611,7 @@ pub async fn messages(
                 stream_tools.clone(),
                 enforce_parser.clone(),
             );
+            tool_parser.set_initial_reasoning_end_marker(prefilled_reasoning_end.clone());
             let should_parse_tools = !stream_tools.is_empty();
 
             let mut current_stream = stream;

--- a/src/server/parser.rs
+++ b/src/server/parser.rs
@@ -311,7 +311,7 @@ pub struct StreamToolParser {
     // Accumulated output for final parsing
     accumulated_output: String,
     // Reasoning block tracking
-    active_reasoning_end: Option<&'static str>,
+    active_reasoning_end: Option<String>,
     // Code block tracking
     in_code_block: bool,
     // Set when incremental parsing found ToolCallItem(s) for the latest processed token.
@@ -329,6 +329,20 @@ const REASONING_MARKERS: &[(&str, &str)] = &[
     ("[THINK]", "[/THINK]"),
     ("<thought>", "</thought>"),
 ];
+
+/// Detect whether a rendered prompt already ends inside a reasoning block.
+///
+/// This happens for templates that prefill `<think>` in `add_generation_prompt`.
+/// Returns the corresponding end marker if matched.
+pub fn detect_prefilled_reasoning_end_marker(prompt: &str) -> Option<String> {
+    let trimmed = prompt.trim_end();
+    for &(start, end) in REASONING_MARKERS {
+        if trimmed.ends_with(start) {
+            return Some(end.to_string());
+        }
+    }
+    None
+}
 
 impl StreamToolParser {
     /// Create a new parser for the given model type
@@ -407,6 +421,11 @@ impl StreamToolParser {
     /// Check if currently inside a reasoning block
     pub fn in_reasoning(&self) -> bool {
         self.active_reasoning_end.is_some()
+    }
+
+    /// Set initial reasoning state when prompt already includes an opening think marker.
+    pub fn set_initial_reasoning_end_marker(&mut self, end_marker: Option<String>) {
+        self.active_reasoning_end = end_marker;
     }
 
     /// Check if currently inside a code block
@@ -493,11 +512,11 @@ impl StreamToolParser {
         if self.active_reasoning_end.is_none() {
             for &(start, end) in REASONING_MARKERS {
                 if token_text.contains(start) || self.accumulated_output.ends_with(start) {
-                    self.active_reasoning_end = Some(end);
+                    self.active_reasoning_end = Some(end.to_string());
                     break;
                 }
             }
-        } else if let Some(end_marker) = self.active_reasoning_end {
+        } else if let Some(end_marker) = self.active_reasoning_end.as_deref() {
             if token_text.contains(end_marker) || self.accumulated_output.ends_with(end_marker) {
                 self.active_reasoning_end = None;
             }

--- a/src/server/parser.rs
+++ b/src/server/parser.rs
@@ -1051,11 +1051,8 @@ impl StreamToolParser {
         match model_type {
             ModelType::LLaMa => "llama",
             ModelType::Mistral | ModelType::Mistral3VL => "mistral",
-            ModelType::Qwen3
-            | ModelType::Qwen3MoE
-            | ModelType::Qwen3_5
-            | ModelType::Qwen3_5MoE
-            | ModelType::Qwen3VL => {
+            ModelType::Qwen3_5 | ModelType::Qwen3_5MoE => "qwen_coder",
+            ModelType::Qwen3 | ModelType::Qwen3MoE | ModelType::Qwen3VL => {
                 if model_lower.contains("coder") {
                     "qwen_coder"
                 } else {
@@ -1892,5 +1889,21 @@ abc
         let safe = parser.sanitize_tool_markup_for_display(raw);
         assert!(safe.contains("<\u{200C}tool_ca"));
         assert!(!parser.contains_tool_markup(&safe));
+    }
+
+    #[test]
+    fn test_parser_defaults_to_qwen_coder_for_qwen35() {
+        assert_eq!(
+            StreamToolParser::parser_name_for_model(&ModelType::Qwen3_5, "qwen3.5-instruct"),
+            "qwen_coder"
+        );
+    }
+
+    #[test]
+    fn test_parser_defaults_to_qwen_coder_for_qwen35_moe() {
+        assert_eq!(
+            StreamToolParser::parser_name_for_model(&ModelType::Qwen3_5MoE, "qwen3.5-moe"),
+            "qwen_coder"
+        );
     }
 }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -389,15 +389,20 @@ pub async fn chat_completion(
         // Clone data needed for the async task
         let engine_clone = data.engine.clone();
         let _img_cfg_clone = img_cfg.clone();
+        let prefilled_reasoning_end = {
+            let e = data.engine.read();
+            e.get_prefilled_reasoning_end_marker(seq_id)
+        };
 
         let tool_config = tool_config.clone();
-        let tool_parser = StreamToolParser::new_with_config(
+        let mut tool_parser = StreamToolParser::new_with_config(
             &model_type,
             parser_model_id.clone(),
             tool_config,
             resolved_tools.clone(),
             enforce_parser.clone(),
         );
+        tool_parser.set_initial_reasoning_end_marker(prefilled_reasoning_end);
         let forced_tool_name = forced_tool_name.clone();
         let stream_tool_schemas = tool_schemas.clone();
         if let Some(ref l) = logger {

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -368,10 +368,12 @@ pub async fn chat_completion(
         if let Some(sid) = session_id {
             crate::log_warn!("Stream request has session_id {sid}");
         }
-        let (seq_id, prompt_length, stream) = {
+        let (seq_id, prompt_length, prefilled_reasoning_end, stream) = {
             let mut e = data.engine.write();
             match e.generate_stream(&params, &messages, image_data, &resolved_tools, &logger) {
-                Ok((seq_id, prompt_length, stream)) => (seq_id, prompt_length, stream),
+                Ok((seq_id, prompt_length, prefilled_reasoning_end, stream)) => {
+                    (seq_id, prompt_length, prefilled_reasoning_end, stream)
+                }
                 Err(e) => {
                     crate::log_error!("Stream generation failed: {:?}", e);
                     return ChatResponder::ValidationError(format!(
@@ -389,10 +391,6 @@ pub async fn chat_completion(
         // Clone data needed for the async task
         let engine_clone = data.engine.clone();
         let _img_cfg_clone = img_cfg.clone();
-        let prefilled_reasoning_end = {
-            let e = data.engine.read();
-            e.get_prefilled_reasoning_end_marker(seq_id)
-        };
 
         let tool_config = tool_config.clone();
         let mut tool_parser = StreamToolParser::new_with_config(

--- a/src/utils/env.rs
+++ b/src/utils/env.rs
@@ -1,0 +1,31 @@
+use std::env;
+
+pub const MAMBA_SNAPSHOT_BLOCK_STRIDE_ENV: &str = "VLLM_RS_MAMBA_SNAPSHOT_STRIDE_BLOCKS";
+pub const DEFAULT_MAMBA_SNAPSHOT_BLOCK_STRIDE: usize = 8;
+
+pub fn mamba_snapshot_block_stride_blocks() -> usize {
+    let default = DEFAULT_MAMBA_SNAPSHOT_BLOCK_STRIDE;
+    let Ok(raw) = env::var(MAMBA_SNAPSHOT_BLOCK_STRIDE_ENV) else {
+        return default;
+    };
+    match raw.trim().parse::<usize>() {
+        Ok(0) => {
+            crate::log_warn!(
+                "{} must be >= 1, got 0. Falling back to default {}.",
+                MAMBA_SNAPSHOT_BLOCK_STRIDE_ENV,
+                default
+            );
+            default
+        }
+        Ok(v) => v,
+        Err(_) => {
+            crate::log_warn!(
+                "Invalid {}='{}'. Falling back to default {}.",
+                MAMBA_SNAPSHOT_BLOCK_STRIDE_ENV,
+                raw,
+                default
+            );
+            default
+        }
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,6 +2,7 @@ pub mod chat_template;
 pub mod command;
 pub mod config;
 pub mod downloader;
+pub mod env;
 pub mod gguf_helper;
 pub mod gguf_varbuilder;
 pub mod gptq;


### PR DESCRIPTION
## Hybrid Mamba Snapshot Stride
For hybrid Mamba models (for example Qwen3.5), prefix reuse also needs a
compatible Mamba snapshot at the matched boundary.

Use environment variable `VLLM_RS_MAMBA_SNAPSHOT_STRIDE_BLOCKS` to control
sparse snapshot capture during decode:
- Default: `8` blocks
- Minimum valid value: `1` (capture every block)
- Effective snapshot boundary in tokens: `block_size * stride`

Example with default `block_size=64` and stride `8`:
- Decode snapshot boundary is every `512` tokens.
- Effective hybrid prefix reuse is aligned to the nearest captured boundary.

This setting only sparsifies decode-time snapshot capture. Prompt/prefill
snapshot capture remains dense.