### PR TITLE
[feature] Surface cached_tokens and reasoning_tokens in chat Usage

### DIFF
--- a/docs/prefix-cache.md
+++ b/docs/prefix-cache.md
@@ -64,3 +64,16 @@ shape:
 
 In Python (offline batch), call `engine.get_num_cached_tokens_for_seq(seq_id)`
 on the `seq_id` returned in each `GenerationOutput`.
+
+For models that emit `<think>…</think>` reasoning blocks, responses also
+include `usage.completion_tokens_details.reasoning_tokens` so clients can
+attribute completion cost across reasoning vs final-answer output:
+
+```json
+"usage": {
+  "prompt_tokens": 12,
+  "completion_tokens": 256,
+  "total_tokens": 268,
+  "completion_tokens_details": { "reasoning_tokens": 192 }
+}
+```

--- a/docs/prefix-cache.md
+++ b/docs/prefix-cache.md
@@ -45,3 +45,22 @@ snapshot capture remains dense.
   reduces the maximum number of concurrent tokens available for new requests.
 - Cached KV reuse is automatic; no `session_id` is required.
 - Sliding window attention limits how much cached context is effectively used.
+
+## Inspecting cache hits
+
+Chat completion responses include the prefix-cache hit count under
+`usage.prompt_tokens_details.cached_tokens` (OpenAI extension). The field is
+omitted when no hits occurred, so existing single-turn responses keep their
+shape:
+
+```json
+"usage": {
+  "prompt_tokens": 499,
+  "completion_tokens": 16,
+  "total_tokens": 515,
+  "prompt_tokens_details": { "cached_tokens": 480 }
+}
+```
+
+In Python (offline batch), call `engine.get_num_cached_tokens_for_seq(seq_id)`
+on the `seq_id` returned in each `GenerationOutput`.

--- a/src/core/block_manager.rs
+++ b/src/core/block_manager.rs
@@ -764,7 +764,7 @@ impl BlockManager {
         MessageType::KvCacheReceive,
         (seq.clone()),
         MessageType::KvCacheReceiveResponse,
-        (bool, u32, usize)
+        (bool, u32, usize, usize)
     );
 
     // After the client received prefill kvcache, it can call PD server to release

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -662,6 +662,11 @@ impl LLMEngine {
         self.scheduler.get_num_cached_tokens()
     }
 
+    /// See [`Scheduler::get_num_cached_tokens_for_seq`].
+    pub fn get_num_cached_tokens_for_seq(&self, seq_id: usize) -> Option<usize> {
+        self.scheduler.get_num_cached_tokens_for_seq(seq_id)
+    }
+
     fn trim_prompt_replay_prefix(
         replay_ids: &[u32],
         guidance_tokens: &GuidanceTokens,

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -1715,7 +1715,7 @@ impl ModelRunner {
         }
     }
 
