### PR TITLE
Improve request admission & mamba cache allocation

### DIFF
--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -58,6 +58,8 @@ pub static GLOBAL_RT: Lazy<Runtime> = Lazy::new(|| {
         .expect("Failed to build global Tokio runtime")
 });
 
+const REQUEST_ADMISSION_DECODE_BUDGET_TOKENS: usize = 4096;
+
 #[derive(Debug, Clone)]
 pub enum StreamItem {
     Token(String, u32), //streaming: (text, token_id)
@@ -530,17 +532,27 @@ impl LLMEngine {
                 .max_tokens
                 .unwrap_or(self.econfig.max_tokens.unwrap_or(16384)),
         );
-        let max_tokens = params.max_tokens.unwrap();
+        let mut max_tokens = params.max_tokens.unwrap();
+        let requested_max_tokens = max_tokens;
 
         let max_model_len = self.econfig.max_model_len.unwrap_or(max_tokens);
         //we also need to consider prompt length
         if length + max_tokens > max_model_len {
-            params.max_tokens = Some(max_model_len - length);
+            max_tokens = max_model_len - length;
+            params.max_tokens = Some(max_tokens);
             log_warn!(
-                "Adjusted max_tokens to {} to fit within max_model_len {} (with prompt length {})",
+                "Adjusted max_tokens to {} to fit within max_model_len {} (with prompt length {}, requested max_tokens {})",
                 max_tokens,
                 max_model_len,
-                length
+                length,
+                requested_max_tokens
+            );
+        }
+        if max_tokens == 0 {
+            candle_core::bail!(
+                "Inputs token length {} leaves no room for generated tokens within max_model_len {}",
+                length,
+                max_model_len
             );
         }
 
@@ -594,26 +606,54 @@ impl LLMEngine {
             image_idx,
         );
 
-        let mut required_blocks = self.scheduler.block_manager.required_blocks(&seq);
+        let prompt_required_blocks = self.scheduler.block_manager.required_blocks(&seq);
+        let requested_decode_blocks = max_tokens.div_ceil(self.econfig.block_size);
+        let minimum_decode_budget_tokens = max_tokens.min(REQUEST_ADMISSION_DECODE_BUDGET_TOKENS);
+        let minimum_decode_blocks = minimum_decode_budget_tokens.div_ceil(self.econfig.block_size);
+        let mut target_required_blocks =
+            prompt_required_blocks.saturating_add(requested_decode_blocks);
+        let mut minimum_required_blocks =
+            prompt_required_blocks.saturating_add(minimum_decode_blocks);
         let mut available_blocks = self.scheduler.block_manager.get_num_free_blocks();
 
-        while required_blocks > available_blocks {
-            // Release cache for unactive sessions.
-            let required_tokens = required_blocks * self.econfig.block_size;
-            if !self.try_release_cache(required_tokens) {
+        while target_required_blocks > available_blocks {
+            let target_required_tokens = target_required_blocks * self.econfig.block_size;
+            let evicted = self
+                .scheduler
+                .evict_prefix_cache_until_free(target_required_blocks);
+            if evicted > 0 {
+                crate::log_warn!(
+                    "Evicted {} prefix cache block(s) to reserve {} KV tokens for request admission (prompt + {} requested decode tokens).",
+                    evicted,
+                    target_required_tokens,
+                    max_tokens
+                );
+            }
+            if evicted == 0 && !self.try_release_cache(target_required_tokens) {
                 break;
             }
-            required_blocks = self.scheduler.block_manager.required_blocks(&seq);
+            let prompt_required_blocks = self.scheduler.block_manager.required_blocks(&seq);
+            target_required_blocks = prompt_required_blocks.saturating_add(requested_decode_blocks);
+            minimum_required_blocks = prompt_required_blocks.saturating_add(minimum_decode_blocks);
             available_blocks = self.scheduler.block_manager.get_num_free_blocks();
         }
 
-        if required_blocks > available_blocks {
+        if minimum_required_blocks > available_blocks {
             let available_tokens = available_blocks * self.econfig.block_size;
-            let required_tokens = required_blocks * self.econfig.block_size;
+            let required_tokens = minimum_required_blocks * self.econfig.block_size;
             candle_core::bail!(
-                "Remaining {} kvcache tokens, but your prompt requires {} new tokens, please request later!",
+                "Remaining {} kvcache tokens, but your request requires at least {} tokens (prompt plus {} decode budget tokens), please request later!",
                 available_tokens,
-                required_tokens
+                required_tokens,
+                minimum_decode_budget_tokens
+            );
+        }
+        if target_required_blocks > available_blocks {
+            crate::log_warn!(
+                "Request admitted with {} KV tokens available, below requested reservation {} tokens but enough for prompt plus {} decode budget tokens.",
+                available_blocks * self.econfig.block_size,
+                target_required_blocks * self.econfig.block_size,
+                minimum_decode_budget_tokens
             );
         }
         let seq_id = self.scheduler.add(seq);

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -519,26 +519,22 @@ impl ModelRunner {
             }
         }
 
-        let mut mamba_prefix_capacity = Self::effective_mamba_prefix_capacity(
-            econfig.prefix_cache.unwrap_or(false),
-            mamba_cache_capacity,
-        );
+        let prefix_cache_enabled = econfig.prefix_cache.unwrap_or(false);
+        let mut mamba_prefix_capacity =
+            Self::effective_mamba_prefix_capacity(prefix_cache_enabled, mamba_cache_capacity);
         if is_hybrid_mamba_model && econfig.mamba_slot_bytes > 0 && econfig.mamba_memory_bytes > 0 {
             let active_reserved = mamba_cache_capacity.saturating_mul(econfig.mamba_slot_bytes);
             let prefix_budget_slots = econfig.mamba_memory_bytes.saturating_sub(active_reserved)
                 / econfig.mamba_slot_bytes;
-            if prefix_budget_slots == 0 && mamba_prefix_capacity > 0 {
-                crate::log_info!(
-                    "Hybrid mamba budget leaves 0 explicit snapshot slots; using auto prefix-state capacity {}.",
-                    mamba_prefix_capacity
-                );
-            } else if mamba_prefix_capacity > prefix_budget_slots {
+            mamba_prefix_capacity = if prefix_cache_enabled {
+                prefix_budget_slots
+            } else {
+                0
+            };
+            if mamba_prefix_capacity == 0 && prefix_cache_enabled {
                 crate::log_warn!(
-                    "Capping hybrid mamba prefix-state cache from {} to {} entries by memory budget.",
-                    mamba_prefix_capacity,
-                    prefix_budget_slots
+                    "Hybrid mamba prefix-state cache disabled because the mamba memory budget leaves no snapshot slots after active slots."
                 );
-                mamba_prefix_capacity = prefix_budget_slots;
             }
         }
         match &model {

--- a/src/utils/kvcache_allocator.rs
+++ b/src/utils/kvcache_allocator.rs
@@ -25,8 +25,10 @@ use std::fmt;
 const CUDA_RESERVED_BYTES: u64 = 512 * 1024 * 1024; // 512 MB recommended minimum remaining memory
 const SIZE_IN_MB: f64 = (1024 * 1024) as f64;
 const SIZE_IN_GB: f64 = 1024.0 * 1024.0 * 1024.0;
-const DEFAULT_HYBRID_MAMBA_FRACTION: f64 = 0.1;
+const DEFAULT_HYBRID_MAMBA_FRACTION: f64 = 0.15;
 const MAX_HYBRID_MAMBA_FRACTION: f64 = 0.3;
+const HYBRID_MAMBA_ACTIVE_SLOT_MULTIPLIER: usize = 3;
+const HYBRID_MAMBA_MIN_ACTIVE_SLOTS: usize = 6;
 
 /// Represents the result of KVCache allocation planning
 #[derive(Debug, Clone)]
@@ -337,7 +339,7 @@ impl KVCacheAllocator {
             Ok(min_available) => {
                 let mut kv_budget = min_available;
                 let mut mamba_budget = 0u64;
-                let mut mamba_capacity = 0usize;
+                let mut mamba_budget_slots = 0usize;
                 let mut mamba_budget_enabled = false;
 
                 if let Some(slot_bytes) = self.hybrid_mamba_slot_bytes {
@@ -369,7 +371,7 @@ impl KVCacheAllocator {
 
                         mamba_budget = target_budget;
                         kv_budget = min_available.saturating_sub(mamba_budget);
-                        mamba_capacity = if slot_bytes == 0 {
+                        mamba_budget_slots = if slot_bytes == 0 {
                             0
                         } else {
                             (mamba_budget as usize / slot_bytes).max(1)
@@ -388,20 +390,33 @@ impl KVCacheAllocator {
                                 econfig.mamba_cache_capacity = None;
                                 return Ok(());
                             }
-                            if allocation.max_num_seqs > mamba_capacity {
+                            let active_mamba_capacity = if econfig.prefix_cache.unwrap_or(false) {
+                                econfig
+                                    .max_num_seqs
+                                    .saturating_mul(HYBRID_MAMBA_ACTIVE_SLOT_MULTIPLIER)
+                                    .max(HYBRID_MAMBA_MIN_ACTIVE_SLOTS)
+                                    .min(mamba_budget_slots)
+                            } else {
+                                mamba_budget_slots
+                            };
+                            if allocation.max_num_seqs > active_mamba_capacity {
                                 crate::log_warn!(
                                     "Clamping max_num_seqs from {} to {} due to hybrid mamba slot capacity.",
                                     allocation.max_num_seqs,
-                                    mamba_capacity
+                                    active_mamba_capacity
                                 );
-                                econfig.max_num_seqs = mamba_capacity;
+                                econfig.max_num_seqs = active_mamba_capacity;
                             }
+                            let prefix_budget_slots =
+                                mamba_budget_slots.saturating_sub(active_mamba_capacity);
                             econfig.mamba_slot_bytes = slot_bytes;
                             econfig.mamba_memory_bytes = mamba_budget as usize;
-                            econfig.mamba_cache_capacity = Some(mamba_capacity);
+                            econfig.mamba_cache_capacity = Some(active_mamba_capacity);
                             crate::log_warn!(
-                                "Hybrid Mamba Allocation: {} slot(s), {:.2} GB budget, {:.2} MB/slot, {} linear-attention layer(s), model dtype {} bytes",
-                                mamba_capacity,
+                                "Hybrid Mamba Allocation: {} active slot(s), {} prefix slot budget, {} total slot budget, {:.2} GB budget, {:.2} MB/slot, {} linear-attention layer(s), model dtype {} bytes",
+                                active_mamba_capacity,
+                                prefix_budget_slots,
+                                mamba_budget_slots,
                                 mamba_budget as f64 / SIZE_IN_GB,
                                 slot_bytes as f64 / SIZE_IN_MB,
                                 self.hybrid_num_gdn_layers,


### PR DESCRIPTION
Two improvements:

1. Make sure sufficient KV cache is reserved for requested `max_tokens` decoding tokens.
2. Preallocate more Mamba cache for prefix reuse and cap Mamba cache at a certain point, resolving excessive GPU memory usage, especially when dealing with concurrent requests.
