### PR TITLE
Fix decoding cache mismatch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vllm-rs"
-version = "0.9.15"
+version = "0.9.16"
 edition = "2021"
 default-run = "vllm-rs"
 description = "A minimal, high-performance large language model (LLM) inference engine implementing vLLM in Rust."

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -18,7 +18,7 @@ use crate::server::{EmbeddingStrategy, UsageResponse};
 use crate::tools::Tool;
 use crate::transfer::PdRole;
 use crate::transfer::Transfer;
-use crate::utils::chat_template::Message;
+use crate::utils::chat_template::{Message, RenderedPromptRepairer};
 use crate::utils::config::{EngineConfig, EosTokenId, ModelType, SamplingParams};
 use crate::utils::guidance::{build_llg_factory, extract_guidance_tokens, GuidanceTokens};
 use crate::utils::heartbeat::heartbeat_worker;
@@ -41,7 +41,6 @@ use once_cell::sync::Lazy;
 use parking_lot::RwLock;
 use rayon::iter::IntoParallelIterator;
 use rayon::iter::ParallelIterator;
-use regex::Regex;
 use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader};
 use std::rc::Rc;
@@ -58,182 +57,6 @@ pub static GLOBAL_RT: Lazy<Runtime> = Lazy::new(|| {
         .build()
         .expect("Failed to build global Tokio runtime")
 });
