### PR TITLE
[feature] tok_detok_worker: opt-in out-of-process tokenize + detokenize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,3 +91,7 @@ nvtx = ["dep:nvtx"]
 [[bin]]
 name = "runner"
 path = "src/runner/runner.rs"
+
+[[bin]]
+name = "tok_detok_worker"
+path = "src/runner/tok_detok_worker.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,3 +99,15 @@ assets = [
     ["target/release/xinfer", "usr/local/bin/", "755"],
     ["target/release/lib/*", "usr/local/lib/xinfer/", "644"],
 ]
+
+# `tok_detok_worker` is an opt-in companion binary spawned out-of-process
+# by the engine when `XINFER_TOK_DETOK_WORKER=1` is set; not built into
+# the main `xinfer` polymorphic-subcommand dispatch because the worker
+# carries its own message-handling main loop that doesn't share the
+# `xinfer` arg surface. The upstream `runner` binary was merged into
+# the polymorphic `xinfer <subcmd>` dispatch (see `src/main.rs`); the
+# pre-rename `[[bin]] runner` entry from the PR is obsolete and dropped
+# during the 2026-05 xinfer rebase.
+[[bin]]
+name = "tok_detok_worker"
+path = "src/runner/tok_detok_worker.rs"

--- a/build.sh
+++ b/build.sh
@@ -90,6 +90,7 @@ fi
 
 RUNNER_BIN="$(bin_name runner)"
 VLLM_RS_BIN="$(bin_name vllm-rs)"
+TOK_DETOK_WORKER_BIN="$(bin_name tok_detok_worker)"
 
 HAS_PYTHON=false
 if [[ "$FEATURES" == *"python"* ]]; then
@@ -113,12 +114,12 @@ if [[ "$INSTALL" == true ]]; then
   echo "Binary-only install requested; skipping maturin and python package staging."
 
   if [[ "$IS_METAL" == true ]]; then
-    echo "Metal feature detected. Building vllm-rs only..."
-    cargo build $RELEASE --bin vllm-rs --features "$FEATURES"
+    echo "Metal feature detected. Building vllm-rs and tok_detok_worker..."
+    cargo build $RELEASE --bin vllm-rs --bin tok_detok_worker --features "$FEATURES"
   else
     FEATURES_NO_PY=$(echo "$FEATURES" | sed -E 's/\bpython\b//g' | xargs)
-    echo "Building vllm-rs and runner binaries..."
-    cargo build $RELEASE --bin vllm-rs --bin runner --features "$FEATURES_NO_PY"
+    echo "Building vllm-rs, runner, and tok_detok_worker binaries..."
+    cargo build $RELEASE --bin vllm-rs --bin runner --bin tok_detok_worker --features "$FEATURES_NO_PY"
   fi
 
   echo "Installing binaries to: $DST"
@@ -130,6 +131,13 @@ if [[ "$INSTALL" == true ]]; then
     exit 1
   fi
   install -m 755 "$VLLM_RS_PATH" "$DST/vllm-rs"
+
+  TOK_DETOK_WORKER_PATH="target/$PROFILE/$TOK_DETOK_WORKER_BIN"
+  if [[ ! -f "$TOK_DETOK_WORKER_PATH" ]]; then
+    echo "Error: tok_detok_worker binary not found at $TOK_DETOK_WORKER_PATH"
+    exit 1
+  fi
+  install -m 755 "$TOK_DETOK_WORKER_PATH" "$DST/tok_detok_worker"
 
   if [[ "$IS_METAL" != true ]]; then
     RUNNER_PATH="target/$PROFILE/$RUNNER_BIN"
@@ -149,11 +157,11 @@ fi
 # -------------------------------------------------------------------
 if [[ "$HAS_PYTHON" != true ]]; then
   if [[ "$IS_METAL" == true ]]; then
-    echo "Metal feature detected. Building vllm-rs only..."
-    cargo build $RELEASE --bin vllm-rs --features "$FEATURES"
+    echo "Metal feature detected. Building vllm-rs and tok_detok_worker..."
+    cargo build $RELEASE --bin vllm-rs --bin tok_detok_worker --features "$FEATURES"
   else
-    echo "Building vllm-rs and runner binaries..."
-    cargo build $RELEASE --bin vllm-rs --bin runner --features "$FEATURES"
+    echo "Building vllm-rs, runner, and tok_detok_worker binaries..."
+    cargo build $RELEASE --bin vllm-rs --bin runner --bin tok_detok_worker --features "$FEATURES"
   fi
   echo "Build complete."
   exit 0
@@ -165,12 +173,14 @@ fi
 DEST_DIR="vllm_rs"
 mkdir -p "$DEST_DIR"
 
+FEATURES_NO_PY=$(echo "$FEATURES" | sed -E 's/\bpython\b//g' | xargs)
 if [[ "$IS_METAL" == true ]]; then
   echo "Metal feature detected. Skipping runner build and copy."
+  echo "Building tok_detok_worker binary..."
+  cargo build $RELEASE --bin tok_detok_worker --features "$FEATURES_NO_PY"
 else
-  FEATURES_RUNNER=$(echo "$FEATURES" | sed -E 's/\bpython\b//g' | xargs)
-  echo "Building runner binary..."
-  cargo build $RELEASE --bin runner --features "$FEATURES_RUNNER"
+  echo "Building runner and tok_detok_worker binaries..."
+  cargo build $RELEASE --bin runner --bin tok_detok_worker --features "$FEATURES_NO_PY"
 
   echo "Copying runner binary into $DEST_DIR/ ..."
   RUNNER_BINARY="target/$PROFILE/$RUNNER_BIN"
@@ -182,6 +192,15 @@ else
   else
     echo "Warning: patchelf not found; runner may need LD_LIBRARY_PATH to find bundled libs."
   fi
+fi
+
+echo "Copying tok_detok_worker binary into $DEST_DIR/ ..."
+TOK_DETOK_WORKER_BINARY="target/$PROFILE/$TOK_DETOK_WORKER_BIN"
+cp "$TOK_DETOK_WORKER_BINARY" "$DEST_DIR/tok_detok_worker"
+chmod 755 "$DEST_DIR/tok_detok_worker"
+if command -v patchelf >/dev/null 2>&1; then
+  echo "Patching tok_detok_worker rpath for bundled libs..."
+  patchelf --set-rpath '$ORIGIN:$ORIGIN/../vllm_rs.libs' "$DEST_DIR/tok_detok_worker"
 fi
 
 # Staging files for python package
@@ -220,6 +239,7 @@ echo "Cleaning up temporary files..."
 if [[ "$IS_METAL" != true ]]; then
   rm -f "$DEST_DIR/runner"
 fi
+rm -f "$DEST_DIR/tok_detok_worker"
 rm -f "$DEST_DIR/__init__.py" \
       "$DEST_DIR/__init__.pyi" \
       "$DEST_DIR/py.typed" \

--- a/build.sh
+++ b/build.sh
@@ -85,6 +85,7 @@ if [[ "$INSTALL" == true ]]; then
 fi
 
 XINFER_BIN="$(bin_name xinfer)"
+TOK_DETOK_WORKER_BIN="$(bin_name tok_detok_worker)"
 
 HAS_PYTHON=false
 if [[ "$FEATURES" == *"python"* ]]; then
@@ -107,8 +108,8 @@ if [[ "$INSTALL" == true ]]; then
   echo "Binary-only install requested; skipping maturin and python package staging."
 
   FEATURES_NO_PY=$(echo "$FEATURES" | sed -E 's/\bpython\b//g' | xargs)
-  echo "Building xinfer binary..."
-  cargo build $RELEASE --bin xinfer --features "$FEATURES_NO_PY"
+  echo "Building xinfer + tok_detok_worker binaries..."
+  cargo build $RELEASE --bin xinfer --bin tok_detok_worker --features "$FEATURES_NO_PY"
 
   echo "Installing binary to: $DST"
   mkdir -p "$DST"
@@ -120,6 +121,13 @@ if [[ "$INSTALL" == true ]]; then
   fi
   install -m 755 "$XINFER_PATH" "$DST/xinfer"
 
+  TOK_DETOK_WORKER_PATH="target/$PROFILE/$TOK_DETOK_WORKER_BIN"
+  if [[ ! -f "$TOK_DETOK_WORKER_PATH" ]]; then
+    echo "Error: tok_detok_worker binary not found at $TOK_DETOK_WORKER_PATH"
+    exit 1
+  fi
+  install -m 755 "$TOK_DETOK_WORKER_PATH" "$DST/tok_detok_worker"
+
   echo "Build and install complete."
   exit 0
 fi
@@ -128,8 +136,8 @@ fi
 # NO PYTHON: build xinfer binary, done
 # -------------------------------------------------------------------
 if [[ "$HAS_PYTHON" != true ]]; then
-  echo "Building xinfer binary..."
-  cargo build $RELEASE --bin xinfer --features "$FEATURES"
+  echo "Building xinfer + tok_detok_worker binaries..."
+  cargo build $RELEASE --bin xinfer --bin tok_detok_worker --features "$FEATURES"
   echo "Build complete."
   exit 0
 fi
@@ -140,12 +148,15 @@ fi
 DEST_DIR="xinfer"
 mkdir -p "$DEST_DIR"
 
+FEATURES_NO_PY=$(echo "$FEATURES" | sed -E 's/\bpython\b//g' | xargs)
 if [[ "$IS_METAL" == true ]]; then
   echo "Metal feature detected. Skipping xinfer binary copy for python package."
+  echo "Building tok_detok_worker binary..."
+  cargo build $RELEASE --bin tok_detok_worker --features "$FEATURES_NO_PY"
 else
   FEATURES_BIN=$(echo "$FEATURES" | sed -E 's/\bpython\b//g' | xargs)
-  echo "Building xinfer binary..."
-  cargo build $RELEASE --bin xinfer --features "$FEATURES_BIN"
+  echo "Building xinfer + tok_detok_worker binaries..."
+  cargo build $RELEASE --bin xinfer --bin tok_detok_worker --features "$FEATURES_BIN"
 
   echo "Copying xinfer binary into $DEST_DIR/ ..."
   XINFER_BINARY="target/$PROFILE/$XINFER_BIN"
@@ -159,6 +170,16 @@ else
   fi
 fi
 
+echo "Copying tok_detok_worker binary into $DEST_DIR/ ..."
+TOK_DETOK_WORKER_BINARY="target/$PROFILE/$TOK_DETOK_WORKER_BIN"
+cp "$TOK_DETOK_WORKER_BINARY" "$DEST_DIR/tok_detok_worker"
+chmod 755 "$DEST_DIR/tok_detok_worker"
+if command -v patchelf >/dev/null 2>&1; then
+  echo "Patching tok_detok_worker rpath for bundled libs..."
+  patchelf --set-rpath '$ORIGIN:$ORIGIN/../xinfer.libs' "$DEST_DIR/tok_detok_worker"
+fi
+
+# Staging files for python package
 cp "xinfer.pyi" "$DEST_DIR/__init__.pyi"
 chmod 755 "$DEST_DIR/__init__.pyi"
 touch "$DEST_DIR/py.typed"
@@ -192,6 +213,7 @@ echo "Cleaning up temporary files..."
 if [[ "$IS_METAL" != true ]]; then
   rm -f "$DEST_DIR/xinfer"
 fi
+rm -f "$DEST_DIR/tok_detok_worker"
 rm -f "$DEST_DIR/__init__.py" \
       "$DEST_DIR/__init__.pyi" \
       "$DEST_DIR/py.typed" \

