### PR TITLE
Support FP8 KV Cache on all CUDA and Metal platforms

### DIFF
--- a/.cursor/skills/test-model/SKILL.md
+++ b/.cursor/skills/test-model/SKILL.md
@@ -295,4 +295,4 @@ Include for each model:
 | `--prefix-cache` | Enable automatic prefix caching |
 | `--ui-server` | Enable built-in ChatGPT-like web UI |
 | `--isq <fmt>` | In-situ quantization (q2k, q3k, q4k, q5k, q6k, q8_0) |
-| `--fp8-kvcache` | Enable FP8 KV cache (no flashinfer/flashattn) |
+| `--fp8-kvcache` | Enable FP8 KV cache (all backends, flashinfer SM80+) |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vllm-rs"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 default-run = "vllm-rs"
 description = "A minimal, high-performance large language model (LLM) inference engine implementing vLLM in Rust."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.5.5", rev = "c7b61fe" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.5.5", rev = "56b5fcf" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.5.5", rev = "e143947" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.5.5", rev = "c7b61fe" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"
@@ -82,7 +82,7 @@ cuda = ["candle-core/cuda", "candle-nn/cuda", "attention-rs/cuda"]
 nccl = ["candle-core/nccl"]
 graph = ["cuda", "attention-rs/graph", "candle-core/graph"]
 cutlass = ["attention-rs/cutlass"]
