### PR TITLE
Enable chunked prefill batching

### DIFF
--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -762,103 +762,116 @@ impl LLMEngine {
         }
     }
 
-    pub fn step(&mut self) -> Result<usize> {
-        pub struct DecodedIds(Either<Vec<usize>, Vec<usize>>);
-
-        // Get scheduled sequence indexes and prefill flag
+    /// Phase 1: Schedule sequences and prepare data for the forward pass.
+    /// Returns (scheduled_ids, is_prefill, cloned_sequences) or None if no work.
+    pub fn prepare_step(&mut self) -> Result<Option<(Vec<usize>, bool, Vec<Sequence>)>> {
         let (scheduled_ids, is_prefill) = match self.scheduler.schedule() {
             Ok((ids, prefill)) => (ids, prefill),
             Err(_) => (vec![], true),
         };
-        let decoded_ids = if !scheduled_ids.is_empty() {
-            if is_prefill {
-                let downgraded = self
-                    .scheduler
-                    .fallback_missing_mamba_prefix_snapshots(&scheduled_ids)?;
-                if downgraded > 0 {
-                    crate::log_warn!(
-                        "Prefill fallback: {} sequence(s) downgraded to full prefill due to missing mamba snapshots.",
-                        downgraded
-                    );
-                }
+        if scheduled_ids.is_empty() {
+            return Ok(None);
+        }
+
+        if is_prefill {
+            let downgraded = self
+                .scheduler
+                .fallback_missing_mamba_prefix_snapshots(&scheduled_ids)?;
+            if downgraded > 0 {
+                crate::log_warn!(
+                    "Prefill fallback: {} sequence(s) downgraded to full prefill due to missing mamba snapshots.",
+                    downgraded
+                );
             }
+        }
 
-            // Get immutable references to scheduled sequences for model_runner
-            let seqs = self.scheduler.get_sequences(&scheduled_ids);
+        let seqs = self.scheduler.get_sequences(&scheduled_ids);
+        let owned_seqs: Vec<Sequence> = seqs.iter().map(|s| (*s).clone()).collect();
+        Ok(Some((scheduled_ids, is_prefill, owned_seqs)))
+    }
 
-            let output_ids = match &mut *self.runners.write() {
-                RunnerType::Thread(model_runner) => {
-                    // Run model on the scheduled sequences in the main thread
-                    model_runner.run(Seqs::SeqRefs(&seqs), is_prefill)?
-                }
-                RunnerType::Process(ref mut runner_streams) => {
-                    let request = if is_prefill {
-                        let sequences = seqs.iter().map(|s| (*s).clone()).collect::<Vec<_>>();
-                        MessageType::RunPrefill((sequences, true))
-                    } else {
-                        let sequences = seqs
-                            .iter()
-                            .map(|s| DecodeSequence::new(s))
-                            .collect::<Vec<_>>();
-                        MessageType::RunDecode((sequences, false))
-                    };
+    /// Phase 2: Run the forward pass. Does NOT require the engine lock - only the runner lock.
+    pub fn run_forward(
+        runners: &Arc<RwLock<RunnerType>>,
+        owned_seqs: &[Sequence],
+        is_prefill: bool,
+    ) -> Result<Vec<u32>> {
+        match &mut *runners.write() {
+            RunnerType::Thread(model_runner) => {
+                let seq_refs: Vec<&Sequence> = owned_seqs.iter().collect();
+                model_runner.run(Seqs::SeqRefs(&seq_refs), is_prefill)
+            }
+            RunnerType::Process(ref mut runner_streams) => {
+                let request = if is_prefill {
+                    MessageType::RunPrefill((owned_seqs.to_vec(), true))
+                } else {
+                    let sequences = owned_seqs
+                        .iter()
+                        .map(|s| DecodeSequence::new(s))
+                        .collect::<Vec<_>>();
+                    MessageType::RunDecode((sequences, false))
+                };
 
-                    let cloned_streams: Vec<LocalStream> = runner_streams
-                        .iter_mut()
-                        .map(|s| s.try_clone().expect("clone failed"))
-                        .collect();
+                let cloned_streams: Vec<LocalStream> = runner_streams
+                    .iter_mut()
+                    .map(|s| s.try_clone().expect("clone failed"))
+                    .collect();
 
-                    let all_outputs: Result<Vec<Vec<u32>>> = cloned_streams
-                        .into_par_iter()
-                        .map(|mut stream| {
-                            let msg = request.clone();
-                            send_local(&mut vec![stream.try_clone()?], &msg, false)?;
-                            let response = receive_local(&mut stream, false)?;
+                let all_outputs: Result<Vec<Vec<u32>>> = cloned_streams
+                    .into_par_iter()
+                    .map(|mut stream| {
+                        let msg = request.clone();
+                        send_local(&mut vec![stream.try_clone()?], &msg, false)?;
+                        let response = receive_local(&mut stream, false)?;
 
-                            match response {
-                                MessageType::RunResponse(output_ids) => {
-                                    if output_ids.len() == 0 {
-                                        candle_core::bail!("Runner step error, no response!")
-                                    } else {
-                                        Ok(output_ids)
-                                    }
-                                }
-                                other => {
-                                    candle_core::bail!("Unexpected response type: {:?}", other)
+                        match response {
+                            MessageType::RunResponse(output_ids) => {
+                                if output_ids.len() == 0 {
+                                    candle_core::bail!("Runner step error, no response!")
+                                } else {
+                                    Ok(output_ids)
                                 }
                             }
-                        })
-                        .collect();
+                            other => {
+                                candle_core::bail!("Unexpected response type: {:?}", other)
+                            }
+                        }
+                    })
+                    .collect();
 
-                    let all_outputs = all_outputs.map_err(candle_core::Error::wrap)?;
-                    // Only run postprocess once after all runners finish (use first result)
-                    if let Some(output_ids) = all_outputs.first() {
-                        output_ids.clone()
-                        // self.scheduler.postprocess(&scheduled_ids, output_ids);
-                    } else {
-                        candle_core::bail!("No output ids received from model runners");
-                    }
-                }
-            };
-            // Postprocess sequences by modifying them inside the scheduler
-            if is_prefill {
-                let (indices, finished_indices) =
-                    self.scheduler.filter_prefill_finished(&scheduled_ids);
-                if indices.is_empty() {
-                    //chunked prefill, no finished
-                    self.check_canceled(None);
-                    return Ok(0);
+                let all_outputs = all_outputs.map_err(candle_core::Error::wrap)?;
+                if let Some(output_ids) = all_outputs.first() {
+                    Ok(output_ids.clone())
                 } else {
-                    let output_ids: Vec<u32> = indices.iter().map(|&i| output_ids[i]).collect();
-                    self.scheduler.postprocess(&finished_indices, &output_ids);
-                    DecodedIds(Either::Left(finished_indices))
+                    candle_core::bail!("No output ids received from model runners");
                 }
+            }
+        }
+    }
+
+    /// Phase 3: Postprocess forward pass results, deliver tokens, and do maintenance.
+    pub fn finish_step(
+        &mut self,
+        scheduled_ids: Vec<usize>,
+        is_prefill: bool,
+        output_ids: Vec<u32>,
+    ) -> Result<usize> {
+        pub struct DecodedIds(Either<Vec<usize>, Vec<usize>>);
+
+        let decoded_ids = if is_prefill {
+            let (indices, finished_indices) =
+                self.scheduler.filter_prefill_finished(&scheduled_ids);
+            if indices.is_empty() {
+                self.check_canceled(None);
+                return Ok(0);
             } else {
-                self.scheduler.postprocess(&scheduled_ids, &output_ids);
-                DecodedIds(Either::Left(scheduled_ids))
+                let output_ids: Vec<u32> = indices.iter().map(|&i| output_ids[i]).collect();
+                self.scheduler.postprocess(&finished_indices, &output_ids);
+                DecodedIds(Either::Left(finished_indices))
             }
         } else {
-            DecodedIds(Either::Right(vec![]))
+            self.scheduler.postprocess(&scheduled_ids, &output_ids);
+            DecodedIds(Either::Left(scheduled_ids))
         };
 
         let (indices, is_running): (&Vec<usize>, bool) = match &decoded_ids.0 {
@@ -866,6 +879,7 @@ impl LLMEngine {
             Either::Right(indices) => (indices, false),
         };
 
+        let mut prefill_batch: Vec<(usize, usize, f32, bool)> = Vec::new();
         for &idx in indices {
             let sq = if is_running {
                 self.scheduler.get_running(idx)
@@ -952,18 +966,12 @@ impl LLMEngine {
 
                         let time_costs = cur_time - s.created_time();
                         if time_costs / 100 > 0 && s.len() > 0 {
-                            crate::log_info!(
-                                "Prefilling [seq_id {}]: {} tokens in {:.2}s ({:.2} tokens/s{})",
+                            prefill_batch.push((
                                 seq_id,
                                 s.len(),
                                 time_costs as f32 / 1000f32,
-                                s.len() as f32 / (time_costs as f32 * 1.0f32 / 1000f32),
-                                if s.num_cached_tokens > 0 {
-                                    ", cache included"
-                                } else {
-                                    ""
-                                },
-                            )
+                                s.num_cached_tokens > 0,
+                            ));
                         }
                     }
 
@@ -1022,6 +1030,27 @@ impl LLMEngine {
                         }
                     }
                 }
+            }
+        }
+
+        if !prefill_batch.is_empty() {
+            let seq_ids: Vec<usize> = prefill_batch.iter().map(|(id, _, _, _)| *id).collect();
+            let total_tokens: usize = prefill_batch.iter().map(|(_, t, _, _)| *t).sum();
+            let max_time: f32 = prefill_batch
+                .iter()
+                .map(|(_, _, t, _)| *t)
+                .fold(0.0f32, f32::max);
+            let has_cache = prefill_batch.iter().any(|(_, _, _, c)| *c);
+            if max_time > 0.0 {
+                crate::log_info!(
+                    "Prefilling {} seq(s) {:?}: {} total tokens in {:.2}s ({:.2} tokens/s{})",
+                    prefill_batch.len(),
+                    seq_ids,
+                    total_tokens,
+                    max_time,
+                    total_tokens as f32 / max_time,
+                    if has_cache { ", cache included" } else { "" },
+                );
             }
         }
         self.scheduler.clear_finished();
@@ -1609,14 +1638,16 @@ impl LLMEngine {
     pub fn start_engine(engine: Arc<RwLock<Self>>) {
         GLOBAL_RT.spawn(async move {
             let engine = engine.clone();
-            let is_pd_server = {
+            let (is_pd_server, runners) = {
                 let guard = engine.read();
-                guard.is_pd_mode() && guard.is_pd_server()
+                (
+                    guard.is_pd_mode() && guard.is_pd_server(),
+                    guard.runners.clone(),
+                )
             };
             loop {
                 let idle = {
                     let guard = engine.read();
-                    //no add_request in PD server, marking it always active
                     guard.is_idle() && !is_pd_server
                 };
 
@@ -1626,20 +1657,49 @@ impl LLMEngine {
                 }
 
                 let mut task_processed = 0;
-                {
+
+                // Phase 1: Schedule (engine lock held briefly)
+                let prep = {
                     let mut guard = engine.write();
-                    match guard.step() {
-                        Ok(n_tasks) => {
-                            task_processed = n_tasks;
+                    match guard.prepare_step() {
+                        Ok(p) => p,
+                        Err(e) => {
+                            crate::log_error!("[Engine Loop] Prepare error: {:?}", e);
+                            if !guard.cancel_all_with_reason(Some(e.to_string())) {
+                                std::process::exit(1);
+                            }
+                            None
+                        }
+                    }
+                };
+                // Engine lock released -- server can accept new requests during forward pass
+
+                if let Some((scheduled_ids, is_prefill, owned_seqs)) = prep {
+                    // Phase 2: Forward pass (only runner lock, engine lock FREE)
+                    match Self::run_forward(&runners, &owned_seqs, is_prefill) {
+                        Ok(output_ids) => {
+                            // Phase 3: Postprocess (engine lock held briefly)
+                            let mut guard = engine.write();
+                            match guard.finish_step(scheduled_ids, is_prefill, output_ids) {
+                                Ok(n) => task_processed = n,
+                                Err(e) => {
+                                    crate::log_error!("[Engine Loop] Finish error: {:?}", e);
+                                    if !guard.cancel_all_with_reason(Some(e.to_string())) {
+                                        std::process::exit(1);
+                                    }
+                                }
+                            }
                         }
                         Err(e) => {
-                            crate::log_error!("[Engine Loop] Step error: {:?}", e);
+                            crate::log_error!("[Engine Loop] Forward error: {:?}", e);
+                            let mut guard = engine.write();
                             if !guard.cancel_all_with_reason(Some(e.to_string())) {
                                 std::process::exit(1);
                             }
                         }
                     }
                 }
+
                 if task_processed == 0 {
                     tokio::time::sleep(tokio::time::Duration::from_millis(if is_pd_server {
                         PD_PREFILL_STATUS_CHECK_COOLING_PERIOD as u64

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -1074,7 +1074,11 @@ impl ModelRunner {
         // Handle cached prefix KV reuse
         let (block_tables, context_lens) = if cu_seqlens_k.last() > cu_seqlens_q.last() {
             let block_tables_t = self.prepare_block_tables(seqs)?;
-            let context_lens: Vec<u32> = seqs.iter().map(|seq| seq.len() as u32).collect();
+            let context_lens: Vec<u32> = seqs
+                .iter()
+                .zip(prefill_tokens.iter())
+                .map(|(seq, &num_tokens)| (seq.num_cached_tokens + num_tokens) as u32)
+                .collect();
             let context_lens = Tensor::from_vec(context_lens, seqs.len(), &self.device)?;
             (Some(block_tables_t), Some(context_lens))
         } else {

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -196,9 +196,11 @@ impl Scheduler {
     }
 
     /// Schedule sequences and return their indexes in `running` along with prefill flag
+    #[allow(non_snake_case)]
     pub fn schedule(&mut self) -> Result<(Vec<usize>, bool)> {
         let mut scheduled_ids = Vec::new();
         let mut num_tokens = 0;
+        let CHUNK_SIZE: usize = if cfg!(feature = "cuda") { 8192 } else { 4096 };
 
         // PD server: Check for new incoming prefill requests
         if self.is_pd_server() {
@@ -227,17 +229,25 @@ impl Scheduler {
         }
 
         // Prefill phase: move sequences from waiting to running if possible
+        // Use effective chunk tokens (not full sequence length) for budget accounting
+        // to enable batched prefill of multiple sequences per step.
+        // Capture running count before this batch so the interleave check only
+        // considers pre-existing decode sequences, not ones added in this loop.
+        let pre_existing_running = self.running.len();
         while let Some(mut seq) = self.waiting.pop_front() {
             // Try to transfer prefill requests to PD server when applicable
             if self.is_pd_mode() && !self.is_pd_server() && self.try_transfer(&mut seq) {
                 break;
             }
 
+            let effective_tokens = std::cmp::min(CHUNK_SIZE, seq.len() - seq.num_cached_tokens);
+
             if scheduled_ids.len() >= std::cmp::max(self.cfg.max_num_seqs, MIN_NUM_SCHEDULED_REQS)
-                || num_tokens + seq.len() >= self.cfg.max_num_batched_tokens - 1
+                || num_tokens + effective_tokens >= self.cfg.max_num_batched_tokens - 1
                 || (seq.block_table.is_empty() && !self.block_manager.can_allocate(&seq))
-                // interleaved scheduling
-                || (self.is_last_prefill && self.running.len() > 0)
+                // interleaved scheduling: alternate prefill/decode for fairness
+                // only block when there are pre-existing decode sequences
+                || (self.is_last_prefill && pre_existing_running > 0)
             {
                 // Put it back and break out if cannot schedule more
                 self.waiting.push_front(seq);
@@ -248,7 +258,7 @@ impl Scheduler {
                 self.block_manager.allocate(&mut seq)?;
             }
             seq.status = SequenceStatus::Running;
-            num_tokens += seq.len();
+            num_tokens += effective_tokens;
             self.running.push(seq);
             scheduled_ids.push(self.running.len() - 1); // index of newly pushed seq
         }
@@ -685,6 +695,8 @@ impl Scheduler {
     ) -> (Vec<usize>, Vec<usize>) {
         let mut finished_seqs = Vec::new();
         let mut remove_ids = Vec::new();
+        let mut chunked_info: Vec<(usize, usize, usize)> = Vec::new(); // (seq_id, cached, remain)
+        let mut chunk_finished_info: Vec<(usize, usize)> = Vec::new(); // (seq_id, total_len)
         let CHUNK_SIZE: usize = if cfg!(feature = "cuda") { 8192 } else { 4096 };
         for (i, id) in scheduled_ids.iter().enumerate() {
             if *id < self.running.len() {
@@ -693,31 +705,50 @@ impl Scheduler {
                     self.block_manager
                         .capture_mamba_prefix_state(seq, seq.len());
                     if seq.len() > CHUNK_SIZE {
-                        crate::log_warn!(
-                            "Seq {} - chunk prefill finished ({} tokens)",
-                            seq.id,
-                            seq.len()
-                        );
+                        chunk_finished_info.push((seq.id, seq.len()));
                     }
                     finished_seqs.push((i, seq.id));
                 } else {
                     self.block_manager
                         .capture_mamba_prefix_state(seq, seq.num_cached_tokens + CHUNK_SIZE);
                     remove_ids.push(seq.id);
-                    //unfinished due to chunked_prefill, push back to waiting list
                     let mut seq = seq.clone();
-                    seq.num_cached_tokens += CHUNK_SIZE; //current prefilled CHUNK_SIZE
+                    seq.num_cached_tokens += CHUNK_SIZE;
                     seq.status = SequenceStatus::Waiting;
-                    crate::log_info!(
-                        "Seq {} - chunk prefilled {} (remain {} tokens)",
+                    chunked_info.push((
                         seq.id,
                         seq.num_cached_tokens,
-                        seq.len() - seq.num_cached_tokens
-                    );
+                        seq.len() - seq.num_cached_tokens,
+                    ));
                     self.waiting.push_back(seq);
                 }
             }
         }
+
+        if !chunked_info.is_empty() {
+            let total_chunked: usize = chunked_info.iter().map(|(_, c, _)| *c).sum();
+            let seq_details: Vec<String> = chunked_info
+                .iter()
+                .map(|(id, cached, remain)| format!("{}:{}/{}", id, cached, cached + remain))
+                .collect();
+            crate::log_info!(
+                "Chunk prefilled {} seq(s) [{}] ({} total tokens processed)",
+                chunked_info.len(),
+                seq_details.join(", "),
+                total_chunked
+            );
+        }
+        if !chunk_finished_info.is_empty() {
+            let seq_ids: Vec<usize> = chunk_finished_info.iter().map(|(id, _)| *id).collect();
+            let total: usize = chunk_finished_info.iter().map(|(_, len)| len).sum();
+            crate::log_warn!(
+                "Chunk prefill finished for {} seq(s) {:?} ({} total tokens)",
+                chunk_finished_info.len(),
+                seq_ids,
+                total
+            );
+        }
+
         self.running.retain(|s| !remove_ids.contains(&s.id));
         let (indices, finished_ids): (Vec<usize>, Vec<usize>) = finished_seqs.into_iter().unzip();
         let finished_indices: Vec<usize> = finished_ids


### PR DESCRIPTION
Chunked prefill requests can be processed in batch

**Before:**

```
2026-05-07T08:56:38.447957Z  INFO vllm_rs::server::server: Received completion request with 1 messages
2026-05-07T08:56:38.447957Z  INFO vllm_rs::server::server: Received completion request with 1 messages
2026-05-07T08:56:38.466555Z  INFO vllm_rs::server::server: Received completion request with 1 messages
2026-05-07T08:56:38.850228Z  INFO vllm_rs::core::runner: User's thinking preference for reasoning models: None
2026-05-07T08:56:38.850265Z  WARN vllm_rs::core::runner: Using user's sampling params: temp=Some(0.7), top_k=Some(20), top_p=Some(0.95), freq_penalty=None, pres_penalty=None
2026-05-07T08:56:40.183555Z  INFO vllm_rs::core::scheduler: Seq 20 - chunk prefilled 8192 (remain 31827 tokens)
2026-05-07T08:56:40.183596Z  INFO vllm_rs::core::scheduler: Seq 21 - chunk prefilled 8192 (remain 31827 tokens)
2026-05-07T08:56:40.183612Z  INFO vllm_rs::core::scheduler: Seq 22 - chunk prefilled 8192 (remain 31827 tokens)
2026-05-07T08:56:40.831610Z  INFO vllm_rs::core::scheduler: Seq 20 - chunk prefilled 16384 (remain 23635 tokens)
2026-05-07T08:56:41.697997Z  INFO vllm_rs::core::scheduler: Seq 21 - chunk prefilled 16384 (remain 23635 tokens)
2026-05-07T08:56:42.342409Z  INFO vllm_rs::core::scheduler: Seq 22 - chunk prefilled 16384 (remain 23635 tokens)
2026-05-07T08:56:43.097914Z  INFO vllm_rs::core::scheduler: Seq 20 - chunk prefilled 24576 (remain 15443 tokens)
2026-05-07T08:56:43.878486Z  INFO vllm_rs::core::scheduler: Seq 21 - chunk prefilled 24576 (remain 15443 tokens)
2026-05-07T08:56:44.814074Z  INFO vllm_rs::core::scheduler: Seq 22 - chunk prefilled 24576 (remain 15443 tokens)
2026-05-07T08:56:45.697528Z  INFO vllm_rs::core::scheduler: Seq 20 - chunk prefilled 32768 (remain 7251 tokens)
2026-05-07T08:56:46.602376Z  INFO vllm_rs::core::scheduler: Seq 21 - chunk prefilled 32768 (remain 7251 tokens)
2026-05-07T08:56:47.535776Z  INFO vllm_rs::core::scheduler: Seq 22 - chunk prefilled 32768 (remain 7251 tokens)
2026-05-07T08:56:48.421715Z  WARN vllm_rs::core::scheduler: Seq 20 - chunk prefill finished (40019 tokens)
2026-05-07T08:56:48.421766Z  INFO vllm_rs::core::engine: Prefilling [seq_id 20]: 40020 tokens in 9.92s (4034.68 tokens/s, cache included)
2026-05-07T08:56:50.483318Z  WARN vllm_rs::core::scheduler: Seq 21 - chunk prefill finished (40019 tokens)
2026-05-07T08:56:50.483356Z  WARN vllm_rs::core::scheduler: Seq 22 - chunk prefill finished (40019 tokens)
2026-05-07T08:56:50.483374Z  INFO vllm_rs::core::engine: Prefilling [seq_id 21]: 40020 tokens in 11.94s (3350.36 tokens/s, cache included)
2026-05-07T08:56:50.483391Z  INFO vllm_rs::core::engine: Prefilling [seq_id 22]: 40020 tokens in 11.90s (3363.59 tokens/s, cache included)
```

**After:**

```
2026-05-07T09:58:07.919276Z  INFO vllm_rs::server::server: Received completion request with 1 messages
2026-05-07T09:58:07.919492Z  INFO vllm_rs::server::server: Received completion request with 1 messages
2026-05-07T09:58:07.931791Z  INFO vllm_rs::server::server: Received completion request with 1 messages
2026-05-07T09:58:09.562435Z  INFO vllm_rs::core::scheduler: Chunk prefilled 3 seq(s) [0, 1, 2] to 8192 tokens (remain 7820)
2026-05-07T09:58:11.268943Z  WARN vllm_rs::core::scheduler: Chunk prefill finished for 3 seq(s) [0, 1, 2] (48036 total tokens)
2026-05-07T09:58:11.269027Z  INFO vllm_rs::core::engine: Prefilling 3 seq(s) [0, 1, 2]: 48039 total tokens in 3.32s (14478.30 tokens/s, cache included)
```