--- a/myproject.toml
+++ b/myproject.toml
@@ -14,5 +14,5 @@ classifiers = [
 
 [tool.maturin]
 python-source = "python"
-include = ["vllm_rs/runner", "vllm_rs/__init__.py", "vllm_rs/__init__.pyi", "py.typed"]
+include = ["vllm_rs/runner", "vllm_rs/tok_detok_worker", "vllm_rs/__init__.py", "vllm_rs/__init__.pyi", "py.typed"]
 sdist-include = ["ReadMe.md"]

--- a/myproject.toml
+++ b/myproject.toml
@@ -14,5 +14,5 @@ classifiers = [
 
 [tool.maturin]
 python-source = "python"
-include = ["xinfer/xinfer", "xinfer/__init__.py", "xinfer/__init__.pyi", "py.typed"]
+include = ["xinfer/xinfer", "xinfer/tok_detok_worker", "xinfer/__init__.py", "xinfer/__init__.pyi", "py.typed"]
 sdist-include = ["ReadMe.md"]

--- a/src/api.rs
+++ b/src/api.rs
@@ -206,16 +206,17 @@ impl Engine {
         images: Option<crate::utils::image::ImageData>,
         tools: Vec<Tool>,
     ) -> Result<GenerationOutput> {
-        let (receivers, tokenizer) = {
+        let (receivers, tokenizer, tok_detok_ipc) = {
             let mut engine = self.engine.write();
             (
                 engine.generate_sync(&vec![params], &vec![messages], images, &tools, &None)?,
                 Arc::new(engine.tokenizer.clone()),
+                engine.tok_detok_ipc.clone(),
             )
         };
 
         let results = GLOBAL_RT.block_on(async {
-            LLMEngine::collect_sync_results(receivers, tokenizer, None).await
+            LLMEngine::collect_sync_results(receivers, tokenizer, None, tok_detok_ipc).await
         })?;
 
         // Extract GenerationOutput

--- a/src/api.rs
+++ b/src/api.rs
@@ -217,16 +217,25 @@ impl Engine {
         images: Option<crate::utils::image::ImageData>,
         tools: Vec<Tool>,
     ) -> Result<GenerationOutput> {
-        let (receivers, tokenizer) = {
-            let mut engine = self.engine.write();
+        let (preprocessed, tokenizer_service) = {
+            let engine = self.engine.read();
             (
-                engine.generate_sync(&vec![params], &vec![messages], images, &tools, &None)?,
-                Arc::new(engine.tokenizer.clone()),
+                engine.preprocess(
+                    std::slice::from_ref(&params),
+                    std::slice::from_ref(&messages),
+                    &tools,
+                    false,
+                )?,
+                engine.tokenizer_service.clone(),
             )
+        };
+        let receivers = {
+            let mut engine = self.engine.write();
+            engine.generate_sync_from_preprocessed(preprocessed, images, &None)?
         };
 
         let results = GLOBAL_RT.block_on(async {
-            LLMEngine::collect_sync_results(receivers, tokenizer, None).await
+            LLMEngine::collect_sync_results(receivers, tokenizer_service, None).await
         })?;
 
         // Extract GenerationOutput
@@ -246,9 +255,19 @@ impl Engine {
         let img_cfg = { self.engine.read().img_cfg.clone() };
         let (messages, image_data) = build_messages_and_images(&messages, img_cfg.as_ref())?;
 
+        let preprocessed = {
+            let engine = self.engine.read();
+            let mut pre = engine.preprocess(
+                std::slice::from_ref(&params),
+                std::slice::from_ref(&messages),
+                &tools,
+                false,
+            )?;
+            pre.pop().expect("preprocess returned 0 items for 1 input")
+        };
         let (seq_id, prompt_length, _prefilled_reasoning_end, stream) = {
             let mut engine = self.engine.write();
-            engine.generate_stream(&params, &messages, image_data, &tools, &None)?
+            engine.generate_stream_from_preprocessed(preprocessed, image_data, &None)?
         };
 
         Ok(EngineStream {

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -99,6 +99,12 @@ pub struct LLMEngine {
     pub tool_config: ToolConfig,
     pub img_cfg: Option<ImageProcessConfig>,
     pub guidance_tokens: GuidanceTokens,
+    /// Optional out-of-process tokenization + detokenization (tok_detok_worker).
+    /// Activated by setting `VLLM_RS_TOK_DETOK_WORKER=1` in env. Spawns one
+    /// `tok_detok_worker` process; the engine binds two namespaced
+    /// `interprocess::local_socket` listeners (one for tokenize, one for
+    /// detokenize) so the two directions don't head-of-line each other.
+    pub tok_detok_ipc: Option<crate::runner::tok_detok_socket::TokDetokIpcPair>,
 }
 
 impl LLMEngine {
@@ -469,6 +475,55 @@ impl LLMEngine {
 
         log_warn!("Model loaded.\n");
 
+        // Optional out-of-process tokenization + detokenization.
+        // Spawns a `tok_detok_worker` subprocess; the engine binds two
+        // `interprocess::local_socket` listeners (one for tokenize, one for
+        // detokenize) so the two directions don't head-of-line each other.
+        let tok_detok_ipc = if std::env::var("VLLM_RS_TOK_DETOK_WORKER")
+            .ok()
+            .map(|s| matches!(s.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+            .unwrap_or(false)
+        {
+            use crate::runner::tok_detok_msgs::{MsgKind, TokDetokInit};
+            use crate::runner::tok_detok_socket::{TokDetokIpcPair, TokDetokSocketServer};
+            use crate::utils::get_tok_detok_worker_path;
+            let pid = std::process::id() % 100000;
+            let tok_sock = format!("vllm-rs-tokdetok-{}-tok", pid);
+            let det_sock = format!("vllm-rs-tokdetok-{}-det", pid);
+            let worker_path = get_tok_detok_worker_path().expect("tok_detok_worker path");
+            // Child lives for the engine lifetime; same `.map(|_| ())` pattern as
+            // `spawn_runner` in `src/utils/mod.rs` to silence `clippy::zombie_processes`.
+            std::process::Command::new(&worker_path)
+                .env("TOK_DETOK_SOCKET_TOK", &tok_sock)
+                .env("TOK_DETOK_SOCKET_DET", &det_sock)
+                .spawn()
+                .map(|_child| ())
+                .expect("spawn tok_detok_worker");
+            log_info!(
+                "[tok_detok_worker] spawned, awaiting connects on tok={} det={}",
+                tok_sock,
+                det_sock
+            );
+            // Worker connects to tok first, then det (same order as
+            // tok_detok_worker.rs main()).
+            let tok = TokDetokSocketServer::bind_and_accept(&tok_sock)
+                .expect("tok_detok tok socket bind");
+            let det = TokDetokSocketServer::bind_and_accept(&det_sock)
+                .expect("tok_detok det socket bind");
+            // Init is delivered on the tok socket; the worker shares the
+            // tokenizer between its two service threads.
+            let init = TokDetokInit {
+                model_paths: model_pathes.clone(),
+                is_gguf,
+            };
+            let bytes = bincode::serialize(&init).unwrap();
+            tok.send(&bytes, MsgKind::TokDetokInit);
+            log_info!("[tok_detok_worker] TokDetokInit sent on tok socket");
+            Some(TokDetokIpcPair { tok, det })
+        } else {
+            None
+        };
+
         let engine = Arc::new(RwLock::new(Self {
             runners,
             scheduler,
@@ -494,6 +549,7 @@ impl LLMEngine {
             img_cfg,
             model_name,
             guidance_tokens,
+            tok_detok_ipc,
         }));
 
         Self::start_engine(engine.clone());
@@ -508,12 +564,30 @@ impl LLMEngine {
         images: &Option<ImageData>,
         image_idx: i32,
     ) -> Result<(usize, usize)> {
-        let tokens = self
-            .tokenizer
-            .encode_fast(prompt, true)
-            .expect("encode failed!");
-        let token_ids: Vec<u32> = tokens.get_ids().iter().map(|&x| x).collect();
-        let length = token_ids.len();
+        // Hot path: route tokenization to out-of-process worker if enabled.
+        let (token_ids, length): (Vec<u32>, usize) = if let Some(ipc) = &self.tok_detok_ipc {
+            use crate::runner::tok_detok_msgs::{MsgKind, TokenizeReq, TokenizeResp};
+            let req = TokenizeReq {
+                prompt: prompt.to_string(),
+            };
+            let bytes = bincode::serialize(&req).expect("tokenize req encode");
+            ipc.tok.send(&bytes, MsgKind::Tokenize);
+            let (kind, data) = ipc.tok.recv_blocking();
+            if kind != MsgKind::TokenizeResp as u8 {
+                candle_core::bail!("tok_detok_worker: unexpected kind={}", kind);
+            }
+            let resp: TokenizeResp = bincode::deserialize(&data).expect("tokenize resp decode");
+            let len = resp.prompt_len;
+            (resp.token_ids, len)
+        } else {
+            let tokens = self
+                .tokenizer
+                .encode_fast(prompt, true)
+                .expect("encode failed!");
+            let token_ids: Vec<u32> = tokens.get_ids().iter().map(|&x| x).collect();
+            let length = token_ids.len();
+            (token_ids, length)
+        };
         let raw_replay_token_ids = self.match_prompt_replay_candidate(&token_ids);
         if let Some(max_model_len) = self.econfig.max_model_len {
             if length > max_model_len - 1 {
@@ -1234,6 +1308,7 @@ impl LLMEngine {
         receivers: Vec<(usize, usize, mpsc::Receiver<StreamItem>)>,
         tokenizer: Arc<Tokenizer>,
         logger: Option<Arc<ChatCompletionLogger>>,
+        tok_detok_ipc: Option<crate::runner::tok_detok_socket::TokDetokIpcPair>,
     ) -> Result<Vec<GenerationOutput>> {
         let decoded_tokens = Arc::new(AtomicUsize::new(0));
         let decode_start_time = Arc::new(AtomicUsize::new(0));
@@ -1246,6 +1321,7 @@ impl LLMEngine {
                 let decode_start_time_clone = decode_start_time.clone();
                 let tokenizer = Arc::clone(&tokenizer);
                 let logger = logger.clone();
+                let tok_detok_ipc = tok_detok_ipc.clone();
                 async move {
                     let mut output: Option<GenerationOutput> = None;
                     let mut collected_token_ids: Vec<u32> = Vec::new();
@@ -1274,9 +1350,32 @@ impl LLMEngine {
                                 stop_sequence,
                             )) => {
                                 let decoded_len = decoded_ids.len();
-                                let decode_output = tokenizer
-                                    .decode(&decoded_ids, true)
-                                    .expect("unable to decode!");
+                                let decode_output = if let Some(ipc) = tok_detok_ipc.as_ref() {
+                                    use crate::runner::tok_detok_msgs::{
+                                        DetokenizeReq, DetokenizeResp, MsgKind,
+                                    };
+                                    let req = DetokenizeReq {
+                                        token_ids: decoded_ids.clone(),
+                                        skip_special_tokens: true,
+                                    };
+                                    let bytes =
+                                        bincode::serialize(&req).expect("detokenize req encode");
+                                    ipc.det.send(&bytes, MsgKind::Detokenize);
+                                    let (kind, data) = ipc.det.recv_blocking();
+                                    if kind != MsgKind::DetokenizeResp as u8 {
+                                        panic!(
+                                            "tok_detok_worker: unexpected detokenize kind={}",
+                                            kind
+                                        );
+                                    }
+                                    let resp: DetokenizeResp = bincode::deserialize(&data)
+                                        .expect("detokenize resp decode");
+                                    resp.text
+                                } else {
+                                    tokenizer
+                                        .decode(&decoded_ids, true)
+                                        .expect("unable to decode!")
+                                };
 
                                 output = Some(GenerationOutput {
                                     seq_id,

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -75,6 +75,23 @@ pub enum RequestType {
     Completion,
 }
 
+/// Output of `LLMEngine::preprocess`. Encapsulates everything that's
+/// needed to register a request with the scheduler, computed up-front so
+/// the engine write lock is held only for the brief scheduler-add step.
+///
+/// Carrying the full `SamplingParams` (cloned) and the chat-templated
+/// `prompt` (owned `String`) lets the caller drop both the engine read
+/// lock and the original `messages: Vec<Message>` borrow before
+/// acquiring the engine write lock.
+#[derive(Debug, Clone)]
+pub struct PreprocessedRequest {
+    pub params: SamplingParams,
+    pub prompt: String,
+    pub image_idx: i32,
+    pub token_ids: Vec<u32>,
+    pub prompt_len: usize,
+}
+
 #[allow(dead_code)]
 pub struct LLMEngine {
     pub runners: Arc<RwLock<RunnerType>>,
@@ -101,6 +118,15 @@ pub struct LLMEngine {
     pub tool_config: ToolConfig,
     pub img_cfg: Option<ImageProcessConfig>,
     pub guidance_tokens: GuidanceTokens,
+    /// Dispatch for the engine's hot-path tokenize/detokenize calls.
+    /// `TokenizerService::Inline` is the default in-process tokenizer.
+    /// `TokenizerService::Worker` is the opt-in out-of-process worker
+    /// activated by `XINFER_TOK_DETOK_WORKER=1`. The enum shape mirrors
+    /// `RunnerType::{Thread, Process}` so future variants (inference
+    /// firewall, grammar-aware, remote multi-model) plug in by adding a
+    /// variant rather than threading another `Option<...>` through the
+    /// engine call sites.
+    pub tokenizer_service: crate::runner::tokenizer_service::TokenizerService,
 }
 
 impl LLMEngine {
@@ -474,6 +500,63 @@ impl LLMEngine {
 
         log_warn!("Model loaded.\n");
 
+        // Optional out-of-process tokenization + detokenization.
+        // Spawns a `tok_detok_worker` subprocess; the engine binds two
+        // `interprocess::local_socket` listeners (one for tokenize, one for
+        // detokenize) so the two directions don't head-of-line each other.
+        let tok_detok_ipc = if std::env::var("XINFER_TOK_DETOK_WORKER")
+            .ok()
+            .map(|s| matches!(s.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+            .unwrap_or(false)
+        {
+            use crate::runner::tok_detok_msgs::{MsgKind, TokDetokInit};
+            use crate::runner::tok_detok_socket::{TokDetokIpcPair, TokDetokSocketServer};
+            use crate::utils::get_tok_detok_worker_path;
+            let pid = std::process::id() % 100000;
+            let tok_sock = format!("xinfer-tokdetok-{}-tok", pid);
+            let det_sock = format!("xinfer-tokdetok-{}-det", pid);
+            let worker_path = get_tok_detok_worker_path().expect("tok_detok_worker path");
+            // Child lives for the engine lifetime; same `.map(|_| ())` pattern as
+            // `spawn_runner` in `src/utils/mod.rs` to silence `clippy::zombie_processes`.
+            std::process::Command::new(&worker_path)
+                .env("XINFER_TOK_DETOK_SOCKET_TOK", &tok_sock)
+                .env("XINFER_TOK_DETOK_SOCKET_DET", &det_sock)
+                .spawn()
+                .map(|_child| ())
+                .expect("spawn tok_detok_worker");
+            log_info!(
+                "[tok_detok_worker] spawned, awaiting connects on tok={} det={}",
+                tok_sock,
+                det_sock
+            );
+            // Worker connects to tok first, then det (same order as
+            // tok_detok_worker.rs main()).
+            let tok = TokDetokSocketServer::bind_and_accept(&tok_sock)
+                .expect("tok_detok tok socket bind");
+            let det = TokDetokSocketServer::bind_and_accept(&det_sock)
+                .expect("tok_detok det socket bind");
+            // Init is delivered on the tok socket; the worker shares the
+            // tokenizer between its two service threads.
+            let init = TokDetokInit {
+                model_paths: model_pathes.clone(),
+                is_gguf,
+            };
+            let bytes = bincode::serialize(&init).unwrap();
+            tok.send(&bytes, MsgKind::TokDetokInit);
+            log_info!("[tok_detok_worker] TokDetokInit sent on tok socket");
+            Some(TokDetokIpcPair { tok, det })
+        } else {
+            None
+        };
+        let tokenizer_arc = Arc::new(tokenizer.clone());
+        let tokenizer_service = match tok_detok_ipc {
+            Some(ipc) => crate::runner::tokenizer_service::TokenizerService::Worker {
+                ipc,
+                tokenizer: tokenizer_arc,
+            },
+            None => crate::runner::tokenizer_service::TokenizerService::Inline(tokenizer_arc),
+        };
+
         let engine = Arc::new(RwLock::new(Self {
             runners,
             scheduler,
@@ -499,6 +582,7 @@ impl LLMEngine {
             img_cfg,
             model_name,
             guidance_tokens,
+            tokenizer_service,
         }));
 
         Self::start_engine(engine.clone());
@@ -513,12 +597,38 @@ impl LLMEngine {
         images: &Option<ImageData>,
         image_idx: i32,
     ) -> Result<(usize, usize)> {
-        let tokens = self
-            .tokenizer
-            .encode_fast(prompt, true)
-            .expect("encode failed!");
-        let token_ids: Vec<u32> = tokens.get_ids().iter().map(|&x| x).collect();
-        let length = token_ids.len();
+        // Hot path: dispatch via TokenizerService — Inline (default) or Worker.
+        let (token_ids, length): (Vec<u32>, usize) = self
+            .tokenizer_service
+            .encode(prompt)
+            .map_err(|e| candle_core::Error::wrap(e))?;
+        self.add_request_pretokenized_(
+            params,
+            prompt,
+            token_ids,
+            length,
+            request_type,
+            images,
+            image_idx,
+        )
+    }
+
+    /// Same as `add_request_` but accepts a pre-computed `token_ids` /
+    /// `length` pair so the caller can tokenize *outside* the engine write
+    /// lock. Enables N concurrent server handlers to tokenize in parallel
+    /// (each under their own `engine.read()`) and only serialize on the
+    /// brief `engine.write()` needed to register the request with the
+    /// scheduler.
+    fn add_request_pretokenized_(
+        &mut self,
+        params: &SamplingParams,
+        prompt: &str,
+        token_ids: Vec<u32>,
+        length: usize,
+        request_type: &RequestType,
+        images: &Option<ImageData>,
+        image_idx: i32,
+    ) -> Result<(usize, usize)> {
         let raw_replay_token_ids = self.match_prompt_replay_candidate(&token_ids);
         if let Some(max_model_len) = self.econfig.max_model_len {
             if length > max_model_len - 1 {
@@ -710,6 +820,81 @@ impl LLMEngine {
             );
         }
         Ok((seq_id, prompt_length, rx))
+    }
+
+    /// Public pretokenized variant of `add_request`. Skips the in-lock
+    /// tokenize so the caller can run `tokenizer_service.encode` outside
+    /// the engine write lock (under `engine.read()` or no lock at all),
+    /// then take `engine.write()` only for the scheduler-add step.
+    pub fn add_request_pretokenized(
+        &mut self,
+        params: &SamplingParams,
+        prompt: &str,
+        token_ids: Vec<u32>,
+        prompt_len: usize,
+        request_type: RequestType,
+        images: &Option<ImageData>,
+        image_idx: i32,
+    ) -> Result<(usize, usize, Receiver<StreamItem>)> {
+        let (seq_id, prompt_length) = self.add_request_pretokenized_(
+            params,
+            prompt,
+            token_ids,
+            prompt_len,
+            &request_type,
+            images,
+            image_idx,
+        )?;
+        let (tx, rx) = channel(1024);
+        self.stream_senders.insert(seq_id, tx);
+        self.request_types.insert(seq_id, request_type.clone());
+        if self.econfig.server_mode.unwrap_or(true) && request_type != RequestType::Completion {
+            log_warn!(
+                "[{:?}] New request [Seq_id {}, {} tokens] received! (session_id: {:?})\n",
+                request_type,
+                seq_id,
+                prompt_length,
+                params.session_id,
+            );
+        }
+        Ok((seq_id, prompt_length, rx))
+    }
+
+    /// Chat-template + tokenize each `(params, messages)` pair. Pure read
+    /// of the engine (`&self`) so multiple concurrent server handlers can
+    /// run this in parallel under their own `engine.read()` guards. The
+    /// returned `Vec<PreprocessedRequest>` feeds `generate_sync_from_preprocessed`
+    /// / `generate_stream_from_preprocessed`, which acquire `engine.write()`
+    /// only briefly for the scheduler-add step.
+    pub fn preprocess(
+        &self,
+        params: &[SamplingParams],
+        message_list: &[Vec<Message>],
+        tools: &[Tool],
+        log: bool,
+    ) -> Result<Vec<PreprocessedRequest>> {
+        if params.len() != message_list.len() {
+            candle_core::bail!(
+                "size of sampling parameters is not match with size of prompts!"
+            );
+        }
+        let tools_vec: Vec<Tool> = tools.to_vec();
+        let mut out = Vec::with_capacity(params.len());
+        for (param, messages) in params.iter().zip(message_list.iter()) {
+            let (prompt, image_idx) = self.apply_chat_template(param, messages, &tools_vec, log);
+            let (token_ids, prompt_len) = self
+                .tokenizer_service
+                .encode(&prompt)
+                .map_err(|e| candle_core::Error::wrap(e))?;
+            out.push(PreprocessedRequest {
+                params: param.clone(),
+                prompt,
+                image_idx,
+                token_ids,
+                prompt_len,
+            });
+        }
+        Ok(out)
     }
 
     pub fn get_num_cached_tokens(&self) -> usize {
@@ -1230,8 +1415,8 @@ impl LLMEngine {
         has_requests_to_cancel
     }
 
-    fn apply_chat_template(
-        &mut self,
+    pub fn apply_chat_template(
+        &self,
         params: &SamplingParams,
         messages: &Vec<Message>,
         tools: &Vec<Tool>,
@@ -1318,13 +1503,47 @@ impl LLMEngine {
         Ok(receivers)
     }
 
+    /// Lock-hoisted equivalent of `generate_sync`. The caller has already
+    /// run `preprocess(...)` (chat template + tokenize) under a brief
+    /// `engine.read()` guard — only the scheduler-add step needs the
+    /// engine write lock, so this method holds it for milliseconds rather
+    /// than tens-to-hundreds of milliseconds.
+    pub fn generate_sync_from_preprocessed(
+        &mut self,
+        preprocessed: Vec<PreprocessedRequest>,
+        images: Option<ImageData>,
+        logger: &Option<Arc<ChatCompletionLogger>>,
+    ) -> Result<Vec<(usize, usize, mpsc::Receiver<StreamItem>)>> {
+        let mut receivers = Vec::with_capacity(preprocessed.len());
+        for pp in preprocessed {
+            if let Some(ref l) = logger {
+                l.log_prompt(&pp.prompt);
+            }
+            if let Ok((seq_id, prompt_length, rx)) = self.add_request_pretokenized(
+                &pp.params,
+                &pp.prompt,
+                pp.token_ids,
+                pp.prompt_len,
+                RequestType::Completion,
+                &images,
+                pp.image_idx,
+            ) {
+                receivers.push((seq_id, prompt_length, rx));
+            }
+        }
+        Ok(receivers)
+    }
+
     pub async fn collect_sync_results(
         receivers: Vec<(usize, usize, mpsc::Receiver<StreamItem>)>,
-        tokenizer: Arc<Tokenizer>,
+        tokenizer_service: crate::runner::tokenizer_service::TokenizerService,
         logger: Option<Arc<ChatCompletionLogger>>,
     ) -> Result<Vec<GenerationOutput>> {
         let decoded_tokens = Arc::new(AtomicUsize::new(0));
         let decode_start_time = Arc::new(AtomicUsize::new(0));
+        // Raw tokenizer for the in-process stream decoder (logger path);
+        // streaming decode is stateful and stays in-process by design.
+        let tokenizer: Arc<Tokenizer> = tokenizer_service.tokenizer().clone();
 
         // Create futures for each receiver (do NOT spawn detached tasks)
         let tasks = receivers
@@ -1334,6 +1553,7 @@ impl LLMEngine {
                 let decode_start_time_clone = decode_start_time.clone();
                 let tokenizer = Arc::clone(&tokenizer);
                 let logger = logger.clone();
+                let tokenizer_service = tokenizer_service.clone();
                 async move {
                     let mut output: Option<GenerationOutput> = None;
                     let mut collected_token_ids: Vec<u32> = Vec::new();
@@ -1362,7 +1582,7 @@ impl LLMEngine {
                                 stop_sequence,
                             )) => {
                                 let decoded_len = decoded_ids.len();
-                                let decode_output = tokenizer
+                                let decode_output = tokenizer_service
                                     .decode(&decoded_ids, true)
                                     .expect("unable to decode!");
 
@@ -1470,6 +1690,39 @@ impl LLMEngine {
             l.log_prompt(&prompt);
         }
         match self.add_request(params, &prompt, RequestType::Stream, &images, image_idx) {
+            Ok((seq_id, prompt_length, rx)) => {
+                let prefilled_reasoning_end = self.get_prefilled_reasoning_end_marker(seq_id);
+                Ok((seq_id, prompt_length, prefilled_reasoning_end, rx))
+            }
+            Err(e) => {
+                candle_core::bail!("{:?}", e)
+            }
+        }
+    }
+
+    /// Lock-hoisted equivalent of `generate_stream`. Takes a single
+    /// already-`preprocess`ed request and registers it with the scheduler
+    /// under the engine write lock. Caller is expected to have run
+    /// `preprocess(&[params], &[messages], ...)` under a brief
+    /// `engine.read()` and pulled the single element out.
+    pub fn generate_stream_from_preprocessed(
+        &mut self,
+        preprocessed: PreprocessedRequest,
+        images: Option<ImageData>,
+        logger: &Option<Arc<ChatCompletionLogger>>,
+    ) -> Result<(usize, usize, Option<String>, mpsc::Receiver<StreamItem>)> {
+        if let Some(ref l) = logger {
+            l.log_prompt(&preprocessed.prompt);
+        }
+        match self.add_request_pretokenized(
+            &preprocessed.params,
+            &preprocessed.prompt,
+            preprocessed.token_ids,
+            preprocessed.prompt_len,
+            RequestType::Stream,
+            &images,
+            preprocessed.image_idx,
+        ) {
             Ok((seq_id, prompt_length, rx)) => {
                 let prefilled_reasoning_end = self.get_prefilled_reasoning_end_marker(seq_id);
                 Ok((seq_id, prompt_length, prefilled_reasoning_end, rx))

--- a/src/main.rs
+++ b/src/main.rs
@@ -422,14 +422,17 @@ async fn main() -> Result<()> {
             } else {
                 vllm_rs::log_warn!("Starting the inference...");
 
-                let (receivers, tokenizer) = {
+                let (receivers, tokenizer, tok_detok_ipc) = {
                     let mut e = engine.write();
                     (
                         e.generate_sync(&params, &message_list, None, &Vec::new(), &None)?,
                         Arc::new(e.tokenizer.clone()),
+                        e.tok_detok_ipc.clone(),
                     )
                 };
-                let results = LLMEngine::collect_sync_results(receivers, tokenizer, None).await?;
+                let results =
+                    LLMEngine::collect_sync_results(receivers, tokenizer, None, tok_detok_ipc)
+                        .await?;
                 // GenerationOutput is returned directly
                 results
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ use clap::Parser;
 use colored::Colorize;
 use reedline::{DefaultPrompt, DefaultPromptSegment, Reedline, Signal};
 use serde_json;
-use std::sync::Arc;
 use tool_parser::ParserFactory;
 use xinfer::core::engine::StreamItem;
 use xinfer::core::engine::GLOBAL_RT;
@@ -345,15 +344,21 @@ async fn main() -> Result<()> {
 
         let mut outputs = {
             if interactive {
+                let preprocessed = {
+                    let e = engine.read();
+                    let mut p = e
+                        .preprocess(
+                            std::slice::from_ref(&request_params),
+                            std::slice::from_ref(&chat_history),
+                            &Vec::new(),
+                            false,
+                        )
+                        .expect("preprocess failed");
+                    p.pop().expect("preprocess returned 0 items for 1 input")
+                };
                 let (seq_id, prompt_length, _prefilled_reasoning_end, stream) = {
                     let mut e = engine.write();
-                    match e.generate_stream(
-                        &request_params,
-                        &chat_history,
-                        None,
-                        &Vec::new(),
-                        &None,
-                    ) {
+                    match e.generate_stream_from_preprocessed(preprocessed, None, &None) {
                         Ok((seq_id, prompt_length, prefilled_reasoning_end, stream)) => {
                             (seq_id, prompt_length, prefilled_reasoning_end, stream)
                         }
@@ -438,14 +443,20 @@ async fn main() -> Result<()> {
             } else {
                 xinfer::log_warn!("Starting the inference...");
 
-                let (receivers, tokenizer) = {
-                    let mut e = engine.write();
+                let (preprocessed, tokenizer_service) = {
+                    let e = engine.read();
                     (
-                        e.generate_sync(&params, &message_list, None, &Vec::new(), &None)?,
-                        Arc::new(e.tokenizer.clone()),
+                        e.preprocess(&params, &message_list, &Vec::new(), false)?,
+                        e.tokenizer_service.clone(),
                     )
                 };
-                let results = LLMEngine::collect_sync_results(receivers, tokenizer, None).await?;
+                let receivers = {
+                    let mut e = engine.write();
+                    e.generate_sync_from_preprocessed(preprocessed, None, &None)?
+                };
+                let results =
+                    LLMEngine::collect_sync_results(receivers, tokenizer_service, None)
+                        .await?;
                 // GenerationOutput is returned directly
                 results
             }

--- a/src/py/mod.rs
+++ b/src/py/mod.rs
@@ -75,7 +75,7 @@ impl Engine {
     ) -> PyResult<Vec<GenerationOutput>> {
         tokio::task::block_in_place(|| {
             GLOBAL_RT.block_on(async {
-                let (receivers, tokenizer) = {
+                let (receivers, tokenizer, tok_detok_ipc) = {
                     let mut engine = self.engine.write();
                     (
                         engine
@@ -84,14 +84,16 @@ impl Engine {
                                 PyValueError::new_err(format!("generate_sync failed: {:?}", e))
                             })?,
                         Arc::new(engine.tokenizer.clone()),
+                        engine.tok_detok_ipc.clone(),
                     )
                 };
 
-                let results = LLMEngine::collect_sync_results(receivers, tokenizer, None)
-                    .await
-                    .map_err(|e| {
-                        PyValueError::new_err(format!("collect_sync_results failed: {:?}", e))
-                    })?;
+                let results =
+                    LLMEngine::collect_sync_results(receivers, tokenizer, None, tok_detok_ipc)
+                        .await
+                        .map_err(|e| {
+                            PyValueError::new_err(format!("collect_sync_results failed: {:?}", e))
+                        })?;
 
                 // GenerationOutput is returned directly
                 let outputs: Vec<GenerationOutput> = results;

--- a/src/py/mod.rs
+++ b/src/py/mod.rs
@@ -75,23 +75,35 @@ impl Engine {
     ) -> PyResult<Vec<GenerationOutput>> {
         tokio::task::block_in_place(|| {
             GLOBAL_RT.block_on(async {
-                let (receivers, tokenizer) = {
-                    let mut engine = self.engine.write();
+                let (preprocessed, tokenizer_service) = {
+                    let engine = self.engine.read();
                     (
                         engine
-                            .generate_sync(&params, &message_list, None, &Vec::new(), &None)
+                            .preprocess(&params, &message_list, &Vec::new(), false)
                             .map_err(|e| {
-                                PyValueError::new_err(format!("generate_sync failed: {:?}", e))
+                                PyValueError::new_err(format!("preprocess failed: {:?}", e))
                             })?,
-                        Arc::new(engine.tokenizer.clone()),
+                        engine.tokenizer_service.clone(),
                     )
                 };
+                let receivers = {
+                    let mut engine = self.engine.write();
+                    engine
+                        .generate_sync_from_preprocessed(preprocessed, None, &None)
+                        .map_err(|e| {
+                            PyValueError::new_err(format!(
+                                "generate_sync_from_preprocessed failed: {:?}",
+                                e
+                            ))
+                        })?
+                };
 
-                let results = LLMEngine::collect_sync_results(receivers, tokenizer, None)
-                    .await
-                    .map_err(|e| {
-                        PyValueError::new_err(format!("collect_sync_results failed: {:?}", e))
-                    })?;
+                let results =
+                    LLMEngine::collect_sync_results(receivers, tokenizer_service, None)
+                        .await
+                        .map_err(|e| {
+                            PyValueError::new_err(format!("collect_sync_results failed: {:?}", e))
+                        })?;
 
                 // GenerationOutput is returned directly
                 let outputs: Vec<GenerationOutput> = results;
@@ -107,10 +119,22 @@ impl Engine {
         params: SamplingParams,
         messages: Vec<Message>,
     ) -> PyResult<(usize, usize, EngineStream)> {
+        let preprocessed = {
+            let engine = self.engine.read();
+            let mut p = engine
+                .preprocess(
+                    std::slice::from_ref(&params),
+                    std::slice::from_ref(&messages),
+                    &Vec::new(),
+                    false,
+                )
+                .map_err(|e| PyValueError::new_err(format!("preprocess error: {:?}", e)))?;
+            p.pop().ok_or_else(|| PyValueError::new_err("preprocess returned 0 items"))?
+        };
         let (seq_id, prompt_length, _prefilled_reasoning_end, stream) = {
             let mut engine = self.engine.write();
             engine
-                .generate_stream(&params, &messages, None, &Vec::new(), &None)
+                .generate_stream_from_preprocessed(preprocessed, None, &None)
                 .map_err(|e| PyValueError::new_err(format!("stream error: {:?}", e)))?
         };
 

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -396,3 +396,6 @@ macro_rules! def_broadcast_message_to_runners {
         }
     };
 }
+
+pub mod tok_detok_msgs;
+pub mod tok_detok_socket;

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -842,3 +842,7 @@ pub fn run_runner_process(args: Vec<String>) -> anyhow::Result<()> {
     crate::log_info!("Runner finished");
     std::process::exit(0);
 }
+
+pub mod tok_detok_msgs;
+pub mod tok_detok_socket;
+pub mod tokenizer_service;

--- a/src/runner/tok_detok_msgs.rs
+++ b/src/runner/tok_detok_msgs.rs
@@ -1,0 +1,111 @@
+// Wire protocol for engine ↔ tok_detok_worker IPC.
+//
+// Format on the wire: [len: u32 LE][kind: u8][bincode(payload): len bytes]
+
+use serde::{Deserialize, Serialize};
+
+use crate::utils::downloader::ModelPaths;
+
+#[derive(Copy, Clone, Debug)]
+#[repr(u8)]
+pub enum MsgKind {
+    TokDetokInit = 1,
+    Tokenize = 2,
+    TokenizeResp = 3,
+    Detokenize = 4,
+    DetokenizeResp = 5,
+    Error = 99,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct TokDetokInit {
+    pub model_paths: ModelPaths,
+    pub is_gguf: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct TokenizeReq {
+    pub prompt: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct TokenizeResp {
+    pub token_ids: Vec<u32>,
+    pub prompt_len: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DetokenizeReq {
+    pub token_ids: Vec<u32>,
+    pub skip_special_tokens: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DetokenizeResp {
+    pub text: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct WorkerError {
+    pub msg: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Wire-format guard: discriminants are part of the IPC contract.
+    #[test]
+    fn msg_kind_discriminants_stable() {
+        assert_eq!(MsgKind::TokDetokInit as u8, 1);
+        assert_eq!(MsgKind::Tokenize as u8, 2);
+        assert_eq!(MsgKind::TokenizeResp as u8, 3);
+        assert_eq!(MsgKind::Detokenize as u8, 4);
+        assert_eq!(MsgKind::DetokenizeResp as u8, 5);
+        assert_eq!(MsgKind::Error as u8, 99);
+    }
+
+    #[test]
+    fn tokenize_req_roundtrip() {
+        let req = TokenizeReq {
+            prompt: "hello world".to_string(),
+        };
+        let bytes = bincode::serialize(&req).unwrap();
+        let back: TokenizeReq = bincode::deserialize(&bytes).unwrap();
+        assert_eq!(back.prompt, req.prompt);
+    }
+
+    #[test]
+    fn tokenize_resp_roundtrip() {
+        let resp = TokenizeResp {
+            token_ids: vec![1, 2, 3, 42, 65535],
+            prompt_len: 5,
+        };
+        let bytes = bincode::serialize(&resp).unwrap();
+        let back: TokenizeResp = bincode::deserialize(&bytes).unwrap();
+        assert_eq!(back.token_ids, resp.token_ids);
+        assert_eq!(back.prompt_len, resp.prompt_len);
+    }
+
+    #[test]
+    fn detokenize_req_roundtrip() {
+        let req = DetokenizeReq {
+            token_ids: vec![100, 200, 300],
+            skip_special_tokens: true,
+        };
+        let bytes = bincode::serialize(&req).unwrap();
+        let back: DetokenizeReq = bincode::deserialize(&bytes).unwrap();
+        assert_eq!(back.token_ids, req.token_ids);
+        assert_eq!(back.skip_special_tokens, req.skip_special_tokens);
+    }
+
+    #[test]
+    fn detokenize_resp_roundtrip() {
+        let resp = DetokenizeResp {
+            text: "hello world".to_string(),
+        };
+        let bytes = bincode::serialize(&resp).unwrap();
+        let back: DetokenizeResp = bincode::deserialize(&bytes).unwrap();
+        assert_eq!(back.text, resp.text);
+    }
+}

--- a/src/runner/tok_detok_socket.rs
+++ b/src/runner/tok_detok_socket.rs
@@ -1,0 +1,175 @@
+// Length-prefixed bincode framing over `interprocess::local_socket::Stream`.
+// Mirrors the `send_local`/`receive_local` pattern in `src/runner/mod.rs` so the
+// engine↔tok_detok_worker channel uses the same transport class as engine↔runner.
+//
+// Wire format: [len: u32 LE][kind: u8][bincode(payload): len bytes]
+
+use std::io::{BufReader, Read, Write};
+use std::sync::{Arc, Mutex};
+
+use interprocess::local_socket::traits::{Listener, Stream as StreamTrait};
+use interprocess::local_socket::{
+    GenericNamespaced, ListenerOptions, Stream as LocalStream, ToNsName,
+};
+
+use crate::runner::tok_detok_msgs::MsgKind;
+
+#[inline]
+fn build_frame(data: &[u8], kind: MsgKind) -> Vec<u8> {
+    let mut frame = Vec::with_capacity(4 + 1 + data.len());
+    frame.extend_from_slice(&(data.len() as u32).to_le_bytes());
+    frame.push(kind as u8);
+    frame.extend_from_slice(data);
+    frame
+}
+
+/// Pair of engine-side endpoints — one for tokenize, one for detokenize.
+/// Both connect to the same tok_detok_worker process; the worker runs them
+/// on separate threads so the two directions don't head-of-line each other.
+#[derive(Clone)]
+pub struct TokDetokIpcPair {
+    pub tok: TokDetokSocketServer,
+    pub det: TokDetokSocketServer,
+}
+
+/// Engine-side endpoint. Accepts a single tok_detok_worker connection.
+#[derive(Clone)]
+pub struct TokDetokSocketServer {
+    pub writer: Arc<Mutex<LocalStream>>,
+    pub reader: Arc<Mutex<BufReader<LocalStream>>>,
+}
+
+impl TokDetokSocketServer {
+    pub fn bind_and_accept(name: &str) -> std::io::Result<Self> {
+        let ns_name = name.to_ns_name::<GenericNamespaced>()?;
+        let listener = ListenerOptions::new().name(ns_name).create_sync()?;
+        let stream = listener.accept()?;
+        let reader_stream = interprocess::TryClone::try_clone(&stream)?;
+        Ok(Self {
+            writer: Arc::new(Mutex::new(stream)),
+            reader: Arc::new(Mutex::new(BufReader::with_capacity(
+                64 * 1024,
+                reader_stream,
+            ))),
+        })
+    }
+
+    #[inline]
+    pub fn send(&self, data: &[u8], kind: MsgKind) {
+        let frame = build_frame(data, kind);
+        let mut w = self.writer.lock().unwrap();
+        let _ = w.write_all(&frame);
+    }
+
+    pub fn recv_blocking(&self) -> (u8, Vec<u8>) {
+        let mut r = self.reader.lock().unwrap();
+        let mut len_buf = [0u8; 4];
+        r.read_exact(&mut len_buf).expect("recv len");
+        let len = u32::from_le_bytes(len_buf) as usize;
+        let mut kind_buf = [0u8; 1];
+        r.read_exact(&mut kind_buf).expect("recv kind");
+        let mut data = vec![0u8; len];
+        r.read_exact(&mut data).expect("recv data");
+        (kind_buf[0], data)
+    }
+}
+
+/// Worker-side endpoint. Connects to the engine's listener.
+pub struct TokDetokSocketClient {
+    pub writer: Arc<Mutex<LocalStream>>,
+    pub reader: Arc<Mutex<BufReader<LocalStream>>>,
+}
+
+impl TokDetokSocketClient {
+    pub fn connect(name: &str) -> std::io::Result<Self> {
+        let ns_name = name.to_ns_name::<GenericNamespaced>()?;
+        for _ in 0..600 {
+            if let Ok(stream) = LocalStream::connect(ns_name.clone()) {
+                let reader_stream = interprocess::TryClone::try_clone(&stream)?;
+                return Ok(Self {
+                    writer: Arc::new(Mutex::new(stream)),
+                    reader: Arc::new(Mutex::new(BufReader::with_capacity(
+                        64 * 1024,
+                        reader_stream,
+                    ))),
+                });
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        Err(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "tok_detok_socket connect timeout",
+        ))
+    }
+
+    #[inline]
+    pub fn send(&self, data: &[u8], kind: MsgKind) {
+        let frame = build_frame(data, kind);
+        let mut w = self.writer.lock().unwrap();
+        let _ = w.write_all(&frame);
+    }
+
+    pub fn recv_blocking(&self) -> (u8, Vec<u8>) {
+        let mut r = self.reader.lock().unwrap();
+        let mut len_buf = [0u8; 4];
+        r.read_exact(&mut len_buf).expect("recv len");
+        let len = u32::from_le_bytes(len_buf) as usize;
+        let mut kind_buf = [0u8; 1];
+        r.read_exact(&mut kind_buf).expect("recv kind");
+        let mut data = vec![0u8; len];
+        r.read_exact(&mut data).expect("recv data");
+        (kind_buf[0], data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runner::tok_detok_msgs::MsgKind;
+
+    // End-to-end framing test: server and client are both in-process threads
+    // sharing the same `interprocess::local_socket` channel used in production.
+    #[test]
+    fn frame_roundtrip_server_client() {
+        let name = format!("vllm-rs-tokdetok-test-{}", std::process::id());
+        let name_for_server = name.clone();
+
+        let server_thread = std::thread::spawn(move || {
+            TokDetokSocketServer::bind_and_accept(&name_for_server).expect("server bind")
+        });
+
+        let client = TokDetokSocketClient::connect(&name).expect("client connect");
+        let server = server_thread.join().expect("server thread join");
+
+        // server -> client
+        server.send(b"hello", MsgKind::TokDetokInit);
+        let (k, d) = client.recv_blocking();
+        assert_eq!(k, MsgKind::TokDetokInit as u8);
+        assert_eq!(&d, b"hello");
+
+        // client -> server
+        client.send(b"world!", MsgKind::DetokenizeResp);
+        let (k, d) = server.recv_blocking();
+        assert_eq!(k, MsgKind::DetokenizeResp as u8);
+        assert_eq!(&d, b"world!");
+    }
+
+    // Empty payload must still frame correctly (len=0).
+    #[test]
+    fn frame_roundtrip_empty_payload() {
+        let name = format!("vllm-rs-tokdetok-test-empty-{}", std::process::id());
+        let name_for_server = name.clone();
+
+        let server_thread = std::thread::spawn(move || {
+            TokDetokSocketServer::bind_and_accept(&name_for_server).expect("server bind")
+        });
+
+        let client = TokDetokSocketClient::connect(&name).expect("client connect");
+        let server = server_thread.join().expect("server thread join");
+
+        server.send(b"", MsgKind::Error);
+        let (k, d) = client.recv_blocking();
+        assert_eq!(k, MsgKind::Error as u8);
+        assert!(d.is_empty());
+    }
+}

--- a/src/runner/tok_detok_socket.rs
+++ b/src/runner/tok_detok_socket.rs
@@ -1,0 +1,190 @@
+// Length-prefixed bincode framing over `interprocess::local_socket::Stream`.
+// Mirrors the `send_local`/`receive_local` pattern in `src/runner/mod.rs` so the
+// engine↔tok_detok_worker channel uses the same transport class as engine↔runner.
+//
+// Wire format: [len: u32 LE][kind: u8][bincode(payload): len bytes]
+
+use std::io::{BufReader, Read, Write};
+use std::sync::{Arc, Mutex};
+
+use interprocess::local_socket::traits::{Listener, Stream as StreamTrait};
+use interprocess::local_socket::{
+    GenericNamespaced, ListenerOptions, Stream as LocalStream, ToNsName,
+};
+
+use crate::runner::tok_detok_msgs::MsgKind;
+
+#[inline]
+fn build_frame(data: &[u8], kind: MsgKind) -> Vec<u8> {
+    let mut frame = Vec::with_capacity(4 + 1 + data.len());
+    frame.extend_from_slice(&(data.len() as u32).to_le_bytes());
+    frame.push(kind as u8);
+    frame.extend_from_slice(data);
+    frame
+}
+
+/// Pair of engine-side endpoints — one for tokenize, one for detokenize.
+/// Both connect to the same tok_detok_worker process; the worker runs them
+/// on separate threads so the two directions don't head-of-line each other.
+#[derive(Clone)]
+pub struct TokDetokIpcPair {
+    pub tok: TokDetokSocketServer,
+    pub det: TokDetokSocketServer,
+}
+
+/// Engine-side endpoint. Accepts a single tok_detok_worker connection.
+#[derive(Clone)]
+pub struct TokDetokSocketServer {
+    pub writer: Arc<Mutex<LocalStream>>,
+    pub reader: Arc<Mutex<BufReader<LocalStream>>>,
+}
+
+impl TokDetokSocketServer {
+    pub fn bind_and_accept(name: &str) -> std::io::Result<Self> {
+        let ns_name = name.to_ns_name::<GenericNamespaced>()?;
+        let listener = ListenerOptions::new().name(ns_name).create_sync()?;
+        let stream = listener.accept()?;
+        let reader_stream = interprocess::TryClone::try_clone(&stream)?;
+        Ok(Self {
+            writer: Arc::new(Mutex::new(stream)),
+            reader: Arc::new(Mutex::new(BufReader::with_capacity(
+                64 * 1024,
+                reader_stream,
+            ))),
+        })
+    }
+
+    #[inline]
+    pub fn send(&self, data: &[u8], kind: MsgKind) {
+        let frame = build_frame(data, kind);
+        let mut w = self.writer.lock().unwrap();
+        let _ = w.write_all(&frame);
+    }
+
+    /// Returns `Ok(None)` on clean peer disconnect (the worker process exit
+    /// closes its half of the socket pair). All other I/O errors bubble.
+    pub fn recv_blocking(&self) -> std::io::Result<Option<(u8, Vec<u8>)>> {
+        let mut r = self.reader.lock().unwrap();
+        let mut len_buf = [0u8; 4];
+        match r.read_exact(&mut len_buf) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+            Err(e) => return Err(e),
+        }
+        let len = u32::from_le_bytes(len_buf) as usize;
+        let mut kind_buf = [0u8; 1];
+        r.read_exact(&mut kind_buf)?;
+        let mut data = vec![0u8; len];
+        r.read_exact(&mut data)?;
+        Ok(Some((kind_buf[0], data)))
+    }
+}
+
+/// Worker-side endpoint. Connects to the engine's listener.
+pub struct TokDetokSocketClient {
+    pub writer: Arc<Mutex<LocalStream>>,
+    pub reader: Arc<Mutex<BufReader<LocalStream>>>,
+}
+
+impl TokDetokSocketClient {
+    pub fn connect(name: &str) -> std::io::Result<Self> {
+        let ns_name = name.to_ns_name::<GenericNamespaced>()?;
+        for _ in 0..600 {
+            if let Ok(stream) = LocalStream::connect(ns_name.clone()) {
+                let reader_stream = interprocess::TryClone::try_clone(&stream)?;
+                return Ok(Self {
+                    writer: Arc::new(Mutex::new(stream)),
+                    reader: Arc::new(Mutex::new(BufReader::with_capacity(
+                        64 * 1024,
+                        reader_stream,
+                    ))),
+                });
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        Err(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "tok_detok_socket connect timeout",
+        ))
+    }
+
+    #[inline]
+    pub fn send(&self, data: &[u8], kind: MsgKind) {
+        let frame = build_frame(data, kind);
+        let mut w = self.writer.lock().unwrap();
+        let _ = w.write_all(&frame);
+    }
+
+    /// Returns `Ok(None)` on clean peer disconnect (`UnexpectedEof` on the
+    /// length-prefix read). Engine shutdown closes the socket, so the
+    /// worker's recv loop must distinguish that from a real I/O error.
+    /// All other read failures (truncated frame, transport error) bubble
+    /// up as `Err`.
+    pub fn recv_blocking(&self) -> std::io::Result<Option<(u8, Vec<u8>)>> {
+        let mut r = self.reader.lock().unwrap();
+        let mut len_buf = [0u8; 4];
+        match r.read_exact(&mut len_buf) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+            Err(e) => return Err(e),
+        }
+        let len = u32::from_le_bytes(len_buf) as usize;
+        let mut kind_buf = [0u8; 1];
+        r.read_exact(&mut kind_buf)?;
+        let mut data = vec![0u8; len];
+        r.read_exact(&mut data)?;
+        Ok(Some((kind_buf[0], data)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runner::tok_detok_msgs::MsgKind;
+
+    // End-to-end framing test: server and client are both in-process threads
+    // sharing the same `interprocess::local_socket` channel used in production.
+    #[test]
+    fn frame_roundtrip_server_client() {
+        let name = format!("xinfer-tokdetok-test-{}", std::process::id());
+        let name_for_server = name.clone();
+
+        let server_thread = std::thread::spawn(move || {
+            TokDetokSocketServer::bind_and_accept(&name_for_server).expect("server bind")
+        });
+
+        let client = TokDetokSocketClient::connect(&name).expect("client connect");
+        let server = server_thread.join().expect("server thread join");
+
+        // server -> client
+        server.send(b"hello", MsgKind::TokDetokInit);
+        let (k, d) = client.recv_blocking().expect("recv").expect("frame");
+        assert_eq!(k, MsgKind::TokDetokInit as u8);
+        assert_eq!(&d, b"hello");
+
+        // client -> server
+        client.send(b"world!", MsgKind::DetokenizeResp);
+        let (k, d) = server.recv_blocking().expect("recv").expect("frame");
+        assert_eq!(k, MsgKind::DetokenizeResp as u8);
+        assert_eq!(&d, b"world!");
+    }
+
+    // Empty payload must still frame correctly (len=0).
+    #[test]
+    fn frame_roundtrip_empty_payload() {
+        let name = format!("xinfer-tokdetok-test-empty-{}", std::process::id());
+        let name_for_server = name.clone();
+
+        let server_thread = std::thread::spawn(move || {
+            TokDetokSocketServer::bind_and_accept(&name_for_server).expect("server bind")
+        });
+
+        let client = TokDetokSocketClient::connect(&name).expect("client connect");
+        let server = server_thread.join().expect("server thread join");
+
+        server.send(b"", MsgKind::Error);
+        let (k, d) = client.recv_blocking().expect("recv").expect("frame");
+        assert_eq!(k, MsgKind::Error as u8);
+        assert!(d.is_empty());
+    }
+}

--- a/src/runner/tok_detok_worker.rs
+++ b/src/runner/tok_detok_worker.rs
@@ -1,0 +1,134 @@
+// tok_detok_worker — runs tokenization and detokenization in a separate
+// process, using two threads on two sockets so tokenize and detokenize
+// requests don't head-of-line each other:
+//
+//     thread A ↔ TOK_DETOK_SOCKET_TOK   (Tokenize / TokenizeResp / Error)
+//     thread B ↔ TOK_DETOK_SOCKET_DET   (Detokenize / DetokenizeResp / Error)
+//
+// Both threads share a single `Arc<Tokenizer>` (encode_fast / decode are
+// thread-safe). Engine spawns this binary and binds two namespaced sockets;
+// names are passed to the worker via env. Init is delivered on the tok
+// socket and carries the model paths + GGUF flag.
+
+use std::sync::Arc;
+use std::thread;
+
+use vllm_rs::log_info;
+use vllm_rs::runner::tok_detok_msgs::{
+    DetokenizeReq, DetokenizeResp, MsgKind, TokDetokInit, TokenizeReq, TokenizeResp, WorkerError,
+};
+use vllm_rs::runner::tok_detok_socket::TokDetokSocketClient;
+use vllm_rs::utils::downloader::ModelPaths;
+use vllm_rs::utils::gguf_helper::get_gguf_info;
+
+use tokenizers::Tokenizer;
+
+fn load_tokenizer(paths: &ModelPaths, is_gguf: bool) -> anyhow::Result<Tokenizer> {
+    if is_gguf {
+        let file = std::fs::File::open(&paths.get_weight_filenames()[0])?;
+        let mut readers = vec![file];
+        let mut readers = readers.iter_mut().collect::<Vec<_>>();
+        let content = vllm_rs::utils::gguf_helper::Content::from_readers(&mut readers)
+            .map_err(|_| anyhow::anyhow!("Unable to read GGUF"))?;
+        let info = get_gguf_info(&content)?;
+        Ok(info.tokenizer)
+    } else {
+        let tokenizer_file = paths.get_tokenizer_filename();
+        let tok = Tokenizer::from_file(&tokenizer_file)
+            .map_err(|e| anyhow::anyhow!("load tokenizer: {:?}", e))?;
+        Ok(tok)
+    }
+}
+
+fn run_tok_loop(client: TokDetokSocketClient, tokenizer: Arc<Tokenizer>) -> anyhow::Result<()> {
+    loop {
+        let (kind, data) = client.recv_blocking();
+        if kind != MsgKind::Tokenize as u8 {
+            continue;
+        }
+        let req: TokenizeReq = bincode::deserialize(&data)?;
+        match tokenizer.encode_fast(req.prompt.as_str(), true) {
+            Ok(tokens) => {
+                let ids: Vec<u32> = tokens.get_ids().iter().copied().collect();
+                let resp = TokenizeResp {
+                    token_ids: ids,
+                    prompt_len: tokens.len(),
+                };
+                let bytes = bincode::serialize(&resp)?;
+                client.send(&bytes, MsgKind::TokenizeResp);
+            }
+            Err(e) => {
+                let bytes = bincode::serialize(&WorkerError {
+                    msg: format!("tokenize error: {e:?}"),
+                })?;
+                client.send(&bytes, MsgKind::Error);
+            }
+        }
+    }
+}
+
+fn run_det_loop(client: TokDetokSocketClient, tokenizer: Arc<Tokenizer>) -> anyhow::Result<()> {
+    loop {
+        let (kind, data) = client.recv_blocking();
+        if kind != MsgKind::Detokenize as u8 {
+            continue;
+        }
+        let req: DetokenizeReq = bincode::deserialize(&data)?;
+        match tokenizer.decode(&req.token_ids, req.skip_special_tokens) {
+            Ok(text) => {
+                let resp = DetokenizeResp { text };
+                let bytes = bincode::serialize(&resp)?;
+                client.send(&bytes, MsgKind::DetokenizeResp);
+            }
+            Err(e) => {
+                let bytes = bincode::serialize(&WorkerError {
+                    msg: format!("detokenize error: {e:?}"),
+                })?;
+                client.send(&bytes, MsgKind::Error);
+            }
+        }
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    log_info!("tok_detok_worker starting");
+    let tok_sock = std::env::var("TOK_DETOK_SOCKET_TOK").expect("TOK_DETOK_SOCKET_TOK missing");
+    let det_sock = std::env::var("TOK_DETOK_SOCKET_DET").expect("TOK_DETOK_SOCKET_DET missing");
+
+    log_info!(
+        "tok_detok_worker connecting tok={} det={}",
+        tok_sock,
+        det_sock
+    );
+    let tok_client = TokDetokSocketClient::connect(&tok_sock)?;
+    let det_client = TokDetokSocketClient::connect(&det_sock)?;
+
+    // Init arrives on the tok socket; carries shared config for both threads.
+    let (kind, data) = tok_client.recv_blocking();
+    if kind != MsgKind::TokDetokInit as u8 {
+        anyhow::bail!("Expected TokDetokInit on tok socket, got kind={}", kind);
+    }
+    let init: TokDetokInit = bincode::deserialize(&data)?;
+    let tokenizer = Arc::new(load_tokenizer(&init.model_paths, init.is_gguf)?);
+    log_info!(
+        "tok_detok_worker tokenizer loaded (is_gguf={}); spawning two service threads",
+        init.is_gguf
+    );
+
+    let tokenizer_for_tok = Arc::clone(&tokenizer);
+    let tok_handle = thread::spawn(move || {
+        if let Err(e) = run_tok_loop(tok_client, tokenizer_for_tok) {
+            eprintln!("tok_detok_worker: tok loop exited: {e:?}");
+        }
+    });
+    let tokenizer_for_det = Arc::clone(&tokenizer);
+    let det_handle = thread::spawn(move || {
+        if let Err(e) = run_det_loop(det_client, tokenizer_for_det) {
+            eprintln!("tok_detok_worker: det loop exited: {e:?}");
+        }
+    });
+
+    let _ = tok_handle.join();
+    let _ = det_handle.join();
+    Ok(())
+}

--- a/src/runner/tok_detok_worker.rs
+++ b/src/runner/tok_detok_worker.rs
@@ -1,0 +1,144 @@
+// tok_detok_worker — runs tokenization and detokenization in a separate
+// process, using two threads on two sockets so tokenize and detokenize
+// requests don't head-of-line each other:
+//
+//     thread A ↔ XINFER_TOK_DETOK_SOCKET_TOK   (Tokenize / TokenizeResp / Error)
+//     thread B ↔ XINFER_TOK_DETOK_SOCKET_DET   (Detokenize / DetokenizeResp / Error)
+//
+// Both threads share a single `Arc<Tokenizer>` (encode_fast / decode are
+// thread-safe). Engine spawns this binary and binds two namespaced sockets;
+// names are passed to the worker via env. Init is delivered on the tok
+// socket and carries the model paths + GGUF flag.
+
+use std::sync::Arc;
+use std::thread;
+
+use xinfer::log_info;
+use xinfer::runner::tok_detok_msgs::{
+    DetokenizeReq, DetokenizeResp, MsgKind, TokDetokInit, TokenizeReq, TokenizeResp, WorkerError,
+};
+use xinfer::runner::tok_detok_socket::TokDetokSocketClient;
+use xinfer::utils::downloader::ModelPaths;
+use xinfer::utils::gguf_helper::get_gguf_info;
+
+use tokenizers::Tokenizer;
+
+fn load_tokenizer(paths: &ModelPaths, is_gguf: bool) -> anyhow::Result<Tokenizer> {
+    if is_gguf {
+        let file = std::fs::File::open(&paths.get_weight_filenames()[0])?;
+        let mut readers = vec![file];
+        let mut readers = readers.iter_mut().collect::<Vec<_>>();
+        let content = xinfer::utils::gguf_helper::Content::from_readers(&mut readers)
+            .map_err(|_| anyhow::anyhow!("Unable to read GGUF"))?;
+        let info = get_gguf_info(&content)?;
+        Ok(info.tokenizer)
+    } else {
+        let tokenizer_file = paths.get_tokenizer_filename();
+        let tok = Tokenizer::from_file(&tokenizer_file)
+            .map_err(|e| anyhow::anyhow!("load tokenizer: {:?}", e))?;
+        Ok(tok)
+    }
+}
+
+fn run_tok_loop(client: TokDetokSocketClient, tokenizer: Arc<Tokenizer>) -> anyhow::Result<()> {
+    loop {
+        // `None` = engine closed its half of the socket on shutdown; exit cleanly.
+        let (kind, data) = match client.recv_blocking()? {
+            Some(frame) => frame,
+            None => return Ok(()),
+        };
+        if kind != MsgKind::Tokenize as u8 {
+            continue;
+        }
+        let req: TokenizeReq = bincode::deserialize(&data)?;
+        match tokenizer.encode_fast(req.prompt.as_str(), true) {
+            Ok(tokens) => {
+                let ids: Vec<u32> = tokens.get_ids().iter().copied().collect();
+                let resp = TokenizeResp {
+                    token_ids: ids,
+                    prompt_len: tokens.len(),
+                };
+                let bytes = bincode::serialize(&resp)?;
+                client.send(&bytes, MsgKind::TokenizeResp);
+            }
+            Err(e) => {
+                let bytes = bincode::serialize(&WorkerError {
+                    msg: format!("tokenize error: {e:?}"),
+                })?;
+                client.send(&bytes, MsgKind::Error);
+            }
+        }
+    }
+}
+
+fn run_det_loop(client: TokDetokSocketClient, tokenizer: Arc<Tokenizer>) -> anyhow::Result<()> {
+    loop {
+        // `None` = engine closed its half of the socket on shutdown; exit cleanly.
+        let (kind, data) = match client.recv_blocking()? {
+            Some(frame) => frame,
+            None => return Ok(()),
+        };
+        if kind != MsgKind::Detokenize as u8 {
+            continue;
+        }
+        let req: DetokenizeReq = bincode::deserialize(&data)?;
+        match tokenizer.decode(&req.token_ids, req.skip_special_tokens) {
+            Ok(text) => {
+                let resp = DetokenizeResp { text };
+                let bytes = bincode::serialize(&resp)?;
+                client.send(&bytes, MsgKind::DetokenizeResp);
+            }
+            Err(e) => {
+                let bytes = bincode::serialize(&WorkerError {
+                    msg: format!("detokenize error: {e:?}"),
+                })?;
+                client.send(&bytes, MsgKind::Error);
+            }
+        }
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    log_info!("tok_detok_worker starting");
+    let tok_sock = std::env::var("XINFER_TOK_DETOK_SOCKET_TOK").expect("XINFER_TOK_DETOK_SOCKET_TOK missing");
+    let det_sock = std::env::var("XINFER_TOK_DETOK_SOCKET_DET").expect("XINFER_TOK_DETOK_SOCKET_DET missing");
+
+    log_info!(
+        "tok_detok_worker connecting tok={} det={}",
+        tok_sock,
+        det_sock
+    );
+    let tok_client = TokDetokSocketClient::connect(&tok_sock)?;
+    let det_client = TokDetokSocketClient::connect(&det_sock)?;
+
+    // Init arrives on the tok socket; carries shared config for both threads.
+    let (kind, data) = tok_client
+        .recv_blocking()?
+        .ok_or_else(|| anyhow::anyhow!("engine closed tok socket before sending TokDetokInit"))?;
+    if kind != MsgKind::TokDetokInit as u8 {
+        anyhow::bail!("Expected TokDetokInit on tok socket, got kind={}", kind);
+    }
+    let init: TokDetokInit = bincode::deserialize(&data)?;
+    let tokenizer = Arc::new(load_tokenizer(&init.model_paths, init.is_gguf)?);
+    log_info!(
+        "tok_detok_worker tokenizer loaded (is_gguf={}); spawning two service threads",
+        init.is_gguf
+    );
+
+    let tokenizer_for_tok = Arc::clone(&tokenizer);
+    let tok_handle = thread::spawn(move || {
+        if let Err(e) = run_tok_loop(tok_client, tokenizer_for_tok) {
+            eprintln!("tok_detok_worker: tok loop exited: {e:?}");
+        }
+    });
+    let tokenizer_for_det = Arc::clone(&tokenizer);
+    let det_handle = thread::spawn(move || {
+        if let Err(e) = run_det_loop(det_client, tokenizer_for_det) {
+            eprintln!("tok_detok_worker: det loop exited: {e:?}");
+        }
+    });
+
+    let _ = tok_handle.join();
+    let _ = det_handle.join();
+    Ok(())
+}

--- a/src/runner/tokenizer_service.rs
+++ b/src/runner/tokenizer_service.rs
@@ -1,0 +1,122 @@
+// TokenizerService — single dispatch enum for the engine's hot-path
+// tokenize/detokenize calls. Mirrors the `RunnerType::{Thread, Process}`
+// shape in `src/core/runner.rs`: keep every variant's complexity off the
+// engine hot path, and let future variants (inference-firewall,
+// grammar-aware, remote multi-model) plug in by adding a variant rather
+// than threading another `Option<...>` through every call site.
+
+use std::sync::Arc;
+
+use anyhow::{anyhow, bail, Result};
+use tokenizers::Tokenizer;
+
+use crate::runner::tok_detok_msgs::{
+    DetokenizeReq, DetokenizeResp, MsgKind, TokenizeReq, TokenizeResp,
+};
+use crate::runner::tok_detok_socket::TokDetokIpcPair;
+
+#[derive(Clone)]
+pub enum TokenizerService {
+    /// In-process tokenizer. Default. Bit-identical to pre-PR behavior.
+    Inline(Arc<Tokenizer>),
+    /// Out-of-process worker via `interprocess::local_socket`. Opt-in via
+    /// `XINFER_TOK_DETOK_WORKER=1`. `tokenizer` is still held so chat
+    /// templates, `/tokenize`, samplers, and other non-hot-path consumers
+    /// don't pay the IPC tax.
+    Worker {
+        ipc: TokDetokIpcPair,
+        tokenizer: Arc<Tokenizer>,
+    },
+}
+
+impl TokenizerService {
+    /// Underlying tokenizer — always available, even in Worker mode.
+    /// Non-hot-path consumers (chat template, `/tokenize` endpoint, stream
+    /// decoder) hold the in-process tokenizer directly via this accessor.
+    pub fn tokenizer(&self) -> &Arc<Tokenizer> {
+        match self {
+            Self::Inline(t) => t,
+            Self::Worker { tokenizer, .. } => tokenizer,
+        }
+    }
+
+    /// Hot-path encode. Returns `(token_ids, prompt_len)`.
+    pub fn encode(&self, prompt: &str) -> Result<(Vec<u32>, usize)> {
+        match self {
+            Self::Inline(tok) => {
+                let enc = tok
+                    .encode_fast(prompt, true)
+                    .map_err(|e| anyhow!("encode failed: {e:?}"))?;
+                let ids: Vec<u32> = enc.get_ids().to_vec();
+                let len = ids.len();
+                Ok((ids, len))
+            }
+            Self::Worker { ipc, .. } => {
+                let req = TokenizeReq {
+                    prompt: prompt.to_string(),
+                };
+                let bytes = bincode::serialize(&req)?;
+                ipc.tok.send(&bytes, MsgKind::Tokenize);
+                let (kind, data) = ipc
+                    .tok
+                    .recv_blocking()?
+                    .ok_or_else(|| anyhow!("tok_detok_worker tok socket closed"))?;
+                if kind != MsgKind::TokenizeResp as u8 {
+                    bail!("tok_detok_worker: unexpected tok kind={}", kind);
+                }
+                let resp: TokenizeResp = bincode::deserialize(&data)?;
+                let len = resp.prompt_len;
+                Ok((resp.token_ids, len))
+            }
+        }
+    }
+
+    /// Hot-path decode of a full token sequence (one-shot, non-streaming).
+    /// Streaming decode uses `tokenizers::DecodeStream` directly against
+    /// the underlying tokenizer — see [`TokenizerService::tokenizer`].
+    pub fn decode(&self, tokens: &[u32], skip_special: bool) -> Result<String> {
+        match self {
+            Self::Inline(tok) => tok
+                .decode(tokens, skip_special)
+                .map_err(|e| anyhow!("decode failed: {e:?}")),
+            Self::Worker { ipc, .. } => {
+                let req = DetokenizeReq {
+                    token_ids: tokens.to_vec(),
+                    skip_special_tokens: skip_special,
+                };
+                let bytes = bincode::serialize(&req)?;
+                ipc.det.send(&bytes, MsgKind::Detokenize);
+                let (kind, data) = ipc
+                    .det
+                    .recv_blocking()?
+                    .ok_or_else(|| anyhow!("tok_detok_worker det socket closed"))?;
+                if kind != MsgKind::DetokenizeResp as u8 {
+                    bail!("tok_detok_worker: unexpected det kind={}", kind);
+                }
+                let resp: DetokenizeResp = bincode::deserialize(&data)?;
+                Ok(resp.text)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Inline encode/decode round-trip against a real tokenizer.
+    // We don't test the Worker variant here because it would need a live
+    // subprocess; that's covered by the integration smoke in the bench.
+    #[test]
+    fn inline_encode_decode_roundtrip() {
+        // Build a trivially-small tokenizer for the test — bytelevel BPE
+        // over ASCII is enough to exercise the round-trip plumbing.
+        let json = r#"{"version":"1.0","truncation":null,"padding":null,"added_tokens":[],"normalizer":null,"pre_tokenizer":{"type":"ByteLevel","add_prefix_space":false,"trim_offsets":true,"use_regex":true},"post_processor":null,"decoder":{"type":"ByteLevel","add_prefix_space":false,"trim_offsets":true,"use_regex":true},"model":{"type":"BPE","dropout":null,"unk_token":null,"continuing_subword_prefix":null,"end_of_word_suffix":null,"fuse_unk":false,"byte_fallback":false,"ignore_merges":false,"vocab":{"a":0,"b":1,"c":2,"d":3,"e":4,"f":5,"g":6,"h":7,"i":8,"j":9,"k":10,"l":11,"m":12,"n":13,"o":14,"p":15,"q":16,"r":17,"s":18,"t":19,"u":20,"v":21,"w":22,"x":23,"y":24,"z":25,"Ġ":26},"merges":[]}}"#;
+        let tok = Tokenizer::from_bytes(json.as_bytes()).expect("build tokenizer");
+        let svc = TokenizerService::Inline(Arc::new(tok));
+        let (ids, len) = svc.encode("hello").expect("encode");
+        assert_eq!(len, ids.len());
+        assert!(!ids.is_empty());
+        let _text = svc.decode(&ids, true).expect("decode");
+    }
+}

--- a/src/server/claude_server.rs
+++ b/src/server/claude_server.rs
@@ -3086,9 +3086,9 @@ pub async fn messages(
             ),
         )
     } else {
-        let tokenizer = {
+        let (tokenizer, tok_detok_ipc) = {
             let e = data.engine.read();
-            Arc::new(e.tokenizer.clone())
+            (Arc::new(e.tokenizer.clone()), e.tok_detok_ipc.clone())
         };
 
         let receivers = {
@@ -3118,22 +3118,28 @@ pub async fn messages(
         if let Some(ref l) = logger {
             l.log_start_response();
         }
-        let results =
-            match LLMEngine::collect_sync_results(receivers, tokenizer, logger.clone()).await {
-                Ok(results) => results,
-                Err(err) => {
-                    return ClaudeResponder::Error(
-                        ClaudeErrorResponse {
-                            response_type: "error",
-                            error: ClaudeErrorBody {
-                                error_type: "server_error".to_string(),
-                                message: format!("Failed to collect results: {err:?}"),
-                            },
+        let results = match LLMEngine::collect_sync_results(
+            receivers,
+            tokenizer,
+            logger.clone(),
+            tok_detok_ipc,
+        )
+        .await
+        {
+            Ok(results) => results,
+            Err(err) => {
+                return ClaudeResponder::Error(
+                    ClaudeErrorResponse {
+                        response_type: "error",
+                        error: ClaudeErrorBody {
+                            error_type: "server_error".to_string(),
+                            message: format!("Failed to collect results: {err:?}"),
                         },
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                    );
-                }
-            };
+                    },
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                );
+            }
+        };
 
         let output = match results.into_iter().next() {
             Some(output) => output,

--- a/src/server/claude_server.rs
+++ b/src/server/claude_server.rs
@@ -2165,9 +2165,33 @@ pub async fn messages(
     };
 
     if use_stream {
+        // Lock-hoist: preprocess (chat-template + tokenize) under engine.read().
+        let preprocessed = {
+            let e = data.engine.read();
+            match e.preprocess(
+                std::slice::from_ref(&params),
+                std::slice::from_ref(&messages),
+                &resolved_tools,
+                false,
+            ) {
+                Ok(mut p) => p.pop().expect("preprocess returned 0 items for 1 input"),
+                Err(err) => {
+                    return ClaudeResponder::Error(
+                        ClaudeErrorResponse {
+                            response_type: "error",
+                            error: ClaudeErrorBody {
+                                error_type: "invalid_request_error".to_string(),
+                                message: format!("Stream preprocess failed: {err:?}"),
+                            },
+                        },
+                        StatusCode::UNPROCESSABLE_ENTITY,
+                    );
+                }
+            }
+        };
         let (seq_id, prompt_length, prefilled_reasoning_end, stream) = {
             let mut e = data.engine.write();
-            match e.generate_stream(&params, &messages, image_data, &resolved_tools, &logger) {
+            match e.generate_stream_from_preprocessed(preprocessed, image_data, &logger) {
                 Ok((seq_id, prompt_length, prefilled_reasoning_end, stream)) => {
                     (seq_id, prompt_length, prefilled_reasoning_end, stream)
                 }
@@ -3086,20 +3110,38 @@ pub async fn messages(
             ),
         )
     } else {
-        let tokenizer = {
+        let tokenizer_service = {
             let e = data.engine.read();
-            Arc::new(e.tokenizer.clone())
+            e.tokenizer_service.clone()
         };
 
+        // Lock-hoist: preprocess (chat-template + tokenize) under engine.read().
+        let preprocessed = {
+            let e = data.engine.read();
+            match e.preprocess(
+                std::slice::from_ref(&params),
+                std::slice::from_ref(&messages),
+                &resolved_tools,
+                false,
+            ) {
+                Ok(p) => p,
+                Err(err) => {
+                    return ClaudeResponder::Error(
+                        ClaudeErrorResponse {
+                            response_type: "error",
+                            error: ClaudeErrorBody {
+                                error_type: "server_error".to_string(),
+                                message: format!("Preprocess failed: {err:?}"),
+                            },
+                        },
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                    );
+                }
+            }
+        };
         let receivers = {
             let mut e = data.engine.write();
-            match e.generate_sync(
-                &vec![params],
-                &vec![messages],
-                image_data,
-                &resolved_tools,
-                &logger,
-            ) {
+            match e.generate_sync_from_preprocessed(preprocessed, image_data, &logger) {
                 Ok(receivers) => receivers,
                 Err(err) => {
                     return ClaudeResponder::Error(
@@ -3118,22 +3160,27 @@ pub async fn messages(
         if let Some(ref l) = logger {
             l.log_start_response();
         }
-        let results =
-            match LLMEngine::collect_sync_results(receivers, tokenizer, logger.clone()).await {
-                Ok(results) => results,
-                Err(err) => {
-                    return ClaudeResponder::Error(
-                        ClaudeErrorResponse {
-                            response_type: "error",
-                            error: ClaudeErrorBody {
-                                error_type: "server_error".to_string(),
-                                message: format!("Failed to collect results: {err:?}"),
-                            },
+        let results = match LLMEngine::collect_sync_results(
+            receivers,
+            tokenizer_service,
+            logger.clone(),
+        )
+        .await
+        {
+            Ok(results) => results,
+            Err(err) => {
+                return ClaudeResponder::Error(
+                    ClaudeErrorResponse {
+                        response_type: "error",
+                        error: ClaudeErrorBody {
+                            error_type: "server_error".to_string(),
+                            message: format!("Failed to collect results: {err:?}"),
                         },
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                    );
-                }
-            };
+                    },
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                );
+            }
+        };
 
         let output = match results.into_iter().next() {
             Some(output) => output,

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -1118,9 +1118,9 @@ pub async fn chat_completion(
         let mut total_prompt_time_taken = 0f32;
         let mut total_decoded_time_taken = 0f32;
         let mut choices = Vec::new();
-        let tokenizer = {
+        let (tokenizer, tok_detok_ipc) = {
             let e = data.engine.read();
-            Arc::new(e.tokenizer.clone())
+            (Arc::new(e.tokenizer.clone()), e.tok_detok_ipc.clone())
         };
 
         crate::log_info!(
@@ -1146,16 +1146,20 @@ pub async fn chat_completion(
         if let Some(ref l) = logger {
             l.log_start_response();
         }
-        let results =
-            match LLMEngine::collect_sync_results(receivers, tokenizer.clone(), logger.clone())
-                .await
-            {
-                Ok(results) => results,
-                Err(e) => {
-                    crate::log_error!("Failed to collect completion results: {:?}", e);
-                    return ChatResponder::InternalError(format!("Internal server error {:?}", e));
-                }
-            };
+        let results = match LLMEngine::collect_sync_results(
+            receivers,
+            tokenizer.clone(),
+            logger.clone(),
+            tok_detok_ipc,
+        )
+        .await
+        {
+            Ok(results) => results,
+            Err(e) => {
+                crate::log_error!("Failed to collect completion results: {:?}", e);
+                return ChatResponder::InternalError(format!("Internal server error {:?}", e));
+            }
+        };
 
         for output in results {
             total_prompt_tokens += output.prompt_length;

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -502,9 +502,30 @@ pub async fn chat_completion(
         if let Some(sid) = session_id {
             crate::log_warn!("Stream request has session_id {sid}");
         }
+        // Lock-hoist: chat-template + tokenize under engine.read() — multiple
+        // concurrent stream handlers can run this in parallel — then take
+        // engine.write() only for the brief scheduler-add step.
+        let preprocessed = {
+            let e = data.engine.read();
+            match e.preprocess(
+                std::slice::from_ref(&params),
+                std::slice::from_ref(&messages),
+                &resolved_tools,
+                false,
+            ) {
+                Ok(mut p) => p.pop().expect("preprocess returned 0 items for 1 input"),
+                Err(e) => {
+                    crate::log_error!("Stream preprocess failed: {:?}", e);
+                    return ChatResponder::ValidationError(format!(
+                        "Stream preprocess failed: {:?}",
+                        e
+                    ));
+                }
+            }
+        };
         let (seq_id, prompt_length, prefilled_reasoning_end, stream) = {
             let mut e = data.engine.write();
-            match e.generate_stream(&params, &messages, image_data, &resolved_tools, &logger) {
+            match e.generate_stream_from_preprocessed(preprocessed, image_data, &logger) {
                 Ok((seq_id, prompt_length, prefilled_reasoning_end, stream)) => {
                     (seq_id, prompt_length, prefilled_reasoning_end, stream)
                 }
@@ -1151,24 +1172,36 @@ pub async fn chat_completion(
         let mut total_prompt_time_taken = 0f32;
         let mut total_decoded_time_taken = 0f32;
         let mut choices = Vec::new();
-        let tokenizer = {
+        let tokenizer_service = {
             let e = data.engine.read();
-            Arc::new(e.tokenizer.clone())
+            e.tokenizer_service.clone()
         };
 
         crate::log_info!(
             "Received completion request with {} messages",
             messages.len()
         );
+        // Lock-hoist: chat-template + tokenize under engine.read() (multiple
+        // concurrent handlers can run this in parallel), then take
+        // engine.write() only for the brief scheduler-add step.
+        let preprocessed = {
+            let e = data.engine.read();
+            match e.preprocess(
+                std::slice::from_ref(&current_params),
+                std::slice::from_ref(&messages),
+                &resolved_tools,
+                false,
+            ) {
+                Ok(p) => p,
+                Err(e) => {
+                    crate::log_error!("Preprocess failed: {:?}", e);
+                    return ChatResponder::InternalError(format!("Internal server error {:?}", e));
+                }
+            }
+        };
         let receivers = {
             let mut e = data.engine.write();
-            match e.generate_sync(
-                &vec![current_params.clone()],
-                &vec![messages],
-                image_data,
-                &resolved_tools,
-                &logger,
-            ) {
+            match e.generate_sync_from_preprocessed(preprocessed, image_data, &logger) {
                 Ok(receivers) => receivers,
                 Err(e) => {
                     crate::log_error!("Completion generation failed: {:?}", e);
@@ -1179,16 +1212,19 @@ pub async fn chat_completion(
         if let Some(ref l) = logger {
             l.log_start_response();
         }
-        let results =
-            match LLMEngine::collect_sync_results(receivers, tokenizer.clone(), logger.clone())
-                .await
-            {
-                Ok(results) => results,
-                Err(e) => {
-                    crate::log_error!("Failed to collect completion results: {:?}", e);
-                    return ChatResponder::InternalError(format!("Internal server error {:?}", e));
-                }
-            };
+        let results = match LLMEngine::collect_sync_results(
+            receivers,
+            tokenizer_service,
+            logger.clone(),
+        )
+        .await
+        {
+            Ok(results) => results,
+            Err(e) => {
+                crate::log_error!("Failed to collect completion results: {:?}", e);
+                return ChatResponder::InternalError(format!("Internal server error {:?}", e));
+            }
+        };
 
         // Per-seq cached counts and decode_output snapshots read after the
         // loop, summed/scanned into single figures for the response Usage.

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1580,6 +1580,35 @@ pub fn get_runner_path() -> Result<PathBuf> {
     }
 }
 
+/// Resolves the path to the `tok_detok_worker` companion binary.
+/// Mirrors `get_runner_path` so it works under pyo3 (where `current_exe()`
+/// returns the Python interpreter, not the package directory).
+pub fn get_tok_detok_worker_path() -> Result<PathBuf> {
+    #[cfg(feature = "python")]
+    {
+        Python::with_gil(|py| {
+            let module = PyModule::import(py, "vllm_rs").map_err(candle_core::Error::wrap)?;
+            let file: String = module
+                .getattr("__file__")
+                .map_err(candle_core::Error::wrap)?
+                .extract()
+                .map_err(candle_core::Error::wrap)?;
+            let module_path = Path::new(&file).parent().unwrap().join("tok_detok_worker");
+            Ok(module_path)
+        })
+    }
+
+    #[cfg(not(feature = "python"))]
+    {
+        let exe_path = std::env::current_exe()?;
+        let exe_dir = exe_path
+            .parent()
+            .ok_or("Failed to get exe directory")
+            .map_err(candle_core::Error::wrap)?;
+        Ok(exe_dir.join("tok_detok_worker"))
+    }
+}
+
 pub fn spawn_runner(
     #[cfg(feature = "python")] py: Python,
     runner_path: &str,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1657,6 +1657,35 @@ pub fn get_runner_path() -> Result<PathBuf> {
     }
 }
 
+/// Resolves the path to the `tok_detok_worker` companion binary.
+/// Mirrors `get_runner_path` so it works under pyo3 (where `current_exe()`
+/// returns the Python interpreter, not the package directory).
+pub fn get_tok_detok_worker_path() -> Result<PathBuf> {
+    #[cfg(feature = "python")]
+    {
+        Python::with_gil(|py| {
+            let module = PyModule::import(py, "xinfer").map_err(candle_core::Error::wrap)?;
+            let file: String = module
+                .getattr("__file__")
+                .map_err(candle_core::Error::wrap)?
+                .extract()
+                .map_err(candle_core::Error::wrap)?;
+            let module_path = Path::new(&file).parent().unwrap().join("tok_detok_worker");
+            Ok(module_path)
+        })
+    }
+
+    #[cfg(not(feature = "python"))]
+    {
+        let exe_path = std::env::current_exe()?;
+        let exe_dir = exe_path
+            .parent()
+            .ok_or("Failed to get exe directory")
+            .map_err(candle_core::Error::wrap)?;
+        Ok(exe_dir.join("tok_detok_worker"))
+    }
+}
+
 pub fn spawn_runner(
     #[cfg(feature = "python")] py: Python,
     runner_path: &str,


### PR DESCRIPTION
Adds opt-in companion binary `tok_detok_worker`. The engine talks to it over `interprocess::local_socket` (same transport class as engine↔runner). Off by default; enable with `VLLM_RS_TOK_DETOK_WORKER=1`.

The worker runs two service threads on two sockets — one for tokenize, one for detokenize — sharing a single `Arc<Tokenizer>`. Splitting the directions removes head-of-line blocking when concurrent requests arrive for tokenize and complete for detokenize at the same time.

Wire format: `[len: u32 LE][kind: u8][bincode(payload)]`. `MsgKind` discriminants are pinned by a unit test so a future reorder can't silently break compat with an in-flight worker.

## Numbers

Real runs across three platforms. Δ vs in-process baseline. `n` = trial count.

Hardware:

- **Mac M3 Max** — Apple M3 Max (14-core CPU, 30-core GPU, 96GB unified memory), Metal backend
- **RTX 3060** — NVIDIA GeForce RTX 3060 12GB, single GPU, CUDA + flashinfer + cutlass
- **Blackwell** — 2× NVIDIA RTX PRO 6000 Blackwell Server Edition (97GB each), CUDA + NCCL, TP=2 unless noted

### Wins

| Platform | Workload | n | Δ |
|---|---|---|---:|
| Mac M3 Max | CLI Qwen3-0.6B b=64 max=256 | 3 | **+8.1% prefill tok/s** |
| Mac M3 Max | Serving Qwen3-0.6B sharegpt c=1 | 10 | **+4.6% req/s, −5.9% TTFT** |
| RTX 3060 | Serving Qwen3-0.6B sharegpt c=32 | 5 | **−4.1% TTFT** (rps flat) |
| RTX 3060 | Serving Qwen3-1.7B sharegpt c=16 | 5 | **−3.2% TTFT** (rps flat) |
| Blackwell TP=2 | CLI Qwen3-30B-A3B b=256 max=512 | 3 | **+1.2% prefill tok/s** |

### No change

| Platform | Workload | n | Δ |
|---|---|---|---:|
| Mac M3 Max | Serving Qwen3-1.7B sharegpt c=1 | 10 | flat |
| Mac M3 Max | Serving Qwen3-4B sharegpt c=1 | 10 | rps +1.9%, TTFT −0.6% |
| RTX 3060 | Serving Qwen3-0.6B sharegpt c=1 | 10 | flat |
| RTX 3060 | Serving Qwen3-1.7B sharegpt c=1 | 10 | flat |
| Blackwell TP=1 | Serving Qwen3-14B sharegpt c=1 | 10 | flat |
| Blackwell TP=2 | Serving Qwen3-30B-A3B sharegpt c=1 | 10 | flat |

### Regressions

| Platform | Workload | n | Δ |
|---|---|---|---:|
| RTX 3060 | CLI Qwen3-0.6B b=64 max=256 | 3 | **−2.7% prefill** |
| RTX 3060 | CLI Qwen3-1.7B b=64 | 3 | −3.7% prefill |
| RTX 3060 | CLI Qwen3-0.6B b=128 / b=256 | 3 | −1.5% to −3.1% prefill |
| Blackwell TP=1 | CLI Qwen3-0.6B b=64 | 1 | −1.7% prefill |

Decode tok/s unchanged in every cell tested.

Extracting tokenize+detokenize parallelizes encode/decode work onto a different core and removes serial waits on the request handler. Visible as TTFT reduction at high serving concurrency, and as prefill throughput gain on slower-tokenizer paths (Mac) and on big-batch big-model configs (Blackwell 30B-A3B TP=2 b=256). On fast-CUDA at small batch, tokenization is already a tiny fraction of wall time, so the per-call IPC round-trip shows up as a small (~−2-4%) prefill regression.