-flashattn = ["attention-rs/flashattn", "attention-rs/no-fp8-kvcache"]
+flashattn = ["attention-rs/flashattn"]
 flashinfer = ["attention-rs/flashinfer"]
 metal = ["candle-core/metal", "candle-nn/metal", "attention-rs/metal", "dep:metal"]
 python = ["pyo3"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.5.4", rev = "0a4ab84" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.5.5", rev = "e143947" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"

--- a/ReadMe-CN.md
+++ b/ReadMe-CN.md
@@ -84,7 +84,7 @@
 
 支持 **Safetensor** (包含GPTQ, AWQ, MXFP4, NVFP4, FP8-blockwise 量化格式) 和 **GGUF** 格式。
 
-所有模型均支持硬件FP8 KvCache加速（需SM90+及关闭`flashinfer` 或 `flashattn` 特性）。
+所有模型均支持FP8 KvCache加速（`--fp8-kvcache`），兼容所有注意力后端：`flashinfer`（SM80+）、`flashattn`、以及 Paged Attention（V100/SM70+）。
 
 ---
 ## 📚 文档
@@ -110,7 +110,7 @@
 ## 📘 使用方法（Python）
 ### 📦 使用 pip 安装
 - 💡 **CUDA 计算能力 < 8.0**（例如 V100）需要**手动编译** （不支持 `flashattn`；或可使用 **Rust 模式**）。
-- 💡 **预编译包** 默认启用了`flashattn` 或 `flashinfer` 特性，若使用 **FP8 KV Cache**，须将其移除后手动编译。
+- 💡 **预编译包** 默认启用了 `flashinfer` 后端，在SM80+上已原生支持 **FP8 KV Cache**。
 
 > 🍎 Metal（macOS）
 ```shell
@@ -178,9 +178,9 @@ python3 -m pip install vllm_rs
 _FP8-Blockwise格式:_
 ```bash
 # CUDA (MoE, Dense) sm90+ 设备需打开`cutlass`特性以支持FP8硬件加速
-vllm-rs --m Qwen/Qwen3.6-27B-FP8 --ui-server --prefix-cache
+python3 -m vllm_rs.server --m Qwen/Qwen3.6-27B-FP8 --ui-server --prefix-cache --fp8-kvcache
 # MacOS/Metal (Dense)
-vllm-rs --m Qwen/Qwen3-4B-Instruct-2507-FP8 --ui-server --prefix-cache
+python3 -m vllm_rs.server --m Qwen/Qwen3-4B-Instruct-2507-FP8 --ui-server --prefix-cache
 ```
 
 _MXFP4 格式:_
@@ -264,7 +264,8 @@ apt-get install -y libnccl2 libnccl-dev
 编译 vLLM.rs
 ```shell
 # 只有单卡的情况下去掉 `nccl`
-# 使用FP8 KVCache 或 V100及较老的机型去掉 `flashattn/flashinfer` 和 `cutlass`特性
+# V100及较老的机型(SM70)去掉 `flashattn/flashinfer` 和 `cutlass`特性
+# SM80+(A100, RTX4090, H100等)推荐使用flashinfer，支持FP8 KVCache
 # 默认安装进/usr/local/bin，使用`--dst`更改安装目录
 ./build.sh --install --features cuda,nccl,graph,flashinfer,cutlass
 
@@ -302,7 +303,7 @@ cargo install --features metal
     <summary>多卡未量化模型</summary>
 
    ```bash
-   vllm-rs --d 0,1 --w /path/Qwen3-30B-A3B-Instruct-2507 --ui-server --prefix-cache
+   vllm-rs --d 0,1 --w /path/Qwen3-30B-A3B-Instruct-2507 --ui-server --prefix-cache --fp8-kvcache
    ```
   </details>
 
@@ -311,7 +312,7 @@ cargo install --features metal
 
   _FP8格式:_
    ```bash
-   vllm-rs --d 0,1 --w /path/Qwen3-Coder-30B-A3B-Instruct-FP8/ --ui-server --prefix-cache
+   vllm-rs --d 0,1 --w /path/Qwen3-Coder-30B-A3B-Instruct-FP8/ --ui-server --prefix-cache --fp8-kvcache
     # Or Qwen3.6-27B-FP8 / Qwen3.6-35B-A3B-FP8
    vllm-rs --m Qwen/Qwen3-Coder-Next-FP8 --ui-server --d 0,1 --prefix-cache
    ```
@@ -341,8 +342,10 @@ vllm-rs --m AxionML/Qwen3.5-2B-NVFP4 --ui-server --prefix-cache
     <summary>未量化模型运行为Q4K量化模型，同时使用FP8 KVCache</summary>
 
    ```bash
-   # 编译时去除`flashinfer` 或 `flashattn` 以使用fp8 kvcache
+   # 使用flashinfer后端（SM80+推荐）
    vllm-rs --d 0,1 --w /path/Qwen3-30B-A3B-Instruct-2507 --isq q4k --server --port 8000 --fp8-kvcache
+   # V100/SM70+ 使用paged attention后端
+   # 编译时去除`flashinfer` 和 `flashattn`
    ```
   </details>
 
@@ -440,16 +443,16 @@ pip install maturin[patchelf]  # Linux/Windows 平台
 # Naive CUDA (不带NCCL，只能用于单卡推理) 
 maturin build --release --features cuda,graph,python
 
-# CUDA (支持FP8 KV Cache，默认使用Paged attention) 
+# CUDA Paged Attention（V100/SM70+，支持FP8 KV Cache）
 ./build.sh --release --features cuda,nccl,graph,python
 
-# CUDA (Flashinfer后端，编译时间3m+) 
-./build.sh --release --features cuda,nccl,flashattn,python
+# CUDA FlashInfer后端（SM80+，支持FP8 KV Cache）
+./build.sh --release --features cuda,nccl,graph,flashinfer,cutlass,python
 
-# CUDA (Flash attention后端，编译时间5m+) 
-./build.sh --release --features cuda,nccl,flashattn,python
+# CUDA Flash Attention后端
+./build.sh --release --features cuda,nccl,graph,flashattn,cutlass,python
 
-# macOS（Metal, 支持FP8 KV Cache，但不支持多GPU推理）
+# macOS（Metal，支持FP8 KV Cache，但不支持多GPU推理）
 maturin build --release --features metal,python
 
 ```
@@ -482,7 +485,7 @@ pip install target/wheels/vllm_rs-*-cp38-abi3-*.whl --force-reinstall
 | `--frequency-penalty` | 频率惩罚，控制模型是否减少`高频重复词`的出现。<br> 数值范围 [-2, 2]，正值越大 → 重复次数越多的词惩罚越强；负值 → 越鼓励重复使用同一词 |
 | `--server`       | 显式启动API服务（未指定 `--i`、`--prompts` 或 `--batch` 时，这是默认行为）        |
 | `--i`            | 交互式CLI对话模式                                        |
-| `--fp8-kvcache`       | 使用FP8 KV Cache (flashinfer/flashattn 没有启用时生效)                 |
+| `--fp8-kvcache`       | 使用FP8 KV Cache（兼容所有后端：flashinfer SM80+、paged attention V100+、Metal）|
 | `--cpu-mem-fold`       | CPU KV Cache大小 (与GPU KV Cache的百分比，默认 0.2，取值0.1 - 10.0)              |
 | `--pd-server`       | 使用PD分离模式时，指定当前实例为PD服务器（此服务器仅用于Prefill）            |
 | `--pd-client`       | 使用PD分离模式时，指定当前实例为PD客户端（此客户端将长的上下文Prefill请求发送给PD服务器处理）|
@@ -520,9 +523,9 @@ pip install target/wheels/vllm_rs-*-cp38-abi3-*.whl --force-reinstall
 * [x] 从Hugginface Hub下载并加载模型
 * [ ] 从ModelScope下载并加载 (中国大陆地区)
 * [x] Metal/macOS平台前缀缓存
-* [x] FP8 KV Cache (CUDA)
+* [x] FP8 KV Cache (CUDA，所有后端，FlashInfer支持SM80+)
 * [x] FP8 KV Cache (Metal)
-* [ ] FP8 KV Cache (with Flash-Attn / Flashinfer)
+* [x] FP8 KV Cache (FlashInfer，SM80+)
 * [x] FP8 模型 (CUDA: MoE, Dense; Metal: Dense)
 * [ ] 支持更多模型类型（Kimi K2, GLM 5.1等）
 * [x] CPU KV Cache 卸载

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -84,7 +84,7 @@ See [**Full Performance Benchmarks →**](docs/performance.md)
 
 Supports both **Safetensor** (including GPTQ, AWQ, MXFP4, NVFP4, and FP8-blockwise formats) and **GGUF** formats.
 
-All models support hardware FP8 KV-cache acceleration (requires SM90+ and disable `flashinfer` or `flashattn`).
+All models support FP8 KV-cache acceleration (`--fp8-kvcache`). Works with all attention backends including `flashinfer` (SM80+), `flashattn`, and paged attention (V100/SM70+).
 
 ---
 ## 📚 Guides
@@ -111,8 +111,7 @@ All models support hardware FP8 KV-cache acceleration (requires SM90+ and disabl
 ### 📦 Install with pip
 - 💡 **CUDA compute capability < 8.0** (e.g., V100) requires a **manual build**  
   (no `flashattn` and `flashinfer` support; alternatively use **Rust mode**).
-- 💡 The **prebuilt wheel** is built with the `flashinfer` backend.  
-  To use **FP8 KV Cache**, you must **build manually** (remove the `flashinfer` or `flashattn` build flag).
+- 💡 The **prebuilt wheel** is built with the `flashinfer` backend and supports **FP8 KV Cache** out of the box on SM80+ (Ampere, Ada, Hopper, Blackwell).
 
 
 > 🍎 Metal (macOS)
@@ -159,7 +158,7 @@ python3 -m vllm_rs.server --m unsloth/Qwen3.5-4B-GGUF --f Qwen3.5-4B-Q3_K_M.gguf
     <summary>Multi-GPU + Safetensors model</summary>
 
 ```bash
-python3 -m vllm_rs.server --m Qwen/Qwen3.5-122B-A10B --d 0,1 --ui-server --prefix-cache
+python3 -m vllm_rs.server --m Qwen/Qwen3.5-122B-A10B --d 0,1 --ui-server --prefix-cache --fp8-kvcache
 ```
 
   </details>
@@ -309,7 +308,7 @@ By default, vllm-rs starts in **API server mode** on port 8000. Use `--i` for in
 
   ```bash
   # Replace "--ui-server" with "--server" will only start API server
-  vllm-rs --d 0,1 --m Qwen/Qwen3-30B-A3B-Instruct-2507 --ui-server --prefix-cache
+  vllm-rs --d 0,1 --m Qwen/Qwen3-30B-A3B-Instruct-2507 --ui-server --prefix-cache --fp8-kvcache
   ```
 
   </details>
@@ -331,7 +330,7 @@ _FP8-Blockwise format:_
 # CUDA (MoE, Dense), be sure to enable `cutlass` feature on sm90+
 vllm-rs --m Qwen/Qwen3.6-27B-FP8 --ui-server --prefix-cache
 # Or Qwen3-Next 80B
-vllm-rs --m Qwen/Qwen3-Coder-Next-FP8 --ui-server --d 0,1 --prefix-cache
+vllm-rs --m Qwen/Qwen3-Coder-Next-FP8 --ui-server --d 0,1 --prefix-cache --fp8-kvcache
 # MacOS/Metal
 vllm-rs --m Qwen/Qwen3.5-4B-FP8 --ui-server --prefix-cache
 ```
@@ -353,7 +352,9 @@ vllm-rs --m AxionML/Qwen3.5-2B-NVFP4 --ui-server --prefix-cache
     <summary>ISQ model + FP8 KvCache</summary>
 
   ```bash
-  # CUDA: Disabled flashinfer/flashattn feature to use fp8-kvcache
+  # CUDA with flashinfer (SM80+, recommended)
+  ./run.sh --release --features cuda,nccl,graph,flashinfer,cutlass --d 0 --m Qwen/Qwen3.6-35B-A3B --isq q4k --fp8-kvcache
+  # CUDA without flashinfer (V100/SM70+, uses paged attention)
   ./run.sh --release --features cuda,nccl,graph,cutlass --d 0 --m Qwen/Qwen3.6-35B-A3B --isq q4k --fp8-kvcache
   # MacOS/Metal
   vllm-rs --ui-server --w /path/Qwen3-4B --isq q6k
@@ -505,16 +506,16 @@ pip install maturin[patchelf]  # For Linux/Windows
 # Naive CUDA (No NCCL, single GPU only) 
 maturin build --release --features cuda,python
 
-# CUDA (with FP8 KV Cache, use Paged Attention, compatible with V100) 
+# CUDA with Paged Attention (V100/SM70+, FP8 KV Cache supported)
 ./build.sh --release --features cuda,nccl,graph,python
 
-# CUDA (Use Flash Attention backend) 
+# CUDA with Flash Attention backend
 ./build.sh --release --features cuda,nccl,graph,flashattn,cutlass,python
 
-# CUDA (Use Flashinfer backend) 
+# CUDA with FlashInfer backend (SM80+, FP8 KV Cache supported)
 ./build.sh --release --features cuda,nccl,graph,flashinfer,cutlass,python
 
-# macOS (Metal, single GPU only, with FP8 kvcache support)
+# macOS (Metal, single GPU only, FP8 KV Cache supported)
 maturin build --release --features metal,python
 ```
 
@@ -547,7 +548,7 @@ pip install target/wheels/vllm_rs-*-cp38-abi3-*.whl --force-reinstall
 | `--frequency-penalty` | Frequency penalty, controls whether the model reduces the probability of `tokens that appear too often`. <br> Range [-2, 2]. Higher positive values → stronger penalty for frequently repeated tokens; negative values → encourages more repetition |
 | `--server`       | Explicitly start API server (this is the default when no `--i`, `--prompts`, or `--batch` is given)        |
 | `--i`            | Interactive CLI chat mode                                        |
-| `--fp8-kvcache`       | Use FP8 KV Cache (when flashinfer and flashattn not enabled)                 |
+| `--fp8-kvcache`       | Use FP8 KV Cache (works with all backends: flashinfer on SM80+, paged attention on V100+, Metal) |
 | `--cpu-mem-fold`       | The percentage of CPU KVCache memory size compare to GPU (default 0.2, range from 0.1 to 10.0)              |
 | `--pd-server`       | When using PD Disaggregation, specify the current instance as the PD server (this server is only used for Prefill) |
 | `--pd-client`       | When using PD Disaggregation, specify the current instance as the PD client (this client sends long-context Prefill requests to the PD server for processing) |
@@ -586,9 +587,9 @@ pip install target/wheels/vllm_rs-*-cp38-abi3-*.whl --force-reinstall
 * [x] Model loading from hugginface hub
 * [ ] Model loading from ModelScope (China)
 * [x] Prefix cache for Metal/macOS
-* [x] FP8 KV Cache (CUDA)
+* [x] FP8 KV Cache (CUDA, all backends including FlashInfer on SM80+)
 * [x] FP8 KV Cache (Metal)
-* [ ] FP8 KV Cache (with Flash-Attn / Flashinfer)
+* [x] FP8 KV Cache (with FlashInfer, SM80+)
 * [x] FP8 Models (CUDA: MoE, Dense; Metal: Dense)
 * [ ] Additional model support (Kimi K2, GLM 5.1 etc.)
 * [x] CPU KV Cache Offloading

--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -4,7 +4,7 @@ This guide walks through building and running vLLM.rs across CUDA/Metal, differe
 
 ## Build & features
 - **Backends**: `--features cuda[,nccl,graph,flashinfer,cutlass]` or `--features metal`. CPU-only is supported but slow.
-- **Quant/accel toggles**: `fp8-kvcache` (KV in FP8, CUDA), `flashattn` or `flashinfer` (Ampere+, long compile), `--prefix-cache` (prefix KV reuse).
+- **Quant/accel toggles**: `--fp8-kvcache` (FP8 KV cache, works with all backends including flashinfer on SM80+), `flashattn` or `flashinfer` (Ampere+), `--prefix-cache` (prefix KV reuse).
 - **Python bindings**: add feature `python` when building wheels (`./build.sh --features python`).
 
 ### Build (CUDA)
@@ -89,7 +89,7 @@ Reasoning defaults to enabled when a request omits `thinking` / `enable_thinking
 ## Troubleshooting & tuning
 - Use `--log` to view loading/progress; watch for “swap” messages (KV pressure).
 - If OOM on Metal, lower `--max-model-len` and batch; on CUDA, reduce `--kv-fraction` or `--max-num-seqs`.
-- For GGUF/ISQ, keep `--max-num-seqs` moderate to avoid bandwidth bottlenecks; consider `--fp8-kvcache` only on Ampere+.
+- For GGUF/ISQ, keep `--max-num-seqs` moderate to avoid bandwidth bottlenecks; `--fp8-kvcache` is supported on all CUDA GPUs (SM70+) and Metal.
 - Use the chat logger to monitor detailed interactions between client and vLLM.rs.
 
 ```shell

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -1190,6 +1190,7 @@ impl ModelRunner {
                         params.page_size,
                         params.out_dtype,
                         None,
+                        Some(params.kv_dtype),
                     )?)
                 }
             };

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -448,13 +448,6 @@ impl EngineConfig {
             device_ids.push(0);
         }
 