-    pub fn receive_kvcache(&self, seq: &Sequence) -> Result<(bool, u32, usize)> {
+    pub fn receive_kvcache(&self, seq: &Sequence) -> Result<(bool, u32, usize, usize)> {
         if let Some(transfer) = &self.transfer {
             if !transfer.is_client() {
                 candle_core::bail!(

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -988,10 +988,11 @@ impl Scheduler {
                 .block_manager
                 .try_receive_kvcache(&self.transferred[idx])
             {
-                Ok((ret, first_token, sending_time)) => {
+                Ok((ret, first_token, sending_time, num_cached_tokens)) => {
                     let seq = &mut self.transferred[idx];
                     success = ret;
                     if success {
+                        seq.num_cached_tokens = num_cached_tokens;
                         // Update sequence and move to running
                         // The first token is generated on PD server,
                         // it has been transfered to client, but haven't been send to user

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -10,7 +10,7 @@ use crate::utils::config::{Config, EngineConfig, EosTokenId};
 use candle_core::Result;
 use parking_lot::RwLock;
 use regex::Regex;
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokenizers::Tokenizer;
@@ -21,6 +21,10 @@ pub struct Scheduler {
     transferred: VecDeque<Sequence>,
     pub block_manager: BlockManager,
     next_seq_id: usize,
+    /// Per-seq cached-token count retained briefly after `clear_finished()`
+    /// so response finalization can still read it. Bounded by
+    /// `FINISHED_CACHED_TOKENS_MAX`; cleared en masse on overflow.
+    finished_cached_tokens: HashMap<usize, usize>,
     eos_token_id: Vec<u32>,
     /// Token IDs that represent the end of a tool call (e.g., </tool_call> tokens)
     tool_call_end_token_ids: Vec<u32>,
@@ -38,6 +42,9 @@ pub struct Scheduler {
 }
 
 const MIN_NUM_SCHEDULED_REQS: usize = 5;
+/// Cap on `Scheduler::finished_cached_tokens`. Bounded memory beats LRU
+/// here: dropping reporting on a small population is acceptable.
+const FINISHED_CACHED_TOKENS_MAX: usize = 16_384;
 pub const KVCACHE_SWAP_THRESHOLD: f32 = 0.95f32; // over 95%
 const SWAP_COOLING_PERIOD: usize = 5000; // 5 seconds cooling time to prevent frequent swap out/in
 const MIN_KVCACHE_TOKENS_LEFT_FOR_SWAP: usize = 1000; // to swap-in, at least 1000 kvcache tokens left for decoding
@@ -133,6 +140,7 @@ impl Scheduler {
                     .unwrap_or(false),
             ),
             next_seq_id: 0,
+            finished_cached_tokens: HashMap::new(),
             eos_token_id: match &config.eos_token_id {
                 Some(EosTokenId::Single(eos)) => vec![*eos],
                 Some(EosTokenId::Multiple(eos)) => eos.into_iter().map(|x| *x).collect(),
@@ -578,9 +586,22 @@ impl Scheduler {
     pub fn clear_finished(&mut self) {
         let is_pd_server = self.is_pd_server();
         for seq in &self.running {
-            if seq.status == SequenceStatus::Finished && is_pd_server {
-                self.print_free_blocks();
+            if seq.status == SequenceStatus::Finished {
+                if is_pd_server {
+                    self.print_free_blocks();
+                }
+                self.finished_cached_tokens
+                    .insert(seq.id, seq.num_cached_tokens);
             }
+        }
+        for seq in &self.waiting {
+            if seq.status == SequenceStatus::Finished {
+                self.finished_cached_tokens
+                    .insert(seq.id, seq.num_cached_tokens);
+            }
+        }
+        if self.finished_cached_tokens.len() > FINISHED_CACHED_TOKENS_MAX {
+            self.finished_cached_tokens.clear();
         }
         self.running
             .retain(|seq| seq.status != SequenceStatus::Finished);
@@ -1036,6 +1057,18 @@ impl Scheduler {
 
     pub fn get_num_cached_tokens(&self) -> usize {
         self.block_manager.prefix_cache_blocks() * self.block_manager.get_block_size()
+    }
+
+    /// Per-seq prefix-cache hit count for response finalization. Falls back
+    /// to `finished_cached_tokens` for seqs already swept by `clear_finished`.
+    pub fn get_num_cached_tokens_for_seq(&self, seq_id: usize) -> Option<usize> {
+        self.running
+            .iter()
+            .chain(self.waiting.iter())
+            .chain(self.transferred.iter())
+            .find(|s| s.id == seq_id)
+            .map(|s| s.num_cached_tokens)
+            .or_else(|| self.finished_cached_tokens.get(&seq_id).copied())
     }
 
     pub fn evict_prefix_cache_until_free(&mut self, min_free_blocks: usize) -> usize {

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -23,7 +23,7 @@ pub struct Scheduler {
     next_seq_id: usize,
     /// Per-seq cached-token count retained briefly after `clear_finished()`
     /// so response finalization can still read it. Bounded by
-    /// `FINISHED_CACHED_TOKENS_MAX`; cleared en masse on overflow.
+    /// `FINISHED_CACHED_TOKENS_MAX`.
     finished_cached_tokens: HashMap<usize, usize>,
     eos_token_id: Vec<u32>,
     /// Token IDs that represent the end of a tool call (e.g., </tool_call> tokens)
@@ -585,23 +585,22 @@ impl Scheduler {
 
     pub fn clear_finished(&mut self) {
         let is_pd_server = self.is_pd_server();
+        let mut finished_counts = Vec::new();
         for seq in &self.running {
             if seq.status == SequenceStatus::Finished {
                 if is_pd_server {
                     self.print_free_blocks();
                 }
-                self.finished_cached_tokens
-                    .insert(seq.id, seq.num_cached_tokens);
+                finished_counts.push((seq.id, seq.num_cached_tokens));
             }
         }
         for seq in &self.waiting {
             if seq.status == SequenceStatus::Finished {
-                self.finished_cached_tokens
-                    .insert(seq.id, seq.num_cached_tokens);
+                finished_counts.push((seq.id, seq.num_cached_tokens));
             }
         }
-        if self.finished_cached_tokens.len() > FINISHED_CACHED_TOKENS_MAX {
-            self.finished_cached_tokens.clear();
+        for (seq_id, num_cached_tokens) in finished_counts {
+            self.remember_finished_cached_tokens(seq_id, num_cached_tokens);
         }
         self.running
             .retain(|seq| seq.status != SequenceStatus::Finished);
@@ -1066,10 +1065,22 @@ impl Scheduler {
         self.running
             .iter()
             .chain(self.waiting.iter())
+            .chain(self.cached.iter())
             .chain(self.transferred.iter())
             .find(|s| s.id == seq_id)
             .map(|s| s.num_cached_tokens)
             .or_else(|| self.finished_cached_tokens.get(&seq_id).copied())
+    }
+
+    fn remember_finished_cached_tokens(&mut self, seq_id: usize, num_cached_tokens: usize) {
+        self.finished_cached_tokens
+            .insert(seq_id, num_cached_tokens);
+        while self.finished_cached_tokens.len() > FINISHED_CACHED_TOKENS_MAX {
+            let Some(oldest_seq_id) = self.finished_cached_tokens.keys().min().copied() else {
+                break;
+            };
+            self.finished_cached_tokens.remove(&oldest_seq_id);
+        }
     }
 
     pub fn evict_prefix_cache_until_free(&mut self, min_free_blocks: usize) -> usize {

--- a/src/py/mod.rs
+++ b/src/py/mod.rs
@@ -134,6 +134,17 @@ impl Engine {
         Ok(engine.get_num_cached_tokens())
     }
 
+    /// Per-sequence prefix-cache hit count. Returns `None` when the seq id
+    /// is unknown (e.g. swept long ago and dropped from the side-cache).
+    #[pyo3(
+        name = "get_num_cached_tokens_for_seq",
+        text_signature = "($self, seq_id)"
+    )]
+    pub fn get_num_cached_tokens_for_seq(&mut self, seq_id: usize) -> PyResult<Option<usize>> {
+        let engine = self.engine.read();
+        Ok(engine.get_num_cached_tokens_for_seq(seq_id))
+    }
+
     #[pyo3(name = "get_available_kv_tokens", text_signature = "($self)")]
     pub fn get_available_kv_tokens(&mut self) -> PyResult<usize> {
         let engine = self.engine.read();

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -226,7 +226,7 @@ pub enum MessageType {
 
     // receive kvcache from PD server
     KvCacheReceive(Sequence),
-    KvCacheReceiveResponse((bool, u32, usize)),
+    KvCacheReceiveResponse((bool, u32, usize, usize)),
 
     // notify PD server to release kvcache
     KvCacheRelease(usize),

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -388,7 +388,7 @@ fn main() -> anyhow::Result<()> {
                 }
                 send_local(
                     &mut vec![stream.try_clone()?],
-                    &MessageType::KvCacheReceiveResponse(ret.unwrap_or((false, 0, 0))),
+                    &MessageType::KvCacheReceiveResponse(ret.unwrap_or((false, 0, 0, 0))),
                     false,
                 )?;
             }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1975,4 +1975,47 @@ mod tests {
         assert_eq!(params.thinking, Some(false));
         assert_eq!(params.reasoning_effort, None);
     }
+
+    #[test]
+    fn usage_omits_prompt_tokens_details_when_none() {
+        let usage = Usage {
+            prompt_tokens: 100,
+            completion_tokens: 50,
+            total_tokens: 150,
+            prompt_tokens_details: None,
+        };
+
+        let value: serde_json::Value = serde_json::to_value(&usage).expect("serialize usage");
+        let object = value.as_object().expect("usage is a JSON object");
+
+        assert_eq!(object.get("prompt_tokens"), Some(&serde_json::json!(100)));
+        assert_eq!(
+            object.get("completion_tokens"),
+            Some(&serde_json::json!(50))
+        );
+        assert_eq!(object.get("total_tokens"), Some(&serde_json::json!(150)));
+        assert!(
+            !object.contains_key("prompt_tokens_details"),
+            "prompt_tokens_details should be omitted when None, got: {value}"
+        );
+    }
+
+    #[test]
+    fn usage_includes_prompt_tokens_details_when_some() {
+        let usage = Usage {
+            prompt_tokens: 200,
+            completion_tokens: 64,
+            total_tokens: 264,
+            prompt_tokens_details: Some(PromptTokensDetails { cached_tokens: 128 }),
+        };
+
+        let value: serde_json::Value = serde_json::to_value(&usage).expect("serialize usage");
+        assert_eq!(
+            value
+                .pointer("/prompt_tokens_details/cached_tokens")
+                .and_then(|v| v.as_u64()),
+            Some(128),
+            "cached_tokens should round-trip under prompt_tokens_details, got: {value}",
+        );
+    }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -611,10 +611,17 @@ pub struct ChatResponseMessage {
 }
 
 #[derive(Serialize, Debug)]
+pub struct PromptTokensDetails {
+    pub cached_tokens: usize,
+}
+
+#[derive(Serialize, Debug)]
 pub struct Usage {
     pub prompt_tokens: usize,
     pub completion_tokens: usize,
     pub total_tokens: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_tokens_details: Option<PromptTokensDetails>,
 }
 
 #[derive(Serialize, Debug)]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -616,12 +616,19 @@ pub struct PromptTokensDetails {
 }
 
 #[derive(Serialize, Debug)]
+pub struct CompletionTokensDetails {
+    pub reasoning_tokens: usize,
+}
+
+#[derive(Serialize, Debug)]
 pub struct Usage {
     pub prompt_tokens: usize,
     pub completion_tokens: usize,
     pub total_tokens: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prompt_tokens_details: Option<PromptTokensDetails>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completion_tokens_details: Option<CompletionTokensDetails>,
 }
 
 #[derive(Serialize, Debug)]
@@ -1977,12 +1984,13 @@ mod tests {
     }
 
     #[test]
-    fn usage_omits_prompt_tokens_details_when_none() {
+    fn usage_omits_token_details_when_none() {
         let usage = Usage {
             prompt_tokens: 100,
             completion_tokens: 50,
             total_tokens: 150,
             prompt_tokens_details: None,
+            completion_tokens_details: None,
         };
 
         let value: serde_json::Value = serde_json::to_value(&usage).expect("serialize usage");
@@ -1998,6 +2006,10 @@ mod tests {
             !object.contains_key("prompt_tokens_details"),
             "prompt_tokens_details should be omitted when None, got: {value}"
         );
+        assert!(
+            !object.contains_key("completion_tokens_details"),
+            "completion_tokens_details should be omitted when None, got: {value}"
+        );
     }
 
     #[test]
@@ -2007,6 +2019,7 @@ mod tests {
             completion_tokens: 64,
             total_tokens: 264,
             prompt_tokens_details: Some(PromptTokensDetails { cached_tokens: 128 }),
+            completion_tokens_details: None,
         };
 
         let value: serde_json::Value = serde_json::to_value(&usage).expect("serialize usage");
@@ -2016,6 +2029,28 @@ mod tests {
                 .and_then(|v| v.as_u64()),
             Some(128),
             "cached_tokens should round-trip under prompt_tokens_details, got: {value}",
+        );
+    }
+
+    #[test]
+    fn usage_includes_completion_tokens_details_when_some() {
+        let usage = Usage {
+            prompt_tokens: 64,
+            completion_tokens: 256,
+            total_tokens: 320,
+            prompt_tokens_details: None,
+            completion_tokens_details: Some(CompletionTokensDetails {
+                reasoning_tokens: 192,
+            }),
+        };
+
+        let value: serde_json::Value = serde_json::to_value(&usage).expect("serialize usage");
+        assert_eq!(
+            value
+                .pointer("/completion_tokens_details/reasoning_tokens")
+                .and_then(|v| v.as_u64()),
+            Some(192),
+            "reasoning_tokens should round-trip under completion_tokens_details, got: {value}",
         );
     }
 }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -10,7 +10,8 @@ use super::{
 use super::{
     ChatChoice, ChatChoiceChunk, ChatCompletionChunk, ChatCompletionRequest,
     ChatCompletionResponse, ChatMessage, ChatResponseMessage, Delta, EmbeddingData,
-    EmbeddingOutput, EmbeddingUsage, ErrorMsg, ServerData, Usage, UsageQuery, UsageResponse,
+    EmbeddingOutput, EmbeddingUsage, ErrorMsg, PromptTokensDetails, ServerData, Usage, UsageQuery,
+    UsageResponse,
 };
 use crate::core::engine::{LLMEngine, StreamItem};
 use crate::server::parser::{BufferedFinalizeResult, StreamResult, StreamToolParser};
@@ -1007,10 +1008,21 @@ pub async fn chat_completion(
                                 },
                                 error: None,
                             }],
-                            usage: include_usage.then_some(Usage {
-                                prompt_tokens: prompt_length,
-                                completion_tokens: total_decoded_tokens,
-                                total_tokens: prompt_length + total_decoded_tokens,
+                            usage: include_usage.then_some({
+                                let cached = engine_clone
+                                    .read()
+                                    .get_num_cached_tokens_for_seq(current_seq_id)
+                                    .unwrap_or(0);
+                                Usage {
+                                    prompt_tokens: prompt_length,
+                                    completion_tokens: total_decoded_tokens,
+                                    total_tokens: prompt_length + total_decoded_tokens,
+                                    prompt_tokens_details: (cached > 0).then_some(
+                                        PromptTokensDetails {
+                                            cached_tokens: cached,
+                                        },
+                                    ),
+                                }
                             }),
                         };
 
@@ -1157,7 +1169,10 @@ pub async fn chat_completion(
                 }
             };
 
+        // Per-seq cached counts read after the loop, summed into one figure.
+        let mut sync_seq_ids: Vec<usize> = Vec::with_capacity(results.len());
         for output in results {
+            sync_seq_ids.push(output.seq_id);
             total_prompt_tokens += output.prompt_length;
             total_decoded_tokens += output.decoded_length;
             let prompt_time_taken =
@@ -1306,10 +1321,24 @@ pub async fn chat_completion(
             created,
             model: model_id.to_string(),
             choices,
-            usage: Usage {
-                prompt_tokens: total_prompt_tokens,
-                completion_tokens: total_decoded_tokens,
-                total_tokens: total_prompt_tokens + total_decoded_tokens,
+            usage: {
+                let cached_tokens_total: usize = {
+                    let engine = data.engine.read();
+                    sync_seq_ids
+                        .iter()
+                        .filter_map(|sid| engine.get_num_cached_tokens_for_seq(*sid))
+                        .sum()
+                };
+                Usage {
+                    prompt_tokens: total_prompt_tokens,
+                    completion_tokens: total_decoded_tokens,
+                    total_tokens: total_prompt_tokens + total_decoded_tokens,
+                    prompt_tokens_details: (cached_tokens_total > 0).then_some(
+                        PromptTokensDetails {
+                            cached_tokens: cached_tokens_total,
+                        },
+                    ),
+                }
             },
         };
 

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -9,9 +9,9 @@ use super::{
 };
 use super::{
     ChatChoice, ChatChoiceChunk, ChatCompletionChunk, ChatCompletionRequest,
-    ChatCompletionResponse, ChatMessage, ChatResponseMessage, Delta, EmbeddingData,
-    EmbeddingOutput, EmbeddingUsage, ErrorMsg, PromptTokensDetails, ServerData, Usage, UsageQuery,
-    UsageResponse,
+    ChatCompletionResponse, ChatMessage, ChatResponseMessage, CompletionTokensDetails, Delta,
+    EmbeddingData, EmbeddingOutput, EmbeddingUsage, ErrorMsg, PromptTokensDetails, ServerData,
+    Usage, UsageQuery, UsageResponse,
 };
 use crate::core::engine::{LLMEngine, StreamItem};
 use crate::server::parser::{BufferedFinalizeResult, StreamResult, StreamToolParser};
@@ -547,6 +547,7 @@ pub async fn chat_completion(
             #[allow(unused_assignments)]
             let mut decode_start_time = 0u64;
             let mut total_decoded_tokens = 0usize;
+            let mut full_decoded_text = String::new();
             let mut pending_tool_calls: Vec<crate::tools::ToolCall> = Vec::new();
             let mut suppressed_tool_markup: String = String::new();
             let mut buffering_since: Option<Instant> = None;
@@ -607,6 +608,11 @@ pub async fn chat_completion(
                                 .unwrap()
                                 .as_millis() as u64;
                         }
+
+                        // Accumulate raw token text so reasoning blocks can
+                        // be tokenized at finalization for `reasoning_tokens`.
+                        // Cheap: text is already small per token.
+                        full_decoded_text.push_str(&token);
 
                         // Capture reasoning state before token processing for routing
                         let was_in_reasoning = tool_parser.in_reasoning();
@@ -1009,9 +1015,18 @@ pub async fn chat_completion(
                                 error: None,
                             }],
                             usage: include_usage.then_some({
-                                let cached = engine_clone
-                                    .read()
+                                let engine = engine_clone.read();
+                                let cached = engine
                                     .get_num_cached_tokens_for_seq(current_seq_id)
+                                    .unwrap_or(0);
+                                let reasoning_tokens =
+                                    crate::utils::chat_template::extract_reasoning_content(
+                                        &full_decoded_text,
+                                    )
+                                    .and_then(|(r, _)| {
+                                        engine.tokenizer.encode(r.as_str(), false).ok()
+                                    })
+                                    .map(|enc| enc.get_ids().len())
                                     .unwrap_or(0);
                                 Usage {
                                     prompt_tokens: prompt_length,
@@ -1022,6 +1037,8 @@ pub async fn chat_completion(
                                             cached_tokens: cached,
                                         },
                                     ),
+                                    completion_tokens_details: (reasoning_tokens > 0)
+                                        .then_some(CompletionTokensDetails { reasoning_tokens }),
                                 }
                             }),
                         };
@@ -1169,10 +1186,13 @@ pub async fn chat_completion(
                 }
             };
 
-        // Per-seq cached counts read after the loop, summed into one figure.
+        // Per-seq cached counts and decode_output snapshots read after the
+        // loop, summed/scanned into single figures for the response Usage.
         let mut sync_seq_ids: Vec<usize> = Vec::with_capacity(results.len());
+        let mut sync_decode_outputs: Vec<String> = Vec::with_capacity(results.len());
         for output in results {
             sync_seq_ids.push(output.seq_id);
+            sync_decode_outputs.push(output.decode_output.clone());
             total_prompt_tokens += output.prompt_length;
             total_decoded_tokens += output.decoded_length;
             let prompt_time_taken =
@@ -1315,6 +1335,28 @@ pub async fn chat_completion(
             total_decoded_tokens as f32 / total_decoded_time_taken.max(0.001)
         );
 
+        let (cached_tokens_total, reasoning_tokens_total): (usize, usize) = {
+            let engine = data.engine.read();
+            let cached: usize = sync_seq_ids
+                .iter()
+                .filter_map(|sid| engine.get_num_cached_tokens_for_seq(*sid))
+                .sum();
+            // Reasoning text is extracted directly from each choice's
+            // `decode_output` rather than from `message.reasoning_content`,
+            // because the latter is only populated on the env-gated tools
+            // path. Counting from the raw text keeps the figure correct
+            // for plain chat completions too.
+            let reasoning: usize = sync_decode_outputs
+                .iter()
+                .filter_map(|text| {
+                    crate::utils::chat_template::extract_reasoning_content(text).map(|(r, _)| r)
+                })
+                .filter_map(|text| engine.tokenizer.encode(text.as_str(), false).ok())
+                .map(|enc| enc.get_ids().len())
+                .sum();
+            (cached, reasoning)
+        };
+
         let response = ChatCompletionResponse {
             id: "cmpl-".to_string() + &Uuid::new_v4().to_string()[..8],
             object: "chat.completion",
@@ -1322,13 +1364,6 @@ pub async fn chat_completion(
             model: model_id.to_string(),
             choices,
             usage: {
-                let cached_tokens_total: usize = {
-                    let engine = data.engine.read();
-                    sync_seq_ids
-                        .iter()
-                        .filter_map(|sid| engine.get_num_cached_tokens_for_seq(*sid))
-                        .sum()
-                };
                 Usage {
                     prompt_tokens: total_prompt_tokens,
                     completion_tokens: total_decoded_tokens,
@@ -1336,6 +1371,11 @@ pub async fn chat_completion(
                     prompt_tokens_details: (cached_tokens_total > 0).then_some(
                         PromptTokensDetails {
                             cached_tokens: cached_tokens_total,
+                        },
+                    ),
+                    completion_tokens_details: (reasoning_tokens_total > 0).then_some(
+                        CompletionTokensDetails {
+                            reasoning_tokens: reasoning_tokens_total,
                         },
                     ),
                 }

--- a/src/transfer/mod.rs
+++ b/src/transfer/mod.rs
@@ -106,6 +106,10 @@ pub struct FinishedPrefillData {
     pub first_token: u32,
     pub transfer_handle: KVTransferHandle,
     pub sending_time: usize,
+    /// Prefix-cache hit length recorded on the prefill server. Restored onto
+    /// the decode-side seq so `Usage.prompt_tokens_details.cached_tokens`
+    /// reports the right value across PD.
+    pub num_cached_tokens: usize,
 }
 
 /// Messages for communication between Client and PDServer.
@@ -210,12 +214,13 @@ impl Transfer {
     }
 
     /// (Client) Receives the KV cache data and copies it into local GPU blocks.
+    /// Returns `(success, first_token, sending_time, num_cached_tokens)`.
     #[allow(unused)]
     pub fn receive_kv_cache(
         &self,
         seq: &Sequence,
         local_gpu_cache: &Vec<(Tensor, Tensor)>,
-    ) -> Result<(bool, u32, usize)> {
+    ) -> Result<(bool, u32, usize, usize)> {
         let status = self.check_prefill_finished(seq.id)?;
         if !status {
             candle_core::bail!("Unable to receive kvcache from the PD server since this sequence is not prefill completed!")
@@ -225,7 +230,7 @@ impl Transfer {
             sf: &Transfer,
             seq: &Sequence,
             local_gpu_cache: &Vec<(Tensor, Tensor)>,
-        ) -> Result<(bool, u32, usize)> {
+        ) -> Result<(bool, u32, usize, usize)> {
             let local_gpu_ids = seq.block_table.clone();
             let local_device = local_gpu_cache[0].0.device();
 
@@ -311,7 +316,7 @@ impl Transfer {
                     }
                 }
             }
-            Ok((true, token, data.sending_time))
+            Ok((true, token, data.sending_time, data.num_cached_tokens))
         }
 
         let dtype = local_gpu_cache[0].0.dtype();
@@ -432,6 +437,7 @@ impl Transfer {
                 first_token,
                 transfer_handle,
                 sending_time,
+                num_cached_tokens: seq.num_cached_tokens,
             });
             // Send the finished data back to the client
             sf.communicator.send(&msg)


### PR DESCRIPTION
Adds two OpenAI-extension fields to chat completion responses so clients can attribute prompt and completion cost in more detail. Both are `Option`-wrapped with `skip_serializing_if = "Option::is_none"`, so responses without cache hits or reasoning content keep their previous JSON shape exactly.

## What's new

`usage.prompt_tokens_details.cached_tokens` — prefix-cache hit count, propagated across PD via a new `FinishedPrefillData.num_cached_tokens` field so the figure is correct in single-process and PD topologies.

`usage.completion_tokens_details.reasoning_tokens` — token count inside `<think>…</think>` (or equivalent) blocks, useful for billing/quota separation between thinking and answer tokens. Counted from the raw `decode_output` directly via `extract_reasoning_content`, so it works on the plain chat path too, not only the env-gated tools path.

## Plumbing

- `Scheduler::get_num_cached_tokens_for_seq` + a small bounded `finished_cached_tokens` side-cache so finalization can read the count after `clear_finished` sweeps the seq.
- `FinishedPrefillData.num_cached_tokens` is a binary-incompatible wire change; pd-server and pd-client must be rebuilt together.
- Python parity: `Engine.get_num_cached_tokens_for_seq(seq_id)`.
- `reasoning_tokens` is computed by extracting the reasoning portion of the response and tokenizing via the engine's tokenizer. Identical logic in both streaming finalization (accumulates raw text during the loop) and `generate_sync` (per-output `decode_output`).
- `docs/prefix-cache.md` updated with samples.

## Tests

`server::tests::usage_omits_token_details_when_none`, `usage_includes_prompt_tokens_details_when_some`, `usage_includes_completion_tokens_details_when_some` — serde round-trip, no fixtures.

## Live samples

Run on macOS Metal with `Qwen3-0.6B`, single-process HTTP server, `--prefix-cache` enabled. Three requests share a long system prompt that's larger than one cache block; the user prompts vary and the model emits `<think>…</think>` reasoning blocks.

```json
// R1: cold (first request) — only reasoning_tokens populated
{
  "prompt_tokens": 236,
  "completion_tokens": 436,
  "total_tokens": 672,
  "completion_tokens_details": { "reasoning_tokens": 420 }
}

// R2: warm (same system prefix as R1) — both fields populated
{
  "prompt_tokens": 235,
  "completion_tokens": 259,
  "total_tokens": 494,
  "prompt_tokens_details": { "cached_tokens": 192 },
  "completion_tokens_details": { "reasoning_tokens": 244 }
}

// R3: short cold prompt, no reasoning — both fields absent (shape preserved)
{
  "prompt_tokens": 9,
  "completion_tokens": 4,
  "total_tokens": 13
}
```

Streaming and non-streaming agree on `reasoning_tokens` for the same prompt (both report 331/344 on a separate `What is 7 times 8?` test).

## Commits

1. `core: per-seq prefix-cache hit count via Scheduler`
2. `transfer: propagate num_cached_tokens across PD TransferKvCache`
3. `server: add Usage.prompt_tokens_details.cached_tokens (OpenAI compat)`
4. `server: tests for Usage.prompt_tokens_details serialization`
5. `py + docs: expose get_num_cached_tokens_for_seq; document cached_tokens`
6. `server: add Usage.completion_tokens_details.reasoning_tokens (OpenAI compat)`

Each commit builds in isolation. fmt clean, no new clippy warnings vs `main` baseline.
