### PR TITLE
Explicit Type Annotation for 292

### DIFF
--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -963,6 +963,7 @@ impl ModelRunner {
     }
 
     #[allow(non_snake_case)]
+    #[allow(unused_mut)]
     fn prepare_prefill(&self, seqs: &[&Sequence]) -> Result<(Tensor, Tensor, InputMetadata)> {
         let mut input_ids: Vec<u32> = Vec::new();
         let mut positions = Vec::new();
@@ -1139,13 +1140,13 @@ impl ModelRunner {
             let cu_seqlens_q_host_u32: Vec<u32> =
                 cu_seqlens_q_vec.iter().map(|&x| x as u32).collect();
 
-            #[cfg(not(feature = "flashinfer"))]
-            let prefill_plan_info: Option<Vec<i64>> = None;
+            let mut prefill_plan_info: Option<Vec<i64>> = None;
+            let mut mla_prefill_plan_info: Option<Vec<i64>> = None;
 
             #[cfg(feature = "flashinfer")]
-            let mla_prefill_plan_info: Option<Vec<i64>> = if self.is_mla_model() {
+            if self.is_mla_model() {
                 if let Some(params) = self.flashinfer_kv_params {
-                    Some(attention_rs::mla::mla_prefill_plan(
+                    mla_prefill_plan_info = Some(attention_rs::mla::mla_prefill_plan(
                         &self.device,
                         &cu_seqlens_q_host_u32,
                         &indptr_host,
@@ -1155,19 +1156,13 @@ impl ModelRunner {
                         params.head_dim,
                         true,
                     )?)
-                } else {
-                    None
                 }
-            } else {
-                None
             };
-            #[cfg(not(feature = "flashinfer"))]
-            let mla_prefill_plan_info: Option<Vec<i64>> = None;
 
             #[cfg(feature = "flashinfer")]
-            let prefill_plan_info: Option<Vec<i64>> = if !self.is_mla_model() {
+            if !self.is_mla_model() {
                 if let Some(params) = self.flashinfer_kv_params {
-                    Some(attention_rs::flashinfer::prefill_plan(
+                    prefill_plan_info = Some(attention_rs::flashinfer::prefill_plan(
                         &self.device,
                         &cu_seqlens_q_host_u32,
                         &indptr_host,
@@ -1181,14 +1176,8 @@ impl ModelRunner {
                         params.out_dtype,
                         None,
                     )?)
-                } else {
-                    None
                 }
-            } else {
-                None
             };
-            #[cfg(not(feature = "flashinfer"))]
-            let prefill_plan_info: Option<Vec<i64>> = None;
 
             Some(FlashInferMetadata {
                 indptr,

--- a/src/models/layers/mla_attention.rs
+++ b/src/models/layers/mla_attention.rs
@@ -57,6 +57,7 @@ impl MlaConfig {
     }
 }
 
+#[allow(unused)]
 pub struct MlaAttention {
     q_a_proj: Option<ReplicatedLinear>,
     q_a_layernorm: Option<NormX>,


### PR DESCRIPTION
Address #292

```mermaid
sequenceDiagram
 participant Compiler
 participant Line1143 as Line 1143<br>#[cfg(not(feature="flashinfer"))]
 participant Line1168 as Line 1168-1189<br>#[cfg(feature="flashinfer")]
 participant Line1193 as Line 1193-1208<br>FlashInferMetadata

 Compiler->>Line1143: Type check let prefill_plan_info = None
 Line1143-->>Compiler: Error: type must be known
 Note over Line1143,Line1193: Type is Option<Vec<i64>>

 alt flashinfer feature enabled
     Compiler->>Line1168: Type check prefill_plan_info
     Line1168-->>Compiler: Result<Vec<i64>> from prefill_plan()
     Compiler->>Line1193: Use prefill_plan_info
 else flashinfer feature disabled
     Compiler->>Line1191: Type check prefill_plan_info = None
     Line1191-->>Compiler: Type inferred from context
     Compiler->>Line1193: Use prefill_plan_info
 end
```