-        if prefix_cache.unwrap_or(false)
-            && fp8_kvcache.unwrap_or(false)
-            && cfg!(feature = "flashattn")
-        {
-            panic!("Error: prefix-cache and fp8 kvcache are not compatible under the current settings!\n\t***Tips: use only one of the two features (`--fp8-kvcache` or `--prefix-cache`).");
-        }
-
         Self {
             model_id,
             weight_path,

--- a/src/utils/kvcache_allocator.rs
+++ b/src/utils/kvcache_allocator.rs
@@ -752,6 +752,21 @@ impl KVCacheAllocator {
         #[cfg(not(feature = "cuda"))]
         let _ = pd_config;
 
+        #[cfg(all(feature = "flashattn", not(feature = "flashinfer"), feature = "cuda"))]
+        if self.fp8_kvcache {
+            let sm = device
+                .as_cuda_device()
+                .ok()
+                .and_then(|d| attention_rs::cuda_utils::sm_version(d))
+                .unwrap_or(0);
+            if sm == 90 {
+                candle_core::bail!(
+                    "FP8 KV cache with FlashAttention requires SM90 (Hopper), \
+                     but detected SM{sm}. Use FlashInfer backend for FP8 KV cache on current GPU."
+                );
+            }
+        }
+
         let cache_dtype = if self.fp8_kvcache { DType::U8 } else { dtype };
         crate::log_warn!(
             "Using FP8 KV Cache? {}, cache dtype {:?}",
@@ -805,13 +820,6 @@ impl KVCacheAllocator {
             }
             Ok((gpu_cache, cpu_cache))
         } else if cfg!(feature = "flashinfer") || cfg!(feature = "flashattn") {
-            if cfg!(feature = "flashattn") {
-                assert!(
-                    !self.fp8_kvcache,
-                    "fp8 kvcache is not compatible with flashattn feature!"
-                );
-            }
-
             let element_size = cache_dtype.size_in_bytes();
             let x = 16 / element_size;
 


### PR DESCRIPTION
Tested case:

```
./run.sh --features cuda,nccl,flashinfer,cutlass,graph --release \
   --w /data/Qwen3.6-27B-FP8/ --ui-server --port 9000 \
   --prefix-cache --fp8-kvcache
```