### PR TITLE
Propagate YARN to attention scale

### DIFF
--- a/src/models/layers/attention.rs
+++ b/src/models/layers/attention.rs
@@ -385,6 +385,39 @@ impl Attention {
         let num_heads = config.num_attention_heads;
         let num_kv_heads = config.num_key_value_heads;
         let head_dim = config.head_dim.unwrap_or(hidden_size / num_heads);
+
+        // Apply YARN scaling to attention_scale if rope_scaling has type="yarn"
+        let attention_scale = if let Some(ref rope_scaling) = config.rope_scaling {
+            use crate::utils::config::RopeScalingValue;
+            let is_yarn = rope_scaling.get("type").and_then(|v| {
+                if let RopeScalingValue::String(s) = v {
+                    Some(s.as_str())
+                } else {
+                    None
+                }
+            }) == Some("yarn");
+            if is_yarn {
+                let factor = rope_scaling
+                    .get("factor")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(1.0) as f32;
+                let mscale_all_dim = rope_scaling
+                    .get("mscale_all_dim")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(0.0) as f32;
+                if mscale_all_dim > 0.0 && factor > 1.0 {
+                    let mscale = 0.1 * mscale_all_dim * factor.ln() + 1.0;
+                    let base_scale = attention_scale.unwrap_or(1.0 / (head_dim as f32).sqrt());
+                    Some(base_scale * mscale * mscale)
+                } else {
+                    attention_scale
+                }
+            } else {
+                attention_scale
+            }
+        } else {
+            attention_scale
+        };
         let key_map: HashMap<&str, &str> = [
             ("q_proj", "attn_q"),
             ("k_proj", "attn_k"),
@@ -932,6 +965,8 @@ impl NaiveAttention {
         )?;
 
         let scale = (head_dim as f64).powf(-0.5);
+        // Note: NaiveAttention is used for vision models and doesn't support YARN scaling
+        // YARN scaling is handled by ScalingRotaryEmbedding which pre-computes the RoPE tables
         Ok(Self {
             q_proj,
             k_proj,


### PR DESCRIPTION

## Problem

For YARN-scaled models (e.g., 12X context extension), the attention
softmax scale was not being adjusted for the extended context window.
This caused attention weights to be too sharp, leading to:
- Poor gradient flow during inference
- Repetitive/looping output as the model attends to incorrect positions
- Degraded generation quality for long contexts

The YARN scaling factor (mscale) compensates for the extended context
by scaling the attention logits before softmax. Without this scaling,
positions beyond the original training context length receive incorrect
attention weights.

## Root Cause

MLA models (DeepSeek) correctly applied YARN scaling in MlaAttention::new()
via `sm_scale *= mscale * mscale`. However, non-MLA models (LLaMA, Qwen3,
etc.) used Attention::new() which passed `None` for attention_scale,
resulting in the default `1.0 / sqrt(head_dim)` without YARN scaling.

## Solution

Applied YARN scaling computation to Attention::new_with_options() for
non-MLA models. When rope_scaling.type == "yarn", the attention_scale
is now computed as:

    base_scale = attention_scale.unwrap_or(1.0 / sqrt(head_dim))
    mscale = 0.1 * mscale_all_dim * log(factor) + 1.0
    sm_scale = base_scale * mscale * mscale

This matches the existing MLA implementation and ensures consistent
attention scaling across all model architectures.

## Data Flow

vllm.rs Config.rope_scaling (from model config or CLI --yarn-scaling-factor)
  -> Attention::new_with_options() or MlaAttention::new()
  -> sm_scale *= mscale * mscale for YARN models
  -> PagedAttention::new() or MLA attention
  -> CUDA kernel uses scaled sm_scale for softmax
