### PR TITLE
Dockerfile: nccl resolved pins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,12 @@ ARG CHINA_MIRROR=0
 RUN set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends --allow-change-held-packages \
-    libnccl-dev libnccl2 \
+    libnccl-dev=$(apt-cache madison libnccl-dev|grep $(echo $CUDA_VERSION|cut -d'.' -f1,2)|head -1|cut -d' ' -f3) \
+    libnccl2=$(apt-cache madison libnccl2|grep $(echo $CUDA_VERSION|cut -d'.' -f1,2)|head -1|cut -d' ' -f5) \
     curl git ca-certificates \
     libssl-dev pkg-config \
     clang libclang-dev \
-    python3-pip; \
+    python3-pip && \
   rm -rf /var/lib/apt/lists/*
 
 RUN set -eux; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ ARG CHINA_MIRROR=0
 RUN set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends --allow-change-held-packages \
-    libnccl-dev=$(apt-cache madison libnccl-dev|grep $(echo $CUDA_VERSION|cut -d'.' -f1,2)|head -1|cut -d' ' -f3) \
-    libnccl2=$(apt-cache madison libnccl2|grep $(echo $CUDA_VERSION|cut -d'.' -f1,2)|head -1|cut -d' ' -f5) \
+    libnccl-dev=$(apt-cache madison libnccl-dev | awk -v cuda="$(echo "$CUDA_VERSION" | cut -d'.' -f1,2)" '$0 ~ cuda {print $3; exit}') \
+    libnccl2=$(apt-cache madison libnccl2 | awk -v cuda="$(echo "$CUDA_VERSION" | cut -d'.' -f1,2)" '$0 ~ cuda {print $3; exit}') \
     curl git ca-certificates \
     libssl-dev pkg-config \
     clang libclang-dev \

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -7,11 +7,9 @@ FROM docker.io/nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu${UBUNTU_VERSION} AS ru
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN <<HEREDOC
-    NCCLVER="$(apt-cache madison libnccl2 | \
-      grep $(dpkg -l cuda-libraries* |awk '/cuda-lib/{print$3}'|cut -d'.' -f 1,2)|head -1|awk '{print$3}')"
     apt-get update && \
     apt-get install -y --no-install-recommends --allow-change-held-packages \
-        libnccl2=$NCCLVER \
+        libnccl2=$(apt-cache madison libnccl2|grep $(echo $CUDA_VERSION|cut -d'.' -f1,2)|head -1|cut -d' ' -f5) \
         libomp-dev \
         ca-certificates \
         libssl-dev \

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -9,7 +9,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN <<HEREDOC
     apt-get update && \
     apt-get install -y --no-install-recommends --allow-change-held-packages \
-        libnccl2=$(apt-cache madison libnccl2|grep $(echo $CUDA_VERSION|cut -d'.' -f1,2)|head -1|cut -d' ' -f5) \
+        libnccl2=$(apt-cache madison libnccl2 | awk -v cuda="$(echo "$CUDA_VERSION" | cut -d'.' -f1,2)" '$0 ~ cuda {print $3; exit}') \
         libomp-dev \
         ca-certificates \
         libssl-dev \


### PR DESCRIPTION
Apt is evil ... enforce NCCL for the selected CUDA version in both containers so that build and runtime targets are correct.