-
-static ADD_GENERATION_PROMPT_COMBINED_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(
-        r#"(?s)\{%-?\s*if\s+add_generation_prompt\s*-?%\}.*?\{\{\-?\s*['"](?P<literal>.*?)['"]\s*\}\}.*?\{%-?\s*endif\s*-?%\}"#,
-    )
-    .expect("valid combined add_generation_prompt regex")
-});
-
-static ADD_GENERATION_PROMPT_SPLIT_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(
-        r#"(?s)\{%-?\s*if\s+add_generation_prompt\s*-?%\}.*?\{\{\-?\s*['"](?P<header>.*?)['"]\s*\}\}.*?if\s+enable_thinking\s+is\s+defined\s+and\s+enable_thinking\s+is\s+false.*?\{\{\-?\s*['"](?P<disabled>.*?)['"]\s*\}\}.*?\{%-?\s*else\s*-?%\}.*?\{\{\-?\s*['"](?P<enabled>.*?)['"]\s*\}\}.*?\{%-?\s*endif\s*-?%\}.*?\{%-?\s*endif\s*-?%\}"#,
-    )
-    .expect("valid split add_generation_prompt regex")
-});
-
-fn escaped_special_token_for_text(token: &str) -> String {
-    if let Some(rest) = token.strip_prefix('<') {
-        format!("<\u{200C}{}", rest)
-    } else {
-        format!("{}\u{200C}", token)
-    }
-}
-
-fn decode_template_string_literal(literal: &str) -> String {
-    let mut decoded = String::with_capacity(literal.len());
-    let mut chars = literal.chars();
-    while let Some(ch) = chars.next() {
-        if ch == '\\' {
-            match chars.next() {
-                Some('n') => decoded.push('\n'),
-                Some('r') => decoded.push('\r'),
-                Some('t') => decoded.push('\t'),
-                Some('\\') => decoded.push('\\'),
-                Some('\'') => decoded.push('\''),
-                Some('"') => decoded.push('"'),
-                Some(other) => {
-                    decoded.push('\\');
-                    decoded.push(other);
-                }
-                None => decoded.push('\\'),
-            }
-        } else {
-            decoded.push(ch);
-        }
-    }
-    decoded
-}
-
-fn extract_generation_prompt_literal_from_chat_template(
-    chat_template: &str,
-    enable_thinking: bool,
-) -> Option<String> {
-    if let Some(captures) = ADD_GENERATION_PROMPT_SPLIT_RE.captures(chat_template) {
-        let header = decode_template_string_literal(captures.name("header")?.as_str());
-        let branch = if enable_thinking {
-            captures.name("enabled")?.as_str()
-        } else {
-            captures.name("disabled")?.as_str()
-        };
-        let suffix = decode_template_string_literal(branch);
-        return Some(format!("{header}{suffix}"));
-    }
-
-    ADD_GENERATION_PROMPT_COMBINED_RE
-        .captures(chat_template)
-        .and_then(|captures| captures.name("literal"))
-        .map(|literal| decode_template_string_literal(literal.as_str()))
-}
-
-fn extract_assistant_header_from_chat_template(
-    chat_template: &str,
-    start_marker: &str,
-    enable_thinking: bool,
-) -> Option<String> {
-    let literal =
-        extract_generation_prompt_literal_from_chat_template(chat_template, enable_thinking)?;
-    if let Some(idx) = literal.find(start_marker) {
-        Some(literal[..idx].to_string())
-    } else if literal.contains("assistant") {
-        Some(literal)
-    } else {
-        None
-    }
-}
-
-fn extract_reasoning_scaffold_from_chat_template(
-    chat_template: &str,
-    start_marker: &str,
-    enable_thinking: bool,
-) -> Option<String> {
-    let literal =
-        extract_generation_prompt_literal_from_chat_template(chat_template, enable_thinking)?;
-    let assistant_header =
-        extract_assistant_header_from_chat_template(chat_template, start_marker, enable_thinking)?;
-    literal
-        .strip_prefix(&assistant_header)
-        .map(|suffix| suffix.to_string())
-}
-
-fn opening_reasoning_scaffold<'a>(scaffold: &'a str, end_marker: &str) -> &'a str {
-    if let Some(idx) = scaffold.find(end_marker) {
-        &scaffold[..idx]
-    } else {
-        scaffold
-    }
-}
-
-fn apply_reasoning_repair_to_rendered_prompt(
-    base_prompt: &str,
-    assistant_header: &str,
-    start_marker: &str,
-    end_marker: &str,
-    scaffold: &str,
-) -> Option<String> {
-    let mut cursor = 0usize;
-    let mut repaired = String::with_capacity(base_prompt.len() + 128);
-    let mut changed = false;
-    let escaped_start_marker = escaped_special_token_for_text(start_marker);
-    let escaped_end_marker = escaped_special_token_for_text(end_marker);
-    let opening_scaffold = opening_reasoning_scaffold(scaffold, end_marker);
-
-    while let Some(rel_idx) = base_prompt[cursor..].find(assistant_header) {
-        let header_idx = cursor + rel_idx;
-        let after_header_idx = header_idx + assistant_header.len();
-        repaired.push_str(&base_prompt[cursor..after_header_idx]);
-
-        let rest = &base_prompt[after_header_idx..];
-        let next_end = rest.find("<|im_end|>").unwrap_or(rest.len());
-        let block_content = &rest[..next_end];
-        let trimmed_block = block_content.trim_start();
-        let has_start_marker = trimmed_block.starts_with(start_marker);
-        let has_escaped_start_marker = trimmed_block.starts_with(&escaped_start_marker);
-        let raw_end_idx = block_content.find(end_marker);
-        let escaped_end_idx = block_content.find(&escaped_end_marker);
-        let has_end_marker = raw_end_idx.is_some() || escaped_end_idx.is_some();
-        let needs_prefix_repair = !has_start_marker;
-        let needs_end_marker_restore = escaped_end_idx.is_some();
-        let should_repair = needs_prefix_repair || needs_end_marker_restore;
-
-        if should_repair {
-            let prefix = if !needs_prefix_repair || has_escaped_start_marker {
-                ""
-            } else if has_end_marker {
-                opening_scaffold
-            } else {
-                scaffold
-            };
-            repaired.push_str(prefix);
-
-            let mut content = block_content.to_string();
-            if needs_prefix_repair && has_escaped_start_marker {
-                let leading_ws_len = content.len() - content.trim_start().len();
-                content.replace_range(
-                    leading_ws_len..leading_ws_len + escaped_start_marker.len(),
-                    start_marker,
-                );
-            }
-            if let Some(end_idx) = content.find(&escaped_end_marker) {
-                content.replace_range(end_idx..end_idx + escaped_end_marker.len(), end_marker);
-            }
-            repaired.push_str(&content);
-            changed = true;
-        } else {
-            repaired.push_str(block_content);
-        }
-
-        cursor = after_header_idx + next_end;
-    }
-
-    if !changed {
-        return None;
-    }
-
-    repaired.push_str(&base_prompt[cursor..]);
-    Some(repaired)
-}
 
 #[derive(Debug, Clone)]
 pub enum StreamItem {
@@ -1274,34 +1097,7 @@ impl LLMEngine {
         (prompt, image_idx)
     }
 
-    fn build_rendered_prompt_repair(
-        &self,
-        base_prompt: &str,
-        enable_thinking: bool,
-    ) -> Option<String> {
-        let Some(template_source) = self.template.template_source() else {
-            return None;
-        };
-        let assistant_header = extract_assistant_header_from_chat_template(
-            template_source,
-            "<think>",
-            enable_thinking,
-        )
-        .or_else(|| {
-            base_prompt
-                .contains("<|im_start|>assistant\n")
-                .then(|| "<|im_start|>assistant\n".to_string())
-        })?;
-        apply_reasoning_repair_to_rendered_prompt(
-            base_prompt,
-            &assistant_header,
-            "<think>",
-            "</think>",
-            "<think>\n",
-        )
-    }
-
-    fn select_prompt_with_reasoning_repair(
+    fn select_prompt_with_prefix_cache_repair(
         &mut self,
         params: &SamplingParams,
         messages: &Vec<Message>,
@@ -1314,9 +1110,10 @@ impl LLMEngine {
             return (base_prompt, image_idx);
         }
 
-        let repaired_prompt =
-            self.build_rendered_prompt_repair(&base_prompt, params.thinking.unwrap_or(false));
-        (repaired_prompt.unwrap_or(base_prompt), image_idx)
+        let enable_thinking = params.thinking.unwrap_or(false);
+        let repaired = RenderedPromptRepairer::from_chat_template(&self.template, enable_thinking)
+            .and_then(|r| r.repair(&base_prompt));
+        (repaired.unwrap_or(base_prompt), image_idx)
     }
 
     pub fn is_idle(&self) -> bool {
@@ -1349,7 +1146,7 @@ impl LLMEngine {
         let mut receivers = Vec::new();
         for (param, messages) in params.iter().zip(message_list.iter()) {
             let (prompt, image_idx) =
-                self.select_prompt_with_reasoning_repair(param, messages, &images, tools, false);
+                self.select_prompt_with_prefix_cache_repair(param, messages, &images, tools, false);
             if let Some(ref l) = logger {
                 l.log_prompt(&prompt);
             }
@@ -1510,7 +1307,7 @@ impl LLMEngine {
         logger: &Option<Arc<ChatCompletionLogger>>,
     ) -> Result<(usize, usize, Option<String>, mpsc::Receiver<StreamItem>)> {
         let (prompt, image_idx) =
-            self.select_prompt_with_reasoning_repair(params, messages, &images, tools, false);
+            self.select_prompt_with_prefix_cache_repair(params, messages, &images, tools, false);
         if let Some(ref l) = logger {
             l.log_prompt(&prompt);
         }
@@ -1786,126 +1583,5 @@ impl LLMEngine {
     /// Get a clone of the chat template for external use (e.g., tokenization without generation)
     pub fn get_chat_template(&self) -> ChatTemplate {
         self.template.clone()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn extracts_assistant_header_from_qwen_generation_prompt_branch() {
-        let template = r#"
-{%- if add_generation_prompt %}
-    {{- '<|im_start|>assistant\n' }}
-    {%- if enable_thinking is defined and enable_thinking is false %}
-        {{- '<think>\n\n</think>\n\n' }}
-    {%- else %}
-        {{- '<think>\n' }}
-    {%- endif %}
-{%- endif %}
-"#;
-        assert_eq!(
-            extract_assistant_header_from_chat_template(template, "<think>", true).as_deref(),
-            Some("<|im_start|>assistant\n")
-        );
-    }
-
-    #[test]
-    fn extracts_assistant_header_from_combined_generation_prompt_literal() {
-        let template = r#"
-{%- if add_generation_prompt %}
-    {{- '<|im_start|>assistant\n<think>\n' }}
-{%- endif %}
-"#;
-        assert_eq!(
-            extract_assistant_header_from_chat_template(template, "<think>", true).as_deref(),
-            Some("<|im_start|>assistant\n")
-        );
-    }
-
-    #[test]
-    fn reasoning_repair_prefixes_cover_common_hidden_scaffolds() {
-        let template = r#"
-{%- if add_generation_prompt %}
-    {{- '<|im_start|>assistant\n' }}
-    {%- if enable_thinking is defined and enable_thinking is false %}
-        {{- '<think>\n\n</think>\n\n' }}
-    {%- else %}
-        {{- '<think>\n' }}
-    {%- endif %}
-{%- endif %}
-"#;
-        assert_eq!(
-            extract_reasoning_scaffold_from_chat_template(template, "<think>", true).as_deref(),
-            Some("<think>\n")
-        );
-        assert_eq!(
-            extract_reasoning_scaffold_from_chat_template(template, "<think>", false).as_deref(),
-            Some("<think>\n\n</think>\n\n")
-        );
-    }
-
-    #[test]
-    fn reasoning_repair_prefix_is_applied_only_to_assistant_messages() {
-        let prompt = "<|im_start|>user\nhi<|im_end|>\n<|im_start|>assistant\nThinking Process:\n...\n</think>\nhello<|im_end|>\n";
-        let repaired = apply_reasoning_repair_to_rendered_prompt(
-            prompt,
-            "<|im_start|>assistant\n",
-            "<think>",
-            "</think>",
-            "<think>\n",
-        )
-        .unwrap();
-        assert!(repaired.contains("<|im_start|>assistant\n<think>\nThinking Process:"));
-    }
-
-    #[test]
-    fn reasoning_repair_applies_when_visible_text_has_no_end_marker() {
-        let prompt =
-            "<|im_start|>assistant\nFinal answer only<|im_end|>\n<|im_start|>assistant\n<think>\n";
-        let repaired = apply_reasoning_repair_to_rendered_prompt(
-            prompt,
-            "<|im_start|>assistant\n",
-            "<think>",
-            "</think>",
-            "<think>\n",
-        )
-        .unwrap();
-        assert!(repaired.starts_with("<|im_start|>assistant\n<think>\nFinal answer only"));
-    }
-
-    #[test]
-    fn reasoning_repair_uses_full_disabled_scaffold_when_end_marker_is_missing() {
-        let prompt = "<|im_start|>assistant\nVisible answer<|im_end|>\n";
-        let repaired = apply_reasoning_repair_to_rendered_prompt(
-            prompt,
-            "<|im_start|>assistant\n",
-            "<think>",
-            "</think>",
-            "<think>\n\n</think>\n\n",
-        )
-        .unwrap();
-        assert!(
-            repaired.starts_with("<|im_start|>assistant\n<think>\n\n</think>\n\nVisible answer")
-        );
-    }
-
-    #[test]
-    fn reasoning_repair_restores_escaped_end_marker_without_readding_prefix() {
-        let prompt =
-            "<|im_start|>assistant\n<think>\nreasoning\n<\u{200C}/think>\nanswer<|im_end|>\n";
-        let repaired = apply_reasoning_repair_to_rendered_prompt(
-            prompt,
-            "<|im_start|>assistant\n",
-            "<think>",
-            "</think>",
-            "<think>\n",
-        )
-        .unwrap();
-        assert_eq!(
-            repaired,
-            "<|im_start|>assistant\n<think>\nreasoning\n</think>\nanswer<|im_end|>\n"
-        );
     }
 }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -41,6 +41,7 @@ use once_cell::sync::Lazy;
 use parking_lot::RwLock;
 use rayon::iter::IntoParallelIterator;
 use rayon::iter::ParallelIterator;
+use regex::Regex;
 use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader};
 use std::rc::Rc;
@@ -57,6 +58,182 @@ pub static GLOBAL_RT: Lazy<Runtime> = Lazy::new(|| {
         .build()
         .expect("Failed to build global Tokio runtime")
 });
+
+static ADD_GENERATION_PROMPT_COMBINED_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r#"(?s)\{%-?\s*if\s+add_generation_prompt\s*-?%\}.*?\{\{\-?\s*['"](?P<literal>.*?)['"]\s*\}\}.*?\{%-?\s*endif\s*-?%\}"#,
+    )
+    .expect("valid combined add_generation_prompt regex")
+});
+
+static ADD_GENERATION_PROMPT_SPLIT_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r#"(?s)\{%-?\s*if\s+add_generation_prompt\s*-?%\}.*?\{\{\-?\s*['"](?P<header>.*?)['"]\s*\}\}.*?if\s+enable_thinking\s+is\s+defined\s+and\s+enable_thinking\s+is\s+false.*?\{\{\-?\s*['"](?P<disabled>.*?)['"]\s*\}\}.*?\{%-?\s*else\s*-?%\}.*?\{\{\-?\s*['"](?P<enabled>.*?)['"]\s*\}\}.*?\{%-?\s*endif\s*-?%\}.*?\{%-?\s*endif\s*-?%\}"#,
+    )
+    .expect("valid split add_generation_prompt regex")
+});
+
+fn escaped_special_token_for_text(token: &str) -> String {
+    if let Some(rest) = token.strip_prefix('<') {
+        format!("<\u{200C}{}", rest)
+    } else {
+        format!("{}\u{200C}", token)
+    }
+}
+
+fn decode_template_string_literal(literal: &str) -> String {
+    let mut decoded = String::with_capacity(literal.len());
+    let mut chars = literal.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '\\' {
+            match chars.next() {
+                Some('n') => decoded.push('\n'),
+                Some('r') => decoded.push('\r'),
+                Some('t') => decoded.push('\t'),
+                Some('\\') => decoded.push('\\'),
+                Some('\'') => decoded.push('\''),
+                Some('"') => decoded.push('"'),
+                Some(other) => {
+                    decoded.push('\\');
+                    decoded.push(other);
+                }
+                None => decoded.push('\\'),
+            }
+        } else {
+            decoded.push(ch);
+        }
+    }
+    decoded
+}
+
+fn extract_generation_prompt_literal_from_chat_template(
+    chat_template: &str,
+    enable_thinking: bool,
+) -> Option<String> {
+    if let Some(captures) = ADD_GENERATION_PROMPT_SPLIT_RE.captures(chat_template) {
+        let header = decode_template_string_literal(captures.name("header")?.as_str());
+        let branch = if enable_thinking {
+            captures.name("enabled")?.as_str()
+        } else {
+            captures.name("disabled")?.as_str()
+        };
+        let suffix = decode_template_string_literal(branch);
+        return Some(format!("{header}{suffix}"));
+    }
+
+    ADD_GENERATION_PROMPT_COMBINED_RE
+        .captures(chat_template)
+        .and_then(|captures| captures.name("literal"))
+        .map(|literal| decode_template_string_literal(literal.as_str()))
+}
+
+fn extract_assistant_header_from_chat_template(
+    chat_template: &str,
+    start_marker: &str,
+    enable_thinking: bool,
+) -> Option<String> {
+    let literal =
+        extract_generation_prompt_literal_from_chat_template(chat_template, enable_thinking)?;
+    if let Some(idx) = literal.find(start_marker) {
+        Some(literal[..idx].to_string())
+    } else if literal.contains("assistant") {
+        Some(literal)
+    } else {
+        None
+    }
+}
+
+fn extract_reasoning_scaffold_from_chat_template(
+    chat_template: &str,
+    start_marker: &str,
+    enable_thinking: bool,
+) -> Option<String> {
+    let literal =
+        extract_generation_prompt_literal_from_chat_template(chat_template, enable_thinking)?;
+    let assistant_header =
+        extract_assistant_header_from_chat_template(chat_template, start_marker, enable_thinking)?;
+    literal
+        .strip_prefix(&assistant_header)
+        .map(|suffix| suffix.to_string())
+}
+
+fn opening_reasoning_scaffold<'a>(scaffold: &'a str, end_marker: &str) -> &'a str {
+    if let Some(idx) = scaffold.find(end_marker) {
+        &scaffold[..idx]
+    } else {
+        scaffold
+    }
+}
+
+fn apply_reasoning_repair_to_rendered_prompt(
+    base_prompt: &str,
+    assistant_header: &str,
+    start_marker: &str,
+    end_marker: &str,
+    scaffold: &str,
+) -> Option<String> {
+    let mut cursor = 0usize;
+    let mut repaired = String::with_capacity(base_prompt.len() + 128);
+    let mut changed = false;
+    let escaped_start_marker = escaped_special_token_for_text(start_marker);
+    let escaped_end_marker = escaped_special_token_for_text(end_marker);
+    let opening_scaffold = opening_reasoning_scaffold(scaffold, end_marker);
+
+    while let Some(rel_idx) = base_prompt[cursor..].find(assistant_header) {
+        let header_idx = cursor + rel_idx;
+        let after_header_idx = header_idx + assistant_header.len();
+        repaired.push_str(&base_prompt[cursor..after_header_idx]);
+
+        let rest = &base_prompt[after_header_idx..];
+        let next_end = rest.find("<|im_end|>").unwrap_or(rest.len());
+        let block_content = &rest[..next_end];
+        let trimmed_block = block_content.trim_start();
+        let has_start_marker = trimmed_block.starts_with(start_marker);
+        let has_escaped_start_marker = trimmed_block.starts_with(&escaped_start_marker);
+        let raw_end_idx = block_content.find(end_marker);
+        let escaped_end_idx = block_content.find(&escaped_end_marker);
+        let has_end_marker = raw_end_idx.is_some() || escaped_end_idx.is_some();
+        let needs_prefix_repair = !has_start_marker;
+        let needs_end_marker_restore = escaped_end_idx.is_some();
+        let should_repair = needs_prefix_repair || needs_end_marker_restore;
+
+        if should_repair {
+            let prefix = if !needs_prefix_repair || has_escaped_start_marker {
+                ""
+            } else if has_end_marker {
+                opening_scaffold
+            } else {
+                scaffold
+            };
+            repaired.push_str(prefix);
+
+            let mut content = block_content.to_string();
+            if needs_prefix_repair && has_escaped_start_marker {
+                let leading_ws_len = content.len() - content.trim_start().len();
+                content.replace_range(
+                    leading_ws_len..leading_ws_len + escaped_start_marker.len(),
+                    start_marker,
+                );
+            }
+            if let Some(end_idx) = content.find(&escaped_end_marker) {
+                content.replace_range(end_idx..end_idx + escaped_end_marker.len(), end_marker);
+            }
+            repaired.push_str(&content);
+            changed = true;
+        } else {
+            repaired.push_str(block_content);
+        }
+
+        cursor = after_header_idx + next_end;
+    }
+
+    if !changed {
+        return None;
+    }
+
+    repaired.push_str(&base_prompt[cursor..]);
+    Some(repaired)
+}
 
 #[derive(Debug, Clone)]
 pub enum StreamItem {
@@ -782,7 +959,6 @@ impl LLMEngine {
                 let seq_id = s.id;
                 if s.is_finished() {
                     // Normal finish handling
-
                     if let Some(sender) = self.stream_senders.get_mut(&seq_id) {
                         if let Some(request_type) = self.request_types.get(&seq_id) {
                             let prompt_start_time = s.created_time();
@@ -1098,6 +1274,51 @@ impl LLMEngine {
         (prompt, image_idx)
     }
 
+    fn build_rendered_prompt_repair(
+        &self,
+        base_prompt: &str,
+        enable_thinking: bool,
+    ) -> Option<String> {
+        let Some(template_source) = self.template.template_source() else {
+            return None;
+        };
+        let assistant_header = extract_assistant_header_from_chat_template(
+            template_source,
+            "<think>",
+            enable_thinking,
+        )
+        .or_else(|| {
+            base_prompt
+                .contains("<|im_start|>assistant\n")
+                .then(|| "<|im_start|>assistant\n".to_string())
+        })?;
+        apply_reasoning_repair_to_rendered_prompt(
+            base_prompt,
+            &assistant_header,
+            "<think>",
+            "</think>",
+            "<think>\n",
+        )
+    }
+
+    fn select_prompt_with_reasoning_repair(
+        &mut self,
+        params: &SamplingParams,
+        messages: &Vec<Message>,
+        _images: &Option<ImageData>,
+        tools: &Vec<Tool>,
+        log: bool,
+    ) -> (String, i32) {
+        let (base_prompt, image_idx) = self.apply_chat_template(params, messages, tools, log);
+        if !self.scheduler.block_manager.prefix_cache_enabled() {
+            return (base_prompt, image_idx);
+        }
+
+        let repaired_prompt =
+            self.build_rendered_prompt_repair(&base_prompt, params.thinking.unwrap_or(false));
+        (repaired_prompt.unwrap_or(base_prompt), image_idx)
+    }
+
     pub fn is_idle(&self) -> bool {
         self.active_requests.is_empty()
     }
@@ -1127,7 +1348,8 @@ impl LLMEngine {
         }
         let mut receivers = Vec::new();
         for (param, messages) in params.iter().zip(message_list.iter()) {
-            let (prompt, image_idx) = self.apply_chat_template(param, messages, tools, false);
+            let (prompt, image_idx) =
+                self.select_prompt_with_reasoning_repair(param, messages, &images, tools, false);
             if let Some(ref l) = logger {
                 l.log_prompt(&prompt);
             }
@@ -1287,7 +1509,8 @@ impl LLMEngine {
         tools: &Vec<Tool>,
         logger: &Option<Arc<ChatCompletionLogger>>,
     ) -> Result<(usize, usize, Option<String>, mpsc::Receiver<StreamItem>)> {
-        let (prompt, image_idx) = self.apply_chat_template(params, messages, tools, false);
+        let (prompt, image_idx) =
+            self.select_prompt_with_reasoning_repair(params, messages, &images, tools, false);
         if let Some(ref l) = logger {
             l.log_prompt(&prompt);
         }
@@ -1563,5 +1786,126 @@ impl LLMEngine {
     /// Get a clone of the chat template for external use (e.g., tokenization without generation)
     pub fn get_chat_template(&self) -> ChatTemplate {
         self.template.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_assistant_header_from_qwen_generation_prompt_branch() {
+        let template = r#"
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}
+"#;
+        assert_eq!(
+            extract_assistant_header_from_chat_template(template, "<think>", true).as_deref(),
+            Some("<|im_start|>assistant\n")
+        );
+    }
+
+    #[test]
+    fn extracts_assistant_header_from_combined_generation_prompt_literal() {
+        let template = r#"
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n<think>\n' }}
+{%- endif %}
+"#;
+        assert_eq!(
+            extract_assistant_header_from_chat_template(template, "<think>", true).as_deref(),
+            Some("<|im_start|>assistant\n")
+        );
+    }
+
+    #[test]
+    fn reasoning_repair_prefixes_cover_common_hidden_scaffolds() {
+        let template = r#"
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}
+"#;
+        assert_eq!(
+            extract_reasoning_scaffold_from_chat_template(template, "<think>", true).as_deref(),
+            Some("<think>\n")
+        );
+        assert_eq!(
+            extract_reasoning_scaffold_from_chat_template(template, "<think>", false).as_deref(),
+            Some("<think>\n\n</think>\n\n")
+        );
+    }
+
+    #[test]
+    fn reasoning_repair_prefix_is_applied_only_to_assistant_messages() {
+        let prompt = "<|im_start|>user\nhi<|im_end|>\n<|im_start|>assistant\nThinking Process:\n...\n</think>\nhello<|im_end|>\n";
+        let repaired = apply_reasoning_repair_to_rendered_prompt(
+            prompt,
+            "<|im_start|>assistant\n",
+            "<think>",
+            "</think>",
+            "<think>\n",
+        )
+        .unwrap();
+        assert!(repaired.contains("<|im_start|>assistant\n<think>\nThinking Process:"));
+    }
+
+    #[test]
+    fn reasoning_repair_applies_when_visible_text_has_no_end_marker() {
+        let prompt =
+            "<|im_start|>assistant\nFinal answer only<|im_end|>\n<|im_start|>assistant\n<think>\n";
+        let repaired = apply_reasoning_repair_to_rendered_prompt(
+            prompt,
+            "<|im_start|>assistant\n",
+            "<think>",
+            "</think>",
+            "<think>\n",
+        )
+        .unwrap();
+        assert!(repaired.starts_with("<|im_start|>assistant\n<think>\nFinal answer only"));
+    }
+
+    #[test]
+    fn reasoning_repair_uses_full_disabled_scaffold_when_end_marker_is_missing() {
+        let prompt = "<|im_start|>assistant\nVisible answer<|im_end|>\n";
+        let repaired = apply_reasoning_repair_to_rendered_prompt(
+            prompt,
+            "<|im_start|>assistant\n",
+            "<think>",
+            "</think>",
+            "<think>\n\n</think>\n\n",
+        )
+        .unwrap();
+        assert!(
+            repaired.starts_with("<|im_start|>assistant\n<think>\n\n</think>\n\nVisible answer")
+        );
+    }
+
+    #[test]
+    fn reasoning_repair_restores_escaped_end_marker_without_readding_prefix() {
+        let prompt =
+            "<|im_start|>assistant\n<think>\nreasoning\n<\u{200C}/think>\nanswer<|im_end|>\n";
+        let repaired = apply_reasoning_repair_to_rendered_prompt(
+            prompt,
+            "<|im_start|>assistant\n",
+            "<think>",
+            "</think>",
+            "<think>\n",
+        )
+        .unwrap();
+        assert_eq!(
+            repaired,
+            "<|im_start|>assistant\n<think>\nreasoning\n</think>\nanswer<|im_end|>\n"
+        );
     }
 }

--- a/src/utils/chat_template.rs
+++ b/src/utils/chat_template.rs
@@ -1,7 +1,9 @@
 use crate::tools::Tool;
 use minijinja::{context, Environment};
+use once_cell::sync::Lazy;
 #[cfg(feature = "python")]
 use pyo3::pyclass;
+use regex::Regex;
 use tokenizers::Tokenizer;
 
 #[cfg(feature = "python")]
@@ -294,5 +296,536 @@ impl ChatTemplate {
               tools => tools,
             })
             .map_err(ApplyChatTemplateError::RenderTemplateError)
+    }
+
+    pub fn eos_token(&self) -> Option<&str> {
+        self.eos_token.as_deref()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rendered-prompt repair for prefix-cache alignment
+// ---------------------------------------------------------------------------
+
+static GENERATION_PROMPT_MULTI_LITERAL_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r#"(?s)\{%-?\s*if\s+add_generation_prompt\s*-?%\}(?P<body>.*?)\{%-?\s*endif\s*-?%\}"#,
+    )
+    .expect("valid generation prompt block regex")
+});
+
+static TEMPLATE_STRING_LITERAL_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"\{\{\-?\s*['"](?P<lit>.*?)['"]\s*-?\}\}"#)
+        .expect("valid template string literal regex")
+});
+
+static ENABLE_THINKING_FALSE_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"(?s)enable_thinking\s+is\s+(defined\s+and\s+enable_thinking\s+is\s+)?false"#)
+        .expect("valid enable_thinking false regex")
+});
+
+fn decode_template_string_literal(literal: &str) -> String {
+    let mut decoded = String::with_capacity(literal.len());
+    let mut chars = literal.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '\\' {
+            match chars.next() {
+                Some('n') => decoded.push('\n'),
+                Some('r') => decoded.push('\r'),
+                Some('t') => decoded.push('\t'),
+                Some('\\') => decoded.push('\\'),
+                Some('\'') => decoded.push('\''),
+                Some('"') => decoded.push('"'),
+                Some(other) => {
+                    decoded.push('\\');
+                    decoded.push(other);
+                }
+                None => decoded.push('\\'),
+            }
+        } else {
+            decoded.push(ch);
+        }
+    }
+    decoded
+}
+
+fn escaped_special_token(token: &str) -> String {
+    if let Some(rest) = token.strip_prefix('<') {
+        format!("<\u{200C}{}", rest)
+    } else {
+        format!("{}\u{200C}", token)
+    }
+}
+
+/// Extracts the full generation-prompt literal that the template would emit
+/// when `add_generation_prompt` is true.
+///
+/// Handles three patterns found across Qwen model families:
+///   1. Single combined literal  (e.g. Qwen3-4B-Thinking)
+///   2. Header literal + `enable_thinking` branch  (e.g. Qwen3.5)
+///   3. Header literal only, no thinking branch  (e.g. Qwen3-Coder-Next, Qwen3-VL)
+fn extract_generation_prompt_literal(chat_template: &str, enable_thinking: bool) -> Option<String> {
+    let block_caps = GENERATION_PROMPT_MULTI_LITERAL_RE.captures(chat_template)?;
+    let body = block_caps.name("body")?.as_str();
+
+    let literals: Vec<String> = TEMPLATE_STRING_LITERAL_RE
+        .captures_iter(body)
+        .filter_map(|c| c.name("lit").map(|m| m.as_str().to_string()))
+        .collect();
+
+    if literals.is_empty() {
+        return None;
+    }
+
+    let has_thinking_branch = body.contains("enable_thinking");
+    if !has_thinking_branch {
+        return Some(
+            literals
+                .iter()
+                .map(|l| decode_template_string_literal(l))
+                .collect::<String>(),
+        );
+    }
+
+    // Template has an enable_thinking branch. Parse the structure:
+    //   header literal(s)  →  before the `if enable_thinking` block
+    //   disabled literal(s) → inside the `enable_thinking is false` branch
+    //   enabled literal(s)  → inside the `else` branch
+    let thinking_block_start = body.find("enable_thinking")?;
+
+    let header_body = &body[..thinking_block_start];
+    let header_literals: Vec<String> = TEMPLATE_STRING_LITERAL_RE
+        .captures_iter(header_body)
+        .filter_map(|c| c.name("lit").map(|m| m.as_str().to_string()))
+        .collect();
+
+    let thinking_body = &body[thinking_block_start..];
+
+    let is_false_first = ENABLE_THINKING_FALSE_RE
+        .is_match(&thinking_body[..thinking_body.find("else").unwrap_or(thinking_body.len())]);
+
+    let branch_literals: Vec<Vec<String>> = thinking_body
+        .split("{%- else")
+        .chain(thinking_body.split("{% else"))
+        .take(2)
+        .map(|section| {
+            TEMPLATE_STRING_LITERAL_RE
+                .captures_iter(section)
+                .filter_map(|c| c.name("lit").map(|m| m.as_str().to_string()))
+                .collect()
+        })
+        .collect();
+
+    let (disabled_lits, enabled_lits) = if branch_literals.len() >= 2 {
+        if is_false_first {
+            (&branch_literals[0], &branch_literals[1])
+        } else {
+            (&branch_literals[1], &branch_literals[0])
+        }
+    } else {
+        return None;
+    };
+
+    let suffix_lits = if enable_thinking {
+        enabled_lits
+    } else {
+        disabled_lits
+    };
+
+    let mut result = String::new();
+    for lit in &header_literals {
+        result.push_str(&decode_template_string_literal(lit));
+    }
+    for lit in suffix_lits {
+        result.push_str(&decode_template_string_literal(lit));
+    }
+    Some(result)
+}
+
+/// Extracts the end-of-turn delimiter from the chat template by looking at how
+/// assistant messages are terminated. Falls back to the configured eos_token.
+fn extract_eot_delimiter(chat_template: &str, eos_token: Option<&str>) -> Option<String> {
+    static EOT_RE: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r#"(?s)message\.role\s*==\s*['"]assistant['"].*?\{\{\-?\s*['"](?P<eot><\|[^|]+\|>)['"]\s*-?\}\}"#)
+            .expect("valid eot regex")
+    });
+
+    if let Some(caps) = EOT_RE.captures(chat_template) {
+        if let Some(eot) = caps.name("eot") {
+            let decoded = decode_template_string_literal(eot.as_str());
+            if decoded.contains("end") || decoded.contains("eot") {
+                return Some(decoded);
+            }
+        }
+    }
+
+    eos_token.map(|s| s.to_string())
+}
+
+/// Holds the extracted repair parameters for a specific template + thinking mode.
+/// `None` fields mean no repair is needed for that aspect.
+#[derive(Debug, Clone)]
+pub struct RenderedPromptRepairer {
+    assistant_header: String,
+    eot_delimiter: String,
+    start_marker: Option<String>,
+    end_marker: Option<String>,
+    scaffold: Option<String>,
+}
+
+impl RenderedPromptRepairer {
+    /// Build a repairer from a chat template source and thinking mode.
+    /// Returns `None` if no repair is possible (e.g. no assistant header found).
+    pub fn from_template(
+        chat_template: &str,
+        eos_token: Option<&str>,
+        enable_thinking: bool,
+    ) -> Option<Self> {
+        let generation_literal = extract_generation_prompt_literal(chat_template, enable_thinking)?;
+
+        if generation_literal.is_empty() {
+            return None;
+        }
+
+        let eot_delimiter = extract_eot_delimiter(chat_template, eos_token)
+            .unwrap_or_else(|| "<|im_end|>".to_string());
+
+        // Find the reasoning start marker within the generation literal.
+        // We look for known reasoning markers that appear in the literal.
+        let known_markers = [
+            ("<think>", "</think>"),
+            ("<thinking>", "</thinking>"),
+            ("<reasoning>", "</reasoning>"),
+            ("<reflection>", "</reflection>"),
+            ("<internal>", "</internal>"),
+        ];
+
+        let mut found_start: Option<(usize, &str, &str)> = None;
+        for (start, end) in &known_markers {
+            if let Some(idx) = generation_literal.find(start) {
+                found_start = Some((idx, start, end));
+                break;
+            }
+        }
+
+        let (assistant_header, start_marker, end_marker, scaffold) =
+            if let Some((idx, start, end)) = found_start {
+                let header = generation_literal[..idx].to_string();
+                let suffix = generation_literal[idx..].to_string();
+                (
+                    header,
+                    Some(start.to_string()),
+                    Some(end.to_string()),
+                    Some(suffix),
+                )
+            } else if generation_literal.contains("assistant") {
+                (generation_literal, None, None, None)
+            } else {
+                return None;
+            };
+
+        if assistant_header.is_empty() {
+            return None;
+        }
+
+        Some(Self {
+            assistant_header,
+            eot_delimiter,
+            start_marker,
+            end_marker,
+            scaffold,
+        })
+    }
+
+    /// Build a repairer from a `ChatTemplate` instance.
+    pub fn from_chat_template(template: &ChatTemplate, enable_thinking: bool) -> Option<Self> {
+        let source = template.template_source()?;
+        Self::from_template(source, template.eos_token(), enable_thinking)
+    }
+
+    /// Returns true if this repairer has a reasoning scaffold to insert.
+    pub fn has_reasoning_scaffold(&self) -> bool {
+        self.scaffold.is_some()
+    }
+
+    /// Apply the repair to a rendered prompt. Returns `None` if no changes needed.
+    pub fn repair(&self, base_prompt: &str) -> Option<String> {
+        let (Some(start_marker), Some(end_marker), Some(scaffold)) =
+            (&self.start_marker, &self.end_marker, &self.scaffold)
+        else {
+            return None;
+        };
+
+        let escaped_start = escaped_special_token(start_marker);
+        let escaped_end = escaped_special_token(end_marker);
+
+        // The "opening scaffold" is the part before the end marker (if the
+        // scaffold contains a paired close, e.g. `<think>\n\n</think>\n\n`).
+        let opening_scaffold = if let Some(idx) = scaffold.find(end_marker.as_str()) {
+            &scaffold[..idx]
+        } else {
+            scaffold.as_str()
+        };
+
+        let mut cursor = 0usize;
+        let mut repaired = String::with_capacity(base_prompt.len() + 128);
+        let mut changed = false;
+
+        while let Some(rel_idx) = base_prompt[cursor..].find(&self.assistant_header) {
+            let header_idx = cursor + rel_idx;
+            let after_header = header_idx + self.assistant_header.len();
+            repaired.push_str(&base_prompt[cursor..after_header]);
+
+            let rest = &base_prompt[after_header..];
+            let block_end = rest.find(self.eot_delimiter.as_str()).unwrap_or(rest.len());
+            let block = &rest[..block_end];
+            let trimmed = block.trim_start();
+
+            let has_start = trimmed.starts_with(start_marker.as_str());
+            let has_escaped_start = trimmed.starts_with(&escaped_start);
+            let raw_end_present = block.contains(end_marker.as_str());
+            let escaped_end_idx = block.find(&escaped_end);
+            let has_end = raw_end_present || escaped_end_idx.is_some();
+
+            let needs_prefix = !has_start;
+            let needs_end_restore = escaped_end_idx.is_some();
+
+            if needs_prefix || needs_end_restore {
+                let prefix = if !needs_prefix || has_escaped_start {
+                    ""
+                } else if has_end {
+                    opening_scaffold
+                } else {
+                    scaffold.as_str()
+                };
+                repaired.push_str(prefix);
+
+                let mut content = block.to_string();
+                if needs_prefix && has_escaped_start {
+                    let ws_len = content.len() - content.trim_start().len();
+                    content.replace_range(ws_len..ws_len + escaped_start.len(), start_marker);
+                }
+                if let Some(eidx) = content.find(&escaped_end) {
+                    content.replace_range(eidx..eidx + escaped_end.len(), end_marker);
+                }
+                repaired.push_str(&content);
+                changed = true;
+            } else {
+                repaired.push_str(block);
+            }
+
+            cursor = after_header + block_end;
+        }
+
+        if !changed {
+            return None;
+        }
+
+        repaired.push_str(&base_prompt[cursor..]);
+        Some(repaired)
+    }
+
+    /// Convenience: try to build a repairer and apply it in one step.
+    /// Returns the repaired prompt or `None` if no repair was needed/possible.
+    pub fn try_repair(
+        chat_template: &str,
+        eos_token: Option<&str>,
+        enable_thinking: bool,
+        base_prompt: &str,
+    ) -> Option<String> {
+        let repairer = Self::from_template(chat_template, eos_token, enable_thinking)?;
+        repairer.repair(base_prompt)
+    }
+}
+
+#[cfg(test)]
+mod repair_tests {
+    use super::*;
+
+    const QWEN35_TEMPLATE: &str = r#"
+{%- for message in messages %}
+    {%- if message.role == "assistant" %}
+        {{- '<|im_start|>' + message.role + '\n' + message.content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + message.content + '<|im_end|>' + '\n' }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}
+"#;
+
+    const QWEN3_4B_TEMPLATE: &str = r#"
+{%- for message in messages %}
+    {%- if message.role == "assistant" %}
+        {{- '<|im_start|>' + message.role + '\n' + message.content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + message.content + '<|im_end|>' + '\n' }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n<think>\n' }}
+{%- endif %}
+"#;
+
+    const QWEN3_CODER_TEMPLATE: &str = r#"
+{%- for message in messages %}
+    {%- if message.role == "assistant" %}
+        {{- '<|im_start|>' + message.role + '\n' + message.content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + message.content + '<|im_end|>' + '\n' }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+{%- endif %}
+"#;
+
+    #[test]
+    fn qwen35_thinking_enabled_extracts_correct_scaffold() {
+        let r = RenderedPromptRepairer::from_template(QWEN35_TEMPLATE, Some("<|im_end|>"), true)
+            .unwrap();
+        assert_eq!(r.assistant_header, "<|im_start|>assistant\n");
+        assert_eq!(r.start_marker.as_deref(), Some("<think>"));
+        assert_eq!(r.end_marker.as_deref(), Some("</think>"));
+        assert_eq!(r.scaffold.as_deref(), Some("<think>\n"));
+    }
+
+    #[test]
+    fn qwen35_thinking_disabled_extracts_paired_scaffold() {
+        let r = RenderedPromptRepairer::from_template(QWEN35_TEMPLATE, Some("<|im_end|>"), false)
+            .unwrap();
+        assert_eq!(r.assistant_header, "<|im_start|>assistant\n");
+        assert_eq!(r.scaffold.as_deref(), Some("<think>\n\n</think>\n\n"));
+    }
+
+    #[test]
+    fn qwen3_4b_combined_literal_extracts_scaffold() {
+        let r = RenderedPromptRepairer::from_template(QWEN3_4B_TEMPLATE, Some("<|im_end|>"), true)
+            .unwrap();
+        assert_eq!(r.assistant_header, "<|im_start|>assistant\n");
+        assert_eq!(r.scaffold.as_deref(), Some("<think>\n"));
+    }
+
+    #[test]
+    fn qwen3_coder_no_thinking_returns_no_scaffold() {
+        let r =
+            RenderedPromptRepairer::from_template(QWEN3_CODER_TEMPLATE, Some("<|im_end|>"), true)
+                .unwrap();
+        assert_eq!(r.assistant_header, "<|im_start|>assistant\n");
+        assert!(!r.has_reasoning_scaffold());
+    }
+
+    #[test]
+    fn no_repair_needed_when_template_has_no_thinking() {
+        let prompt = "<|im_start|>assistant\nHello world<|im_end|>\n";
+        let result = RenderedPromptRepairer::try_repair(
+            QWEN3_CODER_TEMPLATE,
+            Some("<|im_end|>"),
+            true,
+            prompt,
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn repair_inserts_missing_think_prefix_enabled() {
+        let prompt = "<|im_start|>user\nhi<|im_end|>\n\
+                       <|im_start|>assistant\nThinking...\n</think>\nhello<|im_end|>\n";
+        let repaired =
+            RenderedPromptRepairer::try_repair(QWEN35_TEMPLATE, Some("<|im_end|>"), true, prompt)
+                .unwrap();
+        assert!(repaired.contains("<|im_start|>assistant\n<think>\nThinking..."));
+    }
+
+    #[test]
+    fn repair_inserts_full_paired_scaffold_when_disabled_and_no_end_marker() {
+        let prompt = "<|im_start|>assistant\nVisible answer<|im_end|>\n";
+        let repaired =
+            RenderedPromptRepairer::try_repair(QWEN35_TEMPLATE, Some("<|im_end|>"), false, prompt)
+                .unwrap();
+        assert!(
+            repaired.starts_with("<|im_start|>assistant\n<think>\n\n</think>\n\nVisible answer")
+        );
+    }
+
+    #[test]
+    fn repair_inserts_opening_scaffold_when_end_marker_present() {
+        let prompt = "<|im_start|>assistant\nThinking...\n</think>\nhello<|im_end|>\n";
+        let repaired =
+            RenderedPromptRepairer::try_repair(QWEN35_TEMPLATE, Some("<|im_end|>"), false, prompt)
+                .unwrap();
+        assert!(repaired.starts_with("<|im_start|>assistant\n<think>\n\nThinking..."));
+    }
+
+    #[test]
+    fn repair_restores_escaped_end_marker() {
+        let prompt =
+            "<|im_start|>assistant\n<think>\nreasoning\n<\u{200C}/think>\nanswer<|im_end|>\n";
+        let repaired =
+            RenderedPromptRepairer::try_repair(QWEN35_TEMPLATE, Some("<|im_end|>"), true, prompt)
+                .unwrap();
+        assert_eq!(
+            repaired,
+            "<|im_start|>assistant\n<think>\nreasoning\n</think>\nanswer<|im_end|>\n"
+        );
+    }
+
+    #[test]
+    fn repair_with_qwen3_4b_combined_template() {
+        let prompt = "<|im_start|>assistant\nSome reasoning\n</think>\nhello<|im_end|>\n";
+        let repaired =
+            RenderedPromptRepairer::try_repair(QWEN3_4B_TEMPLATE, Some("<|im_end|>"), true, prompt)
+                .unwrap();
+        assert!(repaired.contains("<|im_start|>assistant\n<think>\nSome reasoning"));
+    }
+
+    #[test]
+    fn repair_no_change_when_prefix_already_present() {
+        let prompt = "<|im_start|>assistant\n<think>\nreasoning\n</think>\nhello<|im_end|>\n";
+        let result =
+            RenderedPromptRepairer::try_repair(QWEN35_TEMPLATE, Some("<|im_end|>"), true, prompt);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn extract_generation_literal_qwen35_enabled() {
+        let literal = extract_generation_prompt_literal(QWEN35_TEMPLATE, true).unwrap();
+        assert_eq!(literal, "<|im_start|>assistant\n<think>\n");
+    }
+
+    #[test]
+    fn extract_generation_literal_qwen35_disabled() {
+        let literal = extract_generation_prompt_literal(QWEN35_TEMPLATE, false).unwrap();
+        assert_eq!(literal, "<|im_start|>assistant\n<think>\n\n</think>\n\n");
+    }
+
+    #[test]
+    fn extract_generation_literal_qwen3_4b() {
+        let literal = extract_generation_prompt_literal(QWEN3_4B_TEMPLATE, true).unwrap();
+        assert_eq!(literal, "<|im_start|>assistant\n<think>\n");
+    }
+
+    #[test]
+    fn extract_generation_literal_qwen3_coder() {
+        let literal = extract_generation_prompt_literal(QWEN3_CODER_TEMPLATE, true).unwrap();
+        assert_eq!(literal, "<|im_start|>assistant\n");
+    }
+
+    #[test]
+    fn eot_delimiter_extracted_from_template() {
+        let eot = extract_eot_delimiter(QWEN35_TEMPLATE, Some("<|im_end|>"));
+        assert_eq!(eot.as_deref(), Some("<|im_end|>"));
+    }
+
+    #[test]
+    fn eot_delimiter_falls_back_to_eos_token() {
+        let eot = extract_eot_delimiter("no matching pattern here", Some("<|endoftext|>"));
+        assert_eq!(eot.as_deref(), Some("<|endoftext|>"));
     }
 }

--- a/src/utils/chat_template.rs
+++ b/src/utils/chat_template.rs
@@ -208,6 +208,10 @@ impl ChatTemplate {
         self.enable_thinking = enable;
     }
 
+    pub fn template_source(&self) -> Option<&str> {
+        self.chat_template.as_deref()
+    }
+
     pub fn set_escape_tokens(&mut self, mut tokens: Vec<String>) {
         tokens.retain(|token| !token.is_empty());
         tokens.sort_by_key(|token| std::cmp::Reverse(token.len()));


### PR DESCRIPTION
This PR fixes prefix cache mismatches caused by rendered assistant prompts missing the expected reasoning header.

**Problem:**

A typical mismatch case is this:

Expected cached assistant prefix:

```
<|im_start|>assistant
<think>
Thinking Process:
...
```

But the rendered prompt for a later decode step becomes:

```
<|im_start|>assistant
Thinking Process:
...
</think>
```

The cache expects the assistant turn to start with `<think>\n`, but the actual rendered prompt starts directly with visible reasoning text. That means the token prefix no longer matches the cached prefix.

**Solution:**

The fix runs after chat template application and repairs each assistant block in the rendered prompt by:

1) inserting the missing reasoning prefix at the start of the assistant content
2) restoring escaped reasoning end markers so they remain valid prompt structure

This keeps the repair in the rendered-prompt path, where the cache mismatch actually appears, instead of trying to change message content before template rendering.