### PR TITLE
Improve model precision on SM70/SM75

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xinfer"
-version = "0.12.5"
+version = "0.12.6"
 edition = "2021"
 default-run = "xinfer"
 description = "xInfer — a minimal, high-performance large language model (LLM) inference engine in Rust."

--- a/ReadMe-CN.md
+++ b/ReadMe-CN.md
@@ -16,6 +16,7 @@
 | **🌍** | 跨平台 | CUDA（Linux/Windows）、Metal（macOS），统一二进制，统一 API |
 | **🏭** | 生产就绪 | OpenAI/Anthropic 兼容 API、内置 ChatGPT 风格 Web UI、MCP 工具调用、结构化输出、Embedding + 分词器端点 |
 | **🗜️** | 极致 KV 压缩 | TurboQuant（`2–4 位` KV 缓存）以极小的质量损失将上下文扩展至 **4.3 倍**。单卡 24/32 GB GPU 即可运行 `30B+` MoE 模型并支持**百万级上下文** |
+| **🔥** | V100 + NVFP4 | 业界首创：V100 上运行 NVFP4 + 低位 KV 缓存推理 — 无需硬件 FP4，旧 GPU 重获新生 |
 | **🐍** | 轻量 Python 绑定 | 需要 Python 入口时可选 PyO3 wheel 包 |
 
 ---

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -16,6 +16,7 @@
 | **🌍** | Cross-platform | CUDA (Linux/Windows), Metal (macOS). Same binary, same API |
 | **🏭** | Production-ready | OpenAI/Anthropic-compatible APIs, built-in ChatGPT-style Web UI, MCP tool calling, structured outputs, embedding + tokenizer endpoints |
 | **🗜️** | Aggressive KV compression | TurboQuant (`2–4 bit` KV cache) extends context up to **4.3×** with minimal quality loss. Run `30B+` MoE models with **millions of context** on single 24/32 GB GPUs |
+| **🔥** | V100 + NVFP4 | First-ever NVFP4 + low-bit KV cache on V100 — no hardware FP4 needed, coherent output on legacy GPUs |
 | **🐍** | Lightweight Python bindings | Optional PyO3 wheel when you need a Python entry point |
 
 ---

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -2,26 +2,40 @@
 
 This document contains detailed performance benchmarks for xInfer across different hardware platforms.
 
-## 🚀 CUDA Performance (A100 40GB)
+## 🚀 CUDA Performance
+
+> Tested on **V100-32G**, **A100-40G**, **Hopper-80G** and **RTX 5090**
 
 ### Single Request Decoding Speed
 
-| Model | Format | Size | Decoding Speed |
-|-------|--------|------|----------------|
-| Llama-3.1-8B | ISQ (BF16→Q4K) | 8B | **90.19** tokens/s |
-| DeepSeek-R1-Distill-Llama-8B | Q2_K | 8B | **94.47** tokens/s |
-| DeepSeek-R1-0528-Qwen3-8B | Q4_K_M | 8B | **95** tokens/s |
-| GLM-4-9B-0414 | Q4_K_M | 9B | **70.38** tokens/s |
-| QwQ-32B | Q4_K_M | 32B | **35.69** tokens/s |
-| **Qwen3-30B-A3B** | Q4_K_M | **30B (MoE)** | **75.91** tokens/s |
+| Model | Format | Size | Hardware | Decoding Speed |
+|-------|--------|------|----------|----------------|
+| Qwen3-30B-A3B | NVFP4 | 30B MoE | RTX 5090 (SM120) | **175.30** tokens/s |
+| Gemma4-26B-A4B | NVFP4 | 26B MoE | RTX 5090 (SM120) | **131** tokens/s |
+| Ministral-3-3B (Multimodal) | ISQ (BF16→Q4K) | 3B | A100 (SM80) | **171.92** tokens/s |
+| DeepSeek-R1-0528-Qwen3-8B | Q4_K_M | 8B | A100 (SM80) | **124.87** tokens/s |
+| Llama-3.1-8B | ISQ (BF16→Q4K) | 8B | A100 (SM80) | **120.74** tokens/s |
+| Qwen3-VL-8B-Instruct (Multimodal) | Q8_0 | 8B | A100 (SM80) | **105.31** tokens/s |
+| Qwen3.6-35B-A3B (Multimodal) | FP8 | 35B MoE | H800 (SM90) | **102** tokens/s |
+| GLM4.7 Flash | NVFP4 | 30B MoE | H800 (SM90) | **79** tokens/s |
+| Qwen3-30B-A3B | NVFP4 | 30B MoE | V100 (SM70) | **67.10** tokens/s |
+| GLM-4-9B-0414 | Q4_K_M | 9B | A100 (SM80) | **70.38** tokens/s |
+| MiniMax-M2.5 | NVFP4 | 229B MoE | H800 ×2 (SM90) | **62** tokens/s |
+| Qwen3.5-27B (Multimodal) | Q4_K_M | 27B Dense | A100 (SM80) | **45.20** tokens/s |
+| Qwen3.5-27B/Qwen3.6-27B | FP8 | 27B Dense | H800 (SM90) | **42** tokens/s |
+| QwQ-32B | Q4_K_M | 32B | A100 (SM80) | **41.36** tokens/s |
+| Gemma4-31B | ISQ (BF16→Q4K) | 31B Dense | H800 (SM90) | **41** tokens/s |
+
+### V100 + NVFP4 + TurboQuant (First-Ever)
+
+NVFP4 models running under low-bit KV cache on V100 (SM70) — no hardware FP4 support needed.
+
+```bash
+xinfer --m AxionML/Qwen3.5-4B-NVFP4 --ui-server
+xinfer --m AxionML/Qwen3.5-4B-NVFP4 --kvcache-dtype turbo4 --ui-server
+```
 
 ## 🍎 Metal Performance (Apple Silicon M4)
-
-> Test Configuration:
-> - Models: Qwen3-0.6B (BF16), Qwen3-4B (Q4_K_M), Qwen3-8B (Q2_K)
-> - Concurrent Requests: 1 - 128
-> - Max Model Length: 512 - 2048
-> - Max Output Tokens/Request: 512 - 2048
 
 | Model | Batch Size | Output Tokens | Time (s) | Throughput (tokens/s) |
 |-------|------------|---------------|----------|----------------------|
@@ -30,36 +44,26 @@ This document contains detailed performance benchmarks for xInfer across differe
 | Qwen3-0.6B (BF16) | 1 | 456 | 9.23s | 49.42 |
 | Qwen3-4B (Q4_K_M) | 1 | 1,683 | 52.62s | 31.98 |
 | Qwen3-8B (Q2_K) | 1 | 1,300 | 80.88s | 16.07 |
+| Qwen3.5-4B (Q3_K_M) | 1 | 1,592 | 69.04s | 23.06 |
+| Qwen3.5-2B (NVFP4) | 1 | 1,883 | 60.76s | 30.99 |
+| Qwen3.5-2B (NVFP4) | 2 | 3,942 | 81.96s | 48.10 |
 
-## 📊 Performance Comparison
+## 📊 Performance Notes
 
-> Test Configuration:
-> - Model: Qwen3-0.6B (BF16)
-> - Concurrent Requests: 256
-> - Max Model Length: 1024
-> - Max Output Tokens/Request: 1024
+- **HW NVFP4**: Hardware-accelerated FP4 on Blackwell (SM120, RTX 5090/B200)
+- **HW FP8**: Hardware-accelerated FP8 on Hopper (SM90, H800/H200)
+- **SW FP4/NVFP4**: Software-emulated FP4 on Hopper (SM90) and V100 (SM70)
+- V100 + NVFP4 + TurboQuant is a first-ever combination — no other engine has achieved this
 
-| Inference Engine | Hardware | Tokens | Time (s) | Throughput (tokens/s) |
-|------------------|----------|--------|----------|----------------------|
-| vLLM (Reference) | RTX 4070 | 133,966 | 98.37 | 1,361.84 |
-| Nano-vLLM (Reference) | RTX 4070 | 133,966 | 93.41 | 1,434.13 |
-| **xInfer** | **A100** | 262,144 | 23.88 | **10,977.55** |
-| Nano-vLLM | A100 | 262,144 | 34.22 | 7,660.26 |
+## 🔧 Optimization Tips
 
-### Key Insights
-
-- **40%+ faster** than Nano-vLLM on A100
-- **7x faster** than reference implementations on consumer hardware
-- Efficient memory management with quantized models
+1. **Use KV Cache Quantization** (`--kvcache-dtype fp8|turbo8|turbo4|turbo3`) for memory efficiency — turbo4 gives 3.7× compression with good quality
+2. **Enable FlashInfer** (`flashinfer` feature, SM80+) for maximum CUDA performance
+3. **Prefix Cache** is enabled by default for multi-turn conversations
+4. **Tune `--kv-fraction`** to balance memory usage and batch size
+5. **Use PD Disaggregation** for long-context workloads to prevent decoding stalls
+6. **NVFP4 on V100** — works with TurboQuant KV cache for extended context on legacy hardware
 
 ## 🔧 Reproduce Benchmarks
 
 See [python/ReadMe.md](../python/ReadMe.md) for reproducible benchmark steps.
-
-## Optimization Tips
-
-1. **Use KV Cache Quantization** (`--kvcache-dtype fp8|turbo4|turbo3`) for memory efficiency — turbo4 gives 3.7x compression with good quality
-2. **Enable Flashinfer / Flash Attention** (`flashinfer` or `flashattn` feature) for maximum CUDA performance
-3. **Prefix Cache** is enabled by default for multi-turn conversations
-4. **Tune `--kv-fraction`** to balance memory usage and batch size
-5. **Use PD Disaggregation** for long-context workloads to prevent decoding stalls

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xinfer-ai",
-  "version": "0.12.5",
-  "assetVersion": "0.12.5",
+  "version": "0.12.6",
+  "assetVersion": "0.12.6",
   "description": "xInfer — a high-performance LLM inference engine in Rust with CUDA/Metal acceleration",
   "license": "MIT",
   "homepage": "https://github.com/guoqingbao/xinfer#readme",

--- a/pages/index.html
+++ b/pages/index.html
@@ -168,6 +168,13 @@ footer{padding:56px 0 28px;border-top:1px solid var(--c-border);position:relativ
 .foot-links a{font-size:.84rem;color:var(--c-dim);transition:.2s}.foot-links a:hover{color:var(--c-text)}
 .foot-bot{text-align:center;font-size:.77rem;color:var(--c-dim);padding-top:20px;border-top:1px solid var(--c-border)}
 
+/* --- SCROLL NAV --- */
+.scroll-nav{position:fixed;right:20px;bottom:24px;z-index:90;display:flex;flex-direction:column;gap:6px;opacity:0;transition:opacity .3s}
+.scroll-nav.vis{opacity:1}
+.scroll-nav button{width:36px;height:36px;border-radius:8px;display:flex;align-items:center;justify-content:center;
+  background:var(--c-card);border:1px solid var(--c-border);backdrop-filter:blur(10px);color:var(--c-dim);transition:.2s}
+.scroll-nav button:hover{background:var(--c-card-h);border-color:var(--c-border-h);color:var(--c-text)}
+
 /* --- ANIM --- */
 @keyframes fu{from{opacity:0;transform:translateY(18px)}to{opacity:1;transform:translateY(0)}}
 @keyframes fi{from{opacity:0}to{opacity:1}}
@@ -253,6 +260,7 @@ footer{padding:56px 0 28px;border-top:1px solid var(--c-border);position:relativ
   </div>
 </section>
 
+
 <!-- FEATURES -->
 <section id="features">
   <div class="wrap">
@@ -266,6 +274,7 @@ footer{padding:56px 0 28px;border-top:1px solid var(--c-border);position:relativ
       <div class="fcard" data-d="210"><span class="icon">🌍</span><h3 data-i="f.4t">Cross-Platform</h3><p data-i="f.4d">CUDA on Linux, Metal on macOS. Same binary, same API everywhere.</p></div>
       <div class="fcard" data-d="280"><span class="icon">🏭</span><h3 data-i="f.5t">Production Ready</h3><p data-i="f.5d">OpenAI &amp; Anthropic APIs, built-in Web UI, MCP tool calling, structured outputs.</p></div>
       <div class="fcard" data-d="350"><span class="icon">🗜️</span><h3 data-i="f.6t">KV Compression</h3><p data-i="f.6d">TurboQuant 2–4 bit KV cache extends context up to 4.3× with minimal quality loss.</p></div>
+      <div class="fcard" data-d="420"><span class="icon">🔥</span><h3 data-i="f.7t">V100 Renaissance</h3><p data-i="f.7d">NVFP4 + TurboQuant on V100 — first-ever low-bit model + KV cache on legacy GPUs. No hardware FP4 needed.</p></div>
     </div>
   </div>
 </section>
@@ -310,6 +319,27 @@ footer{padding:56px 0 28px;border-top:1px solid var(--c-border);position:relativ
     <div class="badges rv">
       <span class="bdg">Safetensors</span><span class="bdg">GGUF</span><span class="bdg hi">FP8</span><span class="bdg hi">NVFP4</span>
       <span class="bdg">MXFP4</span><span class="bdg">GPTQ</span><span class="bdg">AWQ</span><span class="bdg">ISQ</span>
+    </div>
+  </div>
+</section>
+
+<!-- KV CACHE -->
+<section id="kv">
+  <div class="wrap">
+    <p class="label rv" data-i="k.label">KV Cache</p>
+    <h2 class="stitle rv gt" data-i="k.title">TurboQuant Compression</h2>
+    <p class="sdesc rv" data-i="k.desc">Extend context length up to 4.3× with --kvcache-dtype.</p>
+    <div class="tw rv">
+      <table>
+        <thead><tr><th data-i="k.cm">Mode (--kvcache-dtype)</th><th data-i="k.cc">Compression</th><th data-i="k.cq">Quality</th><th>GPU</th></tr></thead>
+        <tbody>
+          <tr><td>default (BF16)</td><td>1×</td><td data-i="k.q1">Baseline</td><td>All</td></tr>
+          <tr><td>fp8</td><td><strong>2×</strong></td><td data-i="k.q2">Near-lossless</td><td>SM70+ / M1+</td></tr>
+          <tr><td>turbo8</td><td><strong>2.6×</strong></td><td data-i="k.q3">High quality</td><td>SM70+ / M1+</td></tr>
+          <tr><td>turbo4</td><td><strong>3.7×</strong></td><td data-i="k.q4">Best balance</td><td>SM70+ / M1+</td></tr>
+          <tr><td>turbo3</td><td><strong>4.7×</strong></td><td data-i="k.q5">Max compression</td><td>SM70+ / M1+</td></tr>
+        </tbody>
+      </table>
     </div>
   </div>
 </section>
@@ -387,6 +417,26 @@ footer{padding:56px 0 28px;border-top:1px solid var(--c-border);position:relativ
 <span class="t-x" data-i="i.e3"># Python mode</span>
 <span class="t-c">python3</span> <span class="t-f">-m</span> <span class="t-s">xinfer.server</span> <span class="t-f">--m</span> <span class="t-s">Qwen/Qwen3.6-27B-FP8</span> <span class="t-f">--ui-server</span></pre></div>
     </div>
+    <!-- V100 BANNER -->
+    <div class="rv" id="v100-banner" style="margin-top:24px;border-radius:var(--r);background:linear-gradient(135deg,rgba(56,189,248,.05),rgba(129,140,248,.03));border:1px solid rgba(56,189,248,.15);overflow:hidden">
+      <button id="v100-toggle" style="width:100%;display:flex;align-items:center;gap:10px;padding:12px 18px;background:none;border:none;cursor:pointer;text-align:left;color:inherit">
+        <span style="font-size:.65rem;font-weight:700;padding:2px 7px;border-radius:3px;background:rgba(56,189,248,.1);color:var(--c-accent);letter-spacing:.05em" data-i="bt.new">NEW</span>
+        <span style="font-size:.84rem;color:var(--c-dim);flex:1" data-i="bt.msg">Running NVFP4 models under 4-bit KV cache on V100 — first ever.</span>
+        <svg id="v100-chevron" style="width:14px;height:14px;color:var(--c-dim);transition:transform .25s;flex-shrink:0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
+      </button>
+      <div id="v100-detail" style="max-height:0;overflow:hidden;transition:max-height .3s ease">
+        <div style="padding:0 18px 14px;display:flex;flex-direction:column;gap:8px">
+          <div class="cb" style="margin:0" data-cp="xinfer --m AxionML/Qwen3.5-4B-NVFP4 --ui-server">
+            <div class="cb-h"><div class="cb-dots"><i></i><i></i><i></i></div><span class="cb-t">V100</span><button class="cpb" data-i="cp">Copy</button></div>
+            <div class="cb-b"><pre><span class="t-g">$</span> <span class="t-c">xinfer</span> <span class="t-f">--m</span> <span class="t-s">AxionML/Qwen3.5-4B-NVFP4</span> <span class="t-f">--ui-server</span></pre></div>
+          </div>
+          <div class="cb" style="margin:0" data-cp="xinfer --m AxionML/Qwen3.5-4B-NVFP4 --kvcache-dtype turbo4 --ui-server">
+            <div class="cb-h"><div class="cb-dots"><i></i><i></i><i></i></div><span class="cb-t">V100 + turbo4</span><button class="cpb" data-i="cp">Copy</button></div>
+            <div class="cb-b"><pre><span class="t-g">$</span> <span class="t-c">xinfer</span> <span class="t-f">--m</span> <span class="t-s">AxionML/Qwen3.5-4B-NVFP4</span> <span class="t-f">--kvcache-dtype</span> <span class="t-s">turbo4</span> <span class="t-f">--ui-server</span></pre></div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </section>
 
@@ -405,27 +455,6 @@ footer{padding:56px 0 28px;border-top:1px solid var(--c-border);position:relativ
     <div class="dgrid" id="dcards"></div>
     <h3 style="margin:36px 0 14px;font-size:.95rem" class="rv" data-i="d.pip">Pre-built Python Wheels (pip)</h3>
     <div class="pgrid rv" id="pgrid"></div>
-  </div>
-</section>
-
-<!-- KV CACHE -->
-<section id="kv">
-  <div class="wrap">
-    <p class="label rv" data-i="k.label">KV Cache</p>
-    <h2 class="stitle rv gt" data-i="k.title">TurboQuant Compression</h2>
-    <p class="sdesc rv" data-i="k.desc">Extend context length up to 4.3× with --kvcache-dtype.</p>
-    <div class="tw rv">
-      <table>
-        <thead><tr><th data-i="k.cm">Mode (--kvcache-dtype)</th><th data-i="k.cc">Compression</th><th data-i="k.cq">Quality</th><th>GPU</th></tr></thead>
-        <tbody>
-          <tr><td>default (BF16)</td><td>1×</td><td data-i="k.q1">Baseline</td><td>All</td></tr>
-          <tr><td>fp8</td><td><strong>2×</strong></td><td data-i="k.q2">Near-lossless</td><td>SM70+ / M1+</td></tr>
-          <tr><td>turbo8</td><td><strong>2.6×</strong></td><td data-i="k.q3">High quality</td><td>SM70+ / M1+</td></tr>
-          <tr><td>turbo4</td><td><strong>3.7×</strong></td><td data-i="k.q4">Best balance</td><td>SM70+ / M1+</td></tr>
-          <tr><td>turbo3</td><td><strong>4.7×</strong></td><td data-i="k.q5">Max compression</td><td>SM70+ / M1+</td></tr>
-        </tbody>
-      </table>
-    </div>
   </div>
 </section>
 
@@ -451,6 +480,12 @@ footer{padding:56px 0 28px;border-top:1px solid var(--c-border);position:relativ
     </div>
   </div>
 </section>
+
+<!-- SCROLL NAV -->
+<div class="scroll-nav" id="scroll-nav">
+  <button id="scroll-up" aria-label="Scroll up"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 15l-6-6-6 6"/></svg></button>
+  <button id="scroll-down" aria-label="Scroll down"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></button>
+</div>
 
 <!-- FOOTER -->
 <footer>
@@ -483,6 +518,7 @@ en:{
 'hero.sub':'No PyTorch. No Python runtime. Just fast, portable, production-ready inference.',
 'hero.term':'terminal','hero.cta1':'Get Started','hero.cta2':'View on GitHub →',
 'cp':'Copy','cpd':'Copied!',
+'bt.new':'NEW','bt.msg':'Running NVFP4 models under 4-bit KV cache on V100 — first ever.',
 'f.label':'Features','f.title':'Built for Speed & Simplicity',
 'f.desc':'Everything you need for production LLM inference — without the Python baggage.',
 'f.1t':'Zero Dependencies','f.1d':'Pure Rust backend — no PyTorch, no CUDA Python bindings, no Python runtime.',
@@ -491,10 +527,11 @@ en:{
 'f.4t':'Cross-Platform','f.4d':'CUDA on Linux, Metal on macOS. Same binary, same API everywhere.',
 'f.5t':'Production Ready','f.5d':'OpenAI & Anthropic APIs, built-in Web UI, MCP tool calling, structured outputs.',
 'f.6t':'KV Compression','f.6d':'TurboQuant 2–4 bit KV cache extends context up to 4.3× with minimal quality loss.',
+'f.7t':'V100 Renaissance','f.7d':'NVFP4 + TurboQuant on V100 — first-ever low-bit model + KV cache on legacy GPUs. No hardware FP4 needed.',
 'p.label':'Performance','p.title':'Real-World Benchmarks','p.desc':'Tested on V100, A100, Hopper H800, and RTX 5090.',
 'p.m':'Model','p.fmt':'Format','p.sz':'Size','p.hw':'Hardware','p.sp':'Speed','p.note':'Note',
 'p.n1':'HW NVFP4','p.n2':'HW FP8','p.n3':'SW quant','p.n4':'SW NVFP4 (no HW)','p.n5':'SW FP4',
-'p.fn':'* HW = hardware-accelerated. Hopper (SM90) supports HW FP8 but not HW NVFP4; Blackwell (SM120) supports both. NVFP4 on Hopper uses software emulation.',
+'p.fn':'* HW = hardware-accelerated. Hopper (SM90) supports HW FP8 but not HW NVFP4; Blackwell (SM120) supports both. NVFP4 on Hopper/V100 uses software emulation.',
 'm.label':'Models','m.title':'Supported Models & Formats',
 'm.desc':'From 3B to 397B — dense, MoE, and multimodal architectures.','m.fmts':'Supported Formats',
 'i.label':'Quick Start','i.title':'Install & Run','i.desc':'Get up and running in minutes.',
@@ -520,6 +557,7 @@ cn:{
 'hero.sub':'无需 PyTorch，无需 Python 运行时，开箱即用。',
 'hero.term':'终端','hero.cta1':'快速开始','hero.cta2':'查看 GitHub →',
 'cp':'复制','cpd':'已复制!',
+'bt.new':'新','bt.msg':'V100 上运行 NVFP4 模型 + 4-bit KV 缓存 — 业内首次。',
 'f.label':'功能特性','f.title':'为速度与简洁而生',
 'f.desc':'生产级 LLM 推理所需的一切 — 无需 Python 依赖。',
 'f.1t':'零依赖','f.1d':'纯 Rust 后端 — 无需 PyTorch、CUDA Python 绑定或 Python 运行时。',
@@ -528,10 +566,11 @@ cn:{
 'f.4t':'跨平台','f.4d':'Linux 上 CUDA，macOS 上 Metal。同一二进制，同一 API。',
 'f.5t':'生产就绪','f.5d':'OpenAI/Anthropic API、内置 Web UI、MCP 工具、结构化输出。',
 'f.6t':'KV 压缩','f.6d':'TurboQuant 2–4 bit KV 缓存，上下文扩展最高 4.3 倍。',
+'f.7t':'V100 复兴','f.7d':'V100 上 NVFP4 + TurboQuant — 业界首创低位模型 + KV 缓存在旧 GPU 上运行。无需硬件 FP4 支持。',
 'p.label':'性能','p.title':'真实基准测试','p.desc':'在 V100、A100、Hopper H800 和 RTX 5090 上测试。',
 'p.m':'模型','p.fmt':'格式','p.sz':'大小','p.hw':'硬件','p.sp':'速度','p.note':'说明',
 'p.n1':'硬件 NVFP4','p.n2':'硬件 FP8','p.n3':'软件量化','p.n4':'软件 NVFP4 (无硬件加速)','p.n5':'软件 FP4',
-'p.fn':'* HW = 硬件加速。Hopper (SM90) 支持硬件 FP8 但不支持硬件 NVFP4；Blackwell (SM120) 两者均支持。Hopper 上的 NVFP4 为软件模拟。',
+'p.fn':'* HW = 硬件加速。Hopper (SM90) 支持硬件 FP8 但不支持硬件 NVFP4；Blackwell (SM120) 两者均支持。V100/Hopper 上的 NVFP4 为软件模拟。',
 'm.label':'模型','m.title':'支持的模型与格式',
 'm.desc':'从 3B 到 397B — 稠密、MoE 和多模态架构。','m.fmts':'支持的格式',
 'i.label':'快速开始','i.title':'安装与运行','i.desc':'几分钟内即可运行。',
@@ -565,6 +604,14 @@ document.getElementById('b-en').onclick=function(){setLang('en')};
 document.getElementById('b-cn').onclick=function(){setLang('cn')};
 setLang(lang);
 
+/* ═══ V100 Banner Toggle ═══ */
+var v100t=document.getElementById('v100-toggle'),v100d=document.getElementById('v100-detail'),v100c=document.getElementById('v100-chevron'),v100open=false;
+if(v100t){v100t.onclick=function(){
+  v100open=!v100open;
+  if(v100open){v100d.style.maxHeight=v100d.scrollHeight+'px';v100c.style.transform='rotate(180deg)'}
+  else{v100d.style.maxHeight='0px';v100c.style.transform='rotate(0deg)'}
+}}
+
 /* ═══ Nav scroll ═══ */
 var nv=document.getElementById('nav');
 window.addEventListener('scroll',function(){nv.classList.toggle('scrolled',window.scrollY>30)},{passive:true});
@@ -596,7 +643,7 @@ document.querySelectorAll('.cb').forEach(function(bl){
 });
 
 /* ═══ Download cards ═══ */
-var XINFER_VER='0.12.5';
+var XINFER_VER='0.12.6';
 var DL='https://github.com/guoqingbao/xinfer/releases/download/v'+XINFER_VER+'/';
 var archs=[
   {sm:'sm70',n:'70',name:'SM70',gpu:'V100',cuda:'CUDA 12',d:0},
@@ -688,6 +735,14 @@ var pio=new IntersectionObserver(function(ee){
   });
 },{threshold:.25});
 var ps=document.getElementById('perf');if(ps)pio.observe(ps);
+
+/* ═══ Scroll Nav ═══ */
+var snav=document.getElementById('scroll-nav');
+if(snav){
+  window.addEventListener('scroll',function(){snav.classList.toggle('vis',window.scrollY>200)},{passive:true});
+  document.getElementById('scroll-up').onclick=function(){window.scrollBy({top:-window.innerHeight,behavior:'smooth'})};
+  document.getElementById('scroll-down').onclick=function(){window.scrollBy({top:window.innerHeight,behavior:'smooth'})};
+}
 
 /* ═══ Particles ═══ */
 var cv=document.createElement('canvas');

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -121,6 +121,7 @@ impl LLMEngine {
         let (mut econfig, use_runner) =
             prepare_engine_config(econfig, &config, &config_tokenizer, &mut generation_cfg);
         config.kvcache_dtype = econfig.kvcache_dtype;
+        config.is_f16_mode = dtype == DType::F16;
 
         // In case config file missing bos and eos configuration
         config.apply_generation_cfg(generation_cfg.as_ref());

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -682,6 +682,40 @@ impl ModelRunner {
             );
         }
 
+        #[cfg(feature = "cuda")]
+        if dtype == DType::F16 {
+            let sm = device
+                .as_cuda_device()
+                .ok()
+                .and_then(|d| attention_rs::cuda_utils::sm_version(d))
+                .unwrap_or(0);
+            if sm >= 80 {
+                let will_use_native_flash = {
+                    #[cfg(feature = "flashinfer")]
+                    {
+                        skip_flashinfer_init
+                    }
+                    #[cfg(all(feature = "flashattn", not(feature = "flashinfer")))]
+                    {
+                        config.kvcache_dtype.is_turboquant()
+                            || (config.kvcache_dtype.is_fp8_keys() && sm != 90)
+                    }
+                    #[cfg(not(any(feature = "flashinfer", feature = "flashattn")))]
+                    {
+                        true
+                    }
+                };
+                if will_use_native_flash {
+                    candle_core::bail!(
+                        "F16 dtype is not supported with native flash attention on SM80+ (detected SM{}). \
+                         Native flash kernels on SM80+ are compiled for BF16 only. \
+                         Use --dtype bf16 (default), or build with flashinfer/flashattn features which support F16.",
+                        sm
+                    );
+                }
+            }
+        }
+
         Ok(Self {
             model,
             gpu_kv_cache: Arc::new(Mutex::new(gpu_kv_cache)),

--- a/src/mcp/manager.rs
+++ b/src/mcp/manager.rs
@@ -219,7 +219,7 @@ impl McpClientManager {
                     let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
                     match StdioTransport::spawn_with_env(command, &args_refs, env) {
                         Ok(transport) => {
-                            let mut client = McpClient::new(transport, "xinfer", "0.12.5");
+                            let mut client = McpClient::new(transport, "xinfer", "0.12.6");
                             if let Err(err) = client.initialize() {
                                 crate::log_error!(
                                     "Failed to initialize MCP server {}: {:?}",
@@ -246,7 +246,7 @@ impl McpClientManager {
                 McpTransportType::Http { url, headers } => {
                     match super::transport::HttpTransport::new(url.clone(), headers.clone()) {
                         Ok(transport) => {
-                            let mut client = McpClient::new(transport, "xinfer", "0.12.5");
+                            let mut client = McpClient::new(transport, "xinfer", "0.12.6");
                             if let Err(err) = client.initialize() {
                                 crate::log_error!(
                                     "Failed to initialize remote MCP server {}: {:?}",

--- a/src/models/glm4.rs
+++ b/src/models/glm4.rs
@@ -76,6 +76,12 @@ impl GLM4DecoderLayer {
         .cloned()
         .collect();
 
+        let norm_dtype = if config.higher_precision_required() {
+            DType::F32
+        } else {
+            dtype
+        };
+
         let input_layernorm = rms_norm(
             config.hidden_size,
             config.rms_norm_eps,
@@ -84,7 +90,7 @@ impl GLM4DecoderLayer {
             } else {
                 vb.pp("input_layernorm").clone()
             },
-            dtype,
+            norm_dtype,
             false,
         )?;
 
@@ -96,7 +102,7 @@ impl GLM4DecoderLayer {
             } else {
                 vb.pp("post_attention_layernorm").clone()
             },
-            dtype,
+            norm_dtype,
             false,
         )?;
 
@@ -108,7 +114,7 @@ impl GLM4DecoderLayer {
             } else {
                 vb.pp("post_self_attn_layernorm").clone()
             },
-            dtype,
+            norm_dtype,
             false,
         )?;
 
@@ -120,7 +126,7 @@ impl GLM4DecoderLayer {
             } else {
                 vb.pp("post_mlp_layernorm").clone()
             },
-            dtype,
+            norm_dtype,
             false,
         )?;
 
@@ -242,6 +248,11 @@ impl GLM4ForCausalLM {
             reporter.write().set_progress(i + 1);
         }
 
+        let norm_dtype = if config.higher_precision_required() {
+            DType::F32
+        } else {
+            dtype
+        };
         let norm = rms_norm(
             config.hidden_size,
             config.rms_norm_eps,
@@ -250,7 +261,7 @@ impl GLM4ForCausalLM {
             } else {
                 vb.pp("model.norm")
             },
-            dtype,
+            norm_dtype,
             false,
         )?;
 

--- a/src/models/layers/attention.rs
+++ b/src/models/layers/attention.rs
@@ -529,12 +529,15 @@ impl Attention {
             dtype,
         )?;
 
-        let norm_dtype =
-            if is_qvar_builder || config.quant.is_some() || config.quantization_config.is_some() {
-                DType::F32
-            } else {
-                dtype
-            };
+        let norm_dtype = if is_qvar_builder
+            || config.quant.is_some()
+            || config.quantization_config.is_some()
+            || config.is_f16_mode
+        {
+            DType::F32
+        } else {
+            dtype
+        };
         let q_norm_vb = if is_qvar_builder {
             vb.pp(key_map["q_norm"])
         } else {

--- a/src/models/layers/deltanet.rs
+++ b/src/models/layers/deltanet.rs
@@ -61,6 +61,7 @@ pub struct GatedDeltaNet {
     gdn_layer_idx: usize,
     rms_norm_eps: f64,
     scale: f64,
+    kernel_dtype: DType,
 }
 
 impl GatedDeltaNet {
@@ -172,7 +173,7 @@ impl GatedDeltaNet {
                 value_dim_global,
                 projection_key_map["in_proj_z"],
                 comm.clone(),
-                dtype,
+                DType::F32,
                 |w| {
                     undo_tiled_v_heads_first_dim(
                         &w,
@@ -204,7 +205,7 @@ impl GatedDeltaNet {
                 num_v_heads_global,
                 projection_key_map["in_proj_b"],
                 comm.clone(),
-                dtype,
+                DType::F32,
                 |w| undo_tiled_v_heads_first_dim(&w, num_k_heads_global, num_v_heads_global, 1),
             )
         } else {
@@ -228,7 +229,7 @@ impl GatedDeltaNet {
                 num_v_heads_global,
                 projection_key_map["in_proj_a"],
                 comm.clone(),
-                dtype,
+                DType::F32,
                 |w| undo_tiled_v_heads_first_dim(&w, num_k_heads_global, num_v_heads_global, 1),
             )
         } else {
@@ -262,7 +263,7 @@ impl GatedDeltaNet {
                             head_v_dim,
                             projection_key_map["in_proj_qkv"],
                             comm.clone(),
-                            dtype,
+                            DType::F32,
                         )
                     } else {
                         let vb_qkv = vb.pp(projection_key_map["in_proj_qkv"]);
@@ -311,7 +312,7 @@ impl GatedDeltaNet {
                         key_dim_global * 2 + value_dim_global,
                         projection_key_map["in_proj_qkv"],
                         comm.clone(),
-                        dtype,
+                        DType::F32,
                         |w| {
                             restore_qwen35_qkv_weight(
                                 &w,
@@ -489,7 +490,7 @@ impl GatedDeltaNet {
         }
 
         let is_quantized = config.quantization_config.is_some();
-        let kernel_dtype = if vb.is_qvar_builder() {
+        let kernel_dtype = if vb.is_qvar_builder() || config.is_f16_mode {
             DType::F32
         } else {
             dtype
@@ -617,7 +618,7 @@ impl GatedDeltaNet {
                 hidden_size,
                 gdn_key_map["out_proj"],
                 comm.clone(),
-                dtype,
+                DType::F32,
                 |w| {
                     undo_tiled_v_heads_last_dim(
                         &w,
@@ -667,6 +668,7 @@ impl GatedDeltaNet {
             )
             .ok();
         let scale = 1.0f64 / (head_k_dim as f64).sqrt();
+
         Ok(Self {
             projection,
             out_proj,
@@ -686,6 +688,7 @@ impl GatedDeltaNet {
             gdn_layer_idx,
             rms_norm_eps: config.rms_norm_eps,
             scale,
+            kernel_dtype,
         })
     }
 
@@ -700,9 +703,29 @@ impl GatedDeltaNet {
         if slot_count == 0 {
             candle_core::bail!("Linear attention requires non-empty sequence slots");
         }
+        let original_dtype = xs.dtype();
+
+        // For GGUF (qvar_builder), input is already F32 — project in F32.
+        // For quantized models (FP8/NVFP4), projections need the model dtype (F16/BF16),
+        // so we project first, THEN convert to kernel_dtype for GDN core ops.
         let (token_count, _hidden) = xs.dims2()?;
         let is_prefill = input_metadata.is_prefill;
         let (q, k, v, z, b, a) = self.project_inputs(xs)?;
+
+        // Convert projection outputs to kernel_dtype for GDN core (conv1d, gating, recurrence).
+        // For GGUF and F16 mode, kernel_dtype is F32 to avoid precision loss.
+        let (q, k, v, z, b, a) = if q.dtype() != self.kernel_dtype {
+            (
+                q.to_dtype(self.kernel_dtype)?,
+                k.to_dtype(self.kernel_dtype)?,
+                v.to_dtype(self.kernel_dtype)?,
+                z.to_dtype(self.kernel_dtype)?,
+                b.to_dtype(self.kernel_dtype)?,
+                a.to_dtype(self.kernel_dtype)?,
+            )
+        } else {
+            (q, k, v, z, b, a)
+        };
         let mixed_qkv = Tensor::cat(&[&q, &k, &v], 1)?;
 
         let (kv_conv, prefill_conv_state) = if is_prefill {
@@ -815,7 +838,8 @@ impl GatedDeltaNet {
             self.head_v_dim,
         )?;
 
-        // Output projection
-        self.out_proj.forward(&gated_output.to_dtype(xs.dtype())?)
+        // Output projection — cast back to the caller's original dtype
+        self.out_proj
+            .forward(&gated_output.to_dtype(original_dtype)?)
     }
 }

--- a/src/models/layers/moe.rs
+++ b/src/models/layers/moe.rs
@@ -316,6 +316,7 @@ pub struct FusedMoe {
     all_reduce: AllReduce,
     world_size: usize,
     dtype: DType,
+    gate_dtype: DType,
 }
 
 impl FusedMoe {
@@ -497,6 +498,11 @@ This usually means packed down_proj / gate_up_proj layout was interpreted incorr
             cfg.quantization_config.is_none(),
             "Invalid quantization format!"
         );
+        let gate_dtype = if cfg.higher_precision_required() {
+            DType::F32
+        } else {
+            dtype
+        };
         let gate = linear_no_bias(
             cfg.hidden_size,
             num_experts,
@@ -504,7 +510,7 @@ This usually means packed down_proj / gate_up_proj layout was interpreted incorr
             Shard::default(),
             &None,
             &None,
-            dtype,
+            gate_dtype,
         )?;
 
         let (gate_w, up_w, down_w) = Self::load_packed(cfg, experts_vb, comm.clone())?;
@@ -525,11 +531,17 @@ This usually means packed down_proj / gate_up_proj layout was interpreted incorr
             all_reduce: AllReduce::new(comm),
             world_size,
             dtype,
+            gate_dtype,
         })
     }
 
     pub fn forward(&self, xs: &Tensor, is_prefill: bool) -> Result<Tensor> {
-        let router_logits = self.gate.forward(&xs)?.to_dtype(DType::F32)?;
+        let gate_input = if xs.dtype() != self.gate_dtype {
+            std::borrow::Cow::Owned(xs.to_dtype(self.gate_dtype)?)
+        } else {
+            std::borrow::Cow::Borrowed(xs)
+        };
+        let router_logits = self.gate.forward(&gate_input)?.to_dtype(DType::F32)?;
         let (topk_weights, topk_ids) = self.routing.route(&router_logits, is_prefill)?;
 
         self.forward_with_routing(xs, topk_weights, topk_ids, is_prefill)
@@ -1239,6 +1251,7 @@ pub struct FusedMoeFp8 {
     world_size: usize,
     dtype: DType,
     block_size: Vec<usize>,
+    gate_dtype: DType,
 }
 
 impl FusedMoeFp8 {
@@ -1282,6 +1295,11 @@ impl FusedMoeFp8 {
         let by = block_size[0]; // for scale_n
         let bx = block_size[1]; // for scale_k
 
+        let gate_dtype = if cfg.higher_precision_required() {
+            DType::F32
+        } else {
+            dtype
+        };
         let gate = linear_no_bias(
             cfg.hidden_size,
             num_experts,
@@ -1289,7 +1307,7 @@ impl FusedMoeFp8 {
             Shard::default(),
             &None,
             &None,
-            dtype,
+            gate_dtype,
         )?;
 
         let (
@@ -1499,12 +1517,18 @@ impl FusedMoeFp8 {
             world_size: comm.world_size(),
             dtype,
             block_size: vec![by, bx],
+            gate_dtype,
         })
     }
 
     pub fn forward(&self, xs: &Tensor, is_prefill: bool) -> Result<Tensor> {
         let (num_tokens, hidden_dim) = xs.dims2()?;
-        let router_logits = self.gate.forward(&xs)?.to_dtype(DType::F32)?;
+        let gate_input = if xs.dtype() != self.gate_dtype {
+            std::borrow::Cow::Owned(xs.to_dtype(self.gate_dtype)?)
+        } else {
+            std::borrow::Cow::Borrowed(xs)
+        };
+        let router_logits = self.gate.forward(&gate_input)?.to_dtype(DType::F32)?;
         let (topk_weights, topk_ids) = self.routing.route(&router_logits, is_prefill)?;
 
         let xs = if xs.dtype() == DType::F32 {
@@ -1565,6 +1589,7 @@ pub struct FusedMoeMxfp4 {
     all_reduce: AllReduce,
     world_size: usize,
     dtype: DType,
+    gate_dtype: DType,
 }
 
 impl FusedMoeMxfp4 {
@@ -1599,6 +1624,11 @@ impl FusedMoeMxfp4 {
         let moe_cfg = cfg.moe_cfg.as_ref().expect("MoE config is not available!");
         let num_experts = moe_cfg.num_experts.unwrap();
 
+        let gate_dtype = if cfg.higher_precision_required() {
+            DType::F32
+        } else {
+            dtype
+        };
         let gate = linear_no_bias(
             cfg.hidden_size,
             num_experts,
@@ -1606,7 +1636,7 @@ impl FusedMoeMxfp4 {
             Shard::default(),
             &cfg.quantization_config,
             &None,
-            dtype,
+            gate_dtype,
         )?;
 
         let mut gate_blocks_vec = Vec::new();
@@ -1711,12 +1741,18 @@ impl FusedMoeMxfp4 {
             all_reduce: AllReduce::new(comm.clone()),
             world_size: comm.world_size(),
             dtype,
+            gate_dtype,
         })
     }
 
     pub fn forward(&self, xs: &Tensor, is_prefill: bool) -> Result<Tensor> {
         let (num_tokens, hidden_dim) = xs.dims2()?;
-        let router_logits = self.gate.forward(xs)?.to_dtype(DType::F32)?;
+        let gate_input = if xs.dtype() != self.gate_dtype {
+            std::borrow::Cow::Owned(xs.to_dtype(self.gate_dtype)?)
+        } else {
+            std::borrow::Cow::Borrowed(xs)
+        };
+        let router_logits = self.gate.forward(&gate_input)?.to_dtype(DType::F32)?;
         let (topk_weights, topk_ids) = self.routing.route(&router_logits, is_prefill)?;
 
         let xs = if xs.dtype() == DType::F32 {
@@ -1775,6 +1811,7 @@ pub struct FusedMoeNvfp4 {
     world_size: usize,
     dtype: DType,
     apply_router_weight_on_input: bool,
+    gate_dtype: DType,
 }
 
 impl FusedMoeNvfp4 {
@@ -1852,6 +1889,11 @@ impl FusedMoeNvfp4 {
         let moe_cfg = cfg.moe_cfg.as_ref().expect("MoE config is not available!");
         let num_experts = moe_cfg.num_experts.unwrap();
 
+        let gate_dtype = if cfg.higher_precision_required() {
+            DType::F32
+        } else {
+            dtype
+        };
         let gate = linear_no_bias(
             cfg.hidden_size,
             num_experts,
@@ -1859,7 +1901,7 @@ impl FusedMoeNvfp4 {
             Shard::default(),
             &cfg.quantization_config,
             &None,
-            dtype,
+            gate_dtype,
         )?;
 
         Self::load_experts(
@@ -1871,6 +1913,7 @@ impl FusedMoeNvfp4 {
             comm,
             dtype,
             None,
+            gate_dtype,
         )
     }
 
@@ -1895,6 +1938,11 @@ impl FusedMoeNvfp4 {
         let moe_cfg = cfg.moe_cfg.as_ref().expect("MoE config is not available!");
         let num_experts = moe_cfg.num_experts.unwrap();
 
+        let gate_dtype = if cfg.higher_precision_required() {
+            DType::F32
+        } else {
+            dtype
+        };
         let gate = linear_no_bias(
             cfg.hidden_size,
             num_experts,
@@ -1902,7 +1950,7 @@ impl FusedMoeNvfp4 {
             Shard::default(),
             &None,
             &None,
-            dtype,
+            gate_dtype,
         )?;
 
         let bias = bias_vb.and_then(|bvb| try_load_e_score_correction_bias(bvb, num_experts));
@@ -1915,6 +1963,7 @@ impl FusedMoeNvfp4 {
             comm,
             dtype,
             bias,
+            gate_dtype,
         )
     }
 
@@ -1927,6 +1976,7 @@ impl FusedMoeNvfp4 {
         comm: Rc<Comm>,
         dtype: DType,
         bias: Option<Tensor>,
+        gate_dtype: DType,
     ) -> Result<Self> {
         let mut gate_blocks_vec = Vec::new();
         let mut gate_scales_vec = Vec::new();
@@ -2326,6 +2376,7 @@ impl FusedMoeNvfp4 {
             world_size: comm.world_size(),
             dtype,
             apply_router_weight_on_input: false,
+            gate_dtype,
         })
     }
 
@@ -2338,7 +2389,12 @@ impl FusedMoeNvfp4 {
     }
 
     pub fn forward(&self, xs: &Tensor, is_prefill: bool) -> Result<Tensor> {
-        let router_logits = self.gate.forward(xs)?.to_dtype(DType::F32)?;
+        let gate_input = if xs.dtype() != self.gate_dtype {
+            std::borrow::Cow::Owned(xs.to_dtype(self.gate_dtype)?)
+        } else {
+            std::borrow::Cow::Borrowed(xs)
+        };
+        let router_logits = self.gate.forward(&gate_input)?.to_dtype(DType::F32)?;
         let (topk_weights, topk_ids) = self.routing.route(&router_logits, is_prefill)?;
 
         self.forward_with_routing(xs, topk_weights, topk_ids, is_prefill)

--- a/src/models/llama.rs
+++ b/src/models/llama.rs
@@ -71,6 +71,12 @@ impl LLaMaDecoderLayer {
         .cloned()
         .collect();
 
+        let norm_dtype = if config.higher_precision_required() {
+            DType::F32
+        } else {
+            dtype
+        };
+
         let input_layernorm = rms_norm(
             config.hidden_size,
             config.rms_norm_eps,
@@ -79,7 +85,7 @@ impl LLaMaDecoderLayer {
             } else {
                 vb.pp("input_layernorm").clone()
             },
-            dtype,
+            norm_dtype,
             false,
         )?;
 
@@ -91,7 +97,7 @@ impl LLaMaDecoderLayer {
             } else {
                 vb.pp("post_attention_layernorm").clone()
             },
-            dtype,
+            norm_dtype,
             false,
         )?;
 
@@ -211,6 +217,11 @@ impl LLaMaForCausalLM {
             reporter.write().set_progress(i + 1);
         }
 
+        let norm_dtype = if config.higher_precision_required() {
+            DType::F32
+        } else {
+            dtype
+        };
         let norm = rms_norm(
             config.hidden_size,
             config.rms_norm_eps,
@@ -219,7 +230,7 @@ impl LLaMaForCausalLM {
             } else {
                 vb.pp("model.norm").clone()
             },
-            dtype,
+            norm_dtype,
             false,
         )?;
 

--- a/src/models/qwen3_5.rs
+++ b/src/models/qwen3_5.rs
@@ -35,8 +35,6 @@ pub struct Qwen3_5DecoderLayer {
     input_layernorm: NormX,
     post_attention_layernorm: NormX,
     rotary_emb: Option<Arc<ScalingRotaryEmbedding>>,
-    dtype: DType,
-    is_qvar_builder: bool,
 }
 
 impl Qwen3_5DecoderLayer {
@@ -131,8 +129,6 @@ impl Qwen3_5DecoderLayer {
             input_layernorm,
             post_attention_layernorm,
             rotary_emb: rotary,
-            dtype,
-            is_qvar_builder,
         })
     }
 
@@ -162,19 +158,7 @@ impl Qwen3_5DecoderLayer {
                 )?
             }
             Qwen3_5AttnType::LinearAttention(gdn) => {
-                if self.is_qvar_builder {
-                    gdn.forward(&xs, mamba_cache, input_metadata, seq_slots)?
-                } else if xs.dtype() != self.dtype {
-                    gdn.forward(
-                        &xs.to_dtype(self.dtype)?,
-                        mamba_cache,
-                        input_metadata,
-                        seq_slots,
-                    )?
-                    .to_dtype(xs.dtype())?
-                } else {
-                    gdn.forward(&xs, mamba_cache, input_metadata, seq_slots)?
-                }
+                gdn.forward(&xs, mamba_cache, input_metadata, seq_slots)?
             }
         };
 
@@ -442,7 +426,11 @@ impl Qwen3_5ForCausalLM {
 
         // Start small and let runner preallocate to the final engine capacity.
         let max_batch_size = 1;
-        let conv_cache_dtype = if is_qvar_builder { DType::F32 } else { dtype };
+        let conv_cache_dtype = if is_qvar_builder || config.is_f16_mode {
+            DType::F32
+        } else {
+            dtype
+        };
         let mamba_cache = if num_gdn_layers > 0 {
             MambaCache::new(
                 num_gdn_layers,

--- a/src/models/qwen3_5_moe.rs
+++ b/src/models/qwen3_5_moe.rs
@@ -72,8 +72,6 @@ pub struct Qwen3_5MoEDecoderLayer {
     input_layernorm: NormX,
     post_attention_layernorm: NormX,
     rotary_emb: Option<Arc<ScalingRotaryEmbedding>>,
-    dtype: DType,
-    is_qvar_builder: bool,
 }
 
 impl Qwen3_5MoEDecoderLayer {
@@ -212,7 +210,11 @@ impl Qwen3_5MoEDecoderLayer {
             (None, None)
         };
 
-        let norm_dtype = if is_qvar_builder { DType::F32 } else { dtype };
+        let norm_dtype = if is_qvar_builder || config.higher_precision_required() {
+            DType::F32
+        } else {
+            dtype
+        };
         let input_layernorm = rms_norm(
             config.hidden_size,
             config.rms_norm_eps,
@@ -251,8 +253,6 @@ impl Qwen3_5MoEDecoderLayer {
             input_layernorm,
             post_attention_layernorm,
             rotary_emb: rotary,
-            dtype,
-            is_qvar_builder,
         })
     }
 
@@ -282,19 +282,7 @@ impl Qwen3_5MoEDecoderLayer {
                 )?
             }
             Qwen3_5MoEAttnType::LinearAttention(gdn) => {
-                if self.is_qvar_builder {
-                    gdn.forward(&xs, mamba_cache, input_metadata, seq_slots)?
-                } else if xs.dtype() != self.dtype {
-                    gdn.forward(
-                        &xs.to_dtype(self.dtype)?,
-                        mamba_cache,
-                        input_metadata,
-                        seq_slots,
-                    )?
-                    .to_dtype(xs.dtype())?
-                } else {
-                    gdn.forward(&xs, mamba_cache, input_metadata, seq_slots)?
-                }
+                gdn.forward(&xs, mamba_cache, input_metadata, seq_slots)?
             }
         };
 
@@ -521,7 +509,11 @@ impl Qwen3_5MoEForCausalLM {
 
         let num_gdn_layers = gdn_layer_idx;
 
-        let norm_dtype = if is_qvar_builder { DType::F32 } else { dtype };
+        let norm_dtype = if is_qvar_builder || config.higher_precision_required() {
+            DType::F32
+        } else {
+            dtype
+        };
         let norm = rms_norm(
             config.hidden_size,
             config.rms_norm_eps,
@@ -576,7 +568,11 @@ impl Qwen3_5MoEForCausalLM {
         // Start small and let runner preallocate to the final engine capacity.
         let max_batch_size = 1;
 
-        let conv_cache_dtype = if is_qvar_builder { DType::F32 } else { dtype };
+        let conv_cache_dtype = if is_qvar_builder || config.is_f16_mode {
+            DType::F32
+        } else {
+            dtype
+        };
         let mamba_cache = if num_gdn_layers > 0 {
             MambaCache::new(
                 num_gdn_layers,

--- a/src/models/qwen3_moe.rs
+++ b/src/models/qwen3_moe.rs
@@ -210,6 +210,12 @@ impl Qwen3DecoderLayer {
         .cloned()
         .collect();
 
+        let norm_dtype = if config.higher_precision_required() {
+            DType::F32
+        } else {
+            dtype
+        };
+
         let input_layernorm = rms_norm(
             config.hidden_size,
             config.rms_norm_eps,
@@ -218,7 +224,7 @@ impl Qwen3DecoderLayer {
             } else {
                 vb.pp("input_layernorm").clone()
             },
-            dtype,
+            norm_dtype,
             false,
         )?;
 
@@ -230,7 +236,7 @@ impl Qwen3DecoderLayer {
             } else {
                 vb.pp("post_attention_layernorm").clone()
             },
-            dtype,
+            norm_dtype,
             false,
         )?;
 
@@ -405,6 +411,11 @@ impl Qwen3MoEForCausalLM {
             reporter.write().set_progress(i + 1);
         }
 
+        let norm_dtype = if config.higher_precision_required() {
+            DType::F32
+        } else {
+            dtype
+        };
         let norm = rms_norm(
             config.hidden_size,
             config.rms_norm_eps,
@@ -413,7 +424,7 @@ impl Qwen3MoEForCausalLM {
             } else {
                 vb.pp(&format!("{}norm", prefix))
             },
-            dtype,
+            norm_dtype,
             false,
         )?;
 

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -301,6 +301,8 @@ pub struct Config {
     pub quantization_config: Option<QuantConfig>,
     pub is_multi_model: Option<bool>,
     pub extra_config_json: Option<String>,
+    #[serde(default)]
+    pub is_f16_mode: bool,
 }
 
 impl Config {
@@ -322,7 +324,8 @@ impl Config {
     }
 
     pub fn higher_precision_required(&self) -> bool {
-        self.quant.is_some()
+        self.is_f16_mode
+            || self.quant.is_some()
             || self
                 .quantization_config
                 .as_ref()

--- a/src/utils/image.rs
+++ b/src/utils/image.rs
@@ -679,6 +679,7 @@ mod tests {
             quantization_config: None,
             is_multi_model: None,
             extra_config_json,
+            is_f16_mode: false,
         }
     }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -349,7 +349,7 @@ pub fn config_from_gguf<R: std::io::Seek + std::io::Read>(
             .map(|v| v.to_owned())
     };
 
-    let mod_cfg = if arch == "gemma4" {
+    let moe_cfg = if arch == "gemma4" {
         let expert_count = md_get(format!("{arch}.expert_count").as_str())
             .and_then(|v| v.to_u32())
             .ok()
@@ -524,7 +524,7 @@ pub fn config_from_gguf<R: std::io::Seek + std::io::Read>(
             .and_then(|v| v.to_f64())
             .ok();
 
-        let enable_moe = mod_cfg.is_some();
+        let enable_moe = moe_cfg.is_some();
 
         let num_global_kv_heads = md_get(format!("{arch}.attention.head_count_kv").as_str())
             .ok()
@@ -615,11 +615,12 @@ pub fn config_from_gguf<R: std::io::Seek + std::io::Read>(
         hidden_act: candle_nn::Activation::Silu,
         rope_scaling,
         quant: None,
-        moe_cfg: mod_cfg,
+        moe_cfg,
         kvcache_dtype: crate::utils::config::KvCacheDtype::Auto,
         quantization_config: None,
         is_multi_model: None,
         extra_config_json,
+        is_f16_mode: false,
     };
 
     if arch == "gemma4" || arch == "gemma3" {
@@ -2277,6 +2278,7 @@ mod tests {
             quantization_config: None,
             is_multi_model: Some(true),
             extra_config_json: Some(extra_config_json.to_string()),
+            is_f16_mode: false,
         }
     }
 


### PR DESCRIPTION
Address #352 

### 🚀🔥 We may have, for the first time ever, gotten `V100` working with `NVFP4` models under `low-bit` (3-bit/4-bit) KV cache, with coherent and decent prefill and decoding performance 

Tested with 40K inputs on single `V100` for NVFP4 model (software emulated fp4):

```
cargo run --release --features cuda,nccl -- --m AxionML/Qwen3.5-4B-NVFP4 --ui-server
```

### **Results:**

**Prefill speed:** 594.51 tokens/s (40794 total tokens)
**Decoding speed:** 58.11 tokens/s (under 40K context)
**Model output quality:** coherent

<details>

```
2026-05-27T06:36:44.589094Z  INFO xinfer::core::block_manager: Prefix cache miss seq 0 (40794 tokens, 0 cached blocks, raw_match=0 blocks)
2026-05-27T06:36:49.298835Z  INFO xinfer::core::runner: User's thinking preference for reasoning models: None
2026-05-27T06:36:49.298871Z  WARN xinfer::core::runner: No generation_config, using default sampling (temperature=0.7, top_k=32, top_p=0.95)
2026-05-27T06:36:54.334537Z  INFO xinfer::core::scheduler: Chunk prefilled 1 seq(s) [0:8192/40794] (8192 total tokens processed)
2026-05-27T06:37:06.057311Z  INFO xinfer::core::scheduler: Chunk prefilled 1 seq(s) [0:16384/40794] (16384 total tokens processed)
2026-05-27T06:37:19.826017Z  INFO xinfer::core::scheduler: Chunk prefilled 1 seq(s) [0:24576/40794] (24576 total tokens processed)
2026-05-27T06:37:35.643698Z  INFO xinfer::core::scheduler: Chunk prefilled 1 seq(s) [0:32768/40794] (32768 total tokens processed)
2026-05-27T06:37:53.107304Z  WARN xinfer::core::scheduler: Chunk prefill finished for 1 seq(s) [0] (40794 total tokens)
2026-05-27T06:37:53.107435Z  INFO xinfer::core::engine: Prefilling 1 seq(s) [0]: 40795 total tokens in 68.62s (594.51 tokens/s, cache included)
```

<think>
The user wants me to analyze the provided Rust code file `kvcache_allocator.rs` and understand its functionality. The code is quite long and repetitive (it's duplicated multiple times in the prompt). I need to extract the key information and explain what this module does.

Key observations:
1. This is a Rust module for KVCache allocation in a machine learning inference framework
2. It handles GPU memory management for transformer model KV cache tensors
3. Supports different cache types (TurboQuant, FlashAttention, MLA, hybrid Mamba models)
4. Platform-aware (CUDA, Metal, CPU)
5. Complex memory calculations for different model architectures

Let me analyze the structure and main functions:

1. **KVCacheAllocation** - Result structure from allocation planning
2. **KVCacheError** - Error types for allocation failures
3. **KVCacheAllocator** - Main allocator struct with model parameters and config
4. **Main functions**:
   - `new()` - Constructor
   - `plan()` - Plan allocation based on available memory
   - `plan_allocation()` - Calculate allocation plan
   - `init_kv_cache()` - Initialize actual tensors
   - Various helper methods for memory calculations

The code is duplicated 3 times in the prompt, which seems like a copy-paste error. I should work with the first occurrence.

Let me provide a comprehensive summary of what this code does.
</think>

# KVCache Allocator Module Analysis

This is a **Rust module for managing KVCache (Key-Value Cache) memory allocation** in transformer model inference systems. It handles GPU memory planning, tensor allocation, and platform-specific optimizations.

## Module Overview

```rust
// Main entry point example
let allocator = KVCacheAllocator::new(&econfig, &config, dtype);
let available_memory = allocator.get_available_memory(&device_ids)?;
let allocation = allocator.plan_allocation(available_memory)?;
let (gpu_cache, cpu_cache) = allocator.init_kv_cache(&allocation, dtype, &device)?;
```

## Core Components

### 1. **KVCacheAllocation** - Allocation Plan Structure
```rust
pub struct KVCacheAllocation {
    pub num_gpu_blocks: usize,
    pub num_cpu_blocks: usize,
    pub max_num_seqs: usize,
    pub max_model_len: usize,
    pub kvcache_memory_bytes: usize,
    pub max_num_batched_tokens: usize,
}
```

### 2. **KVCacheError** - Error Types
- `InsufficientGpuMemory` - Not enough GPU memory
- `InvalidConfiguration` - Invalid parameters
- `PlatformError` - CUDA/Metal unavailable

### 3. **KVCacheAllocator** - Main Allocator
Handles:
- Memory budget calculation
- Model architecture-specific cache sizing
- Platform-aware GPU/CPU allocation
- Hybrid Mamba/MLA model support

## Key Features

### **Memory Calculation**
- `per_block_bytes()` - Calculates memory per cache block
- Supports **TurboQuant** (Turbo3/4/8), **MLA**, **FlashAttention**
- Handles per-layer heterogeneous configs (Gemma4)

### **Allocation Strategy**
```rust
pub fn plan(&self, device_ids: &[usize], econfig: &mut EngineConfig) -> Result<()>
pub fn plan_allocation(&self, min_available_memory: u64, num_shards: usize) -> Result<KVCacheAllocation>
```

- Respects **`kv_fraction`** (50-70% of GPU memory)
- Supports **Hybrid Mamba** allocation (15-30% budget)
- Auto-decides optimal `max_num_seqs` and `max_model_len`

### **Platform Support**
- **CUDA** (NVIDIA GPUs): Uses `cuMemGetInfo_v2`
- **Metal** (Apple Silicon): Uses `metal::Device`
- **CPU fallback**: Uses `sysinfo`

### **Cache Types Supported**
| Type | Description |
|------|-------------|
| **Standard FP8** | Traditional K/V cache |
| **TurboQuant** | Compressed KV cache (3/4/8-bit) |
| **MLA** | Matrix Linear Attention |
| **Hybrid Mamba** | Linear attention + Mamba layers |

### **Configuration Options**
```rust
// User constraints
user_max_model_len: Option<usize>,
user_max_num_seqs: Option<usize>,
kv_fraction: f64,  // 0.5-0.7 (default 0.7 for FlashAttention)
cpu_mem_fold: f32,  // CPU memory ratio (default 0.2)
```

## Usage Pattern

```rust
// 1. Create allocator
let allocator = KVCacheAllocator::new(&econfig, &config, dtype);

// 2. Get available memory across devices
let available_memory = allocator.get_available_memory(&device_ids)?;
```

</details>


### **Results (Under 4-bit kvcache):**

```
cargo run --release --features cuda,nccl -- --m AxionML/Qwen3.5-4B-NVFP4 --ui-server --kvcache-dtype turbo4 --i
```

**Prefill speed:** 539.58 tokens/s (40794 total tokens)
**Decoding speed:** 48.90 tokens/s (under 40K context)
**Model output quality:** coherent

<details>

```
2026-05-27T06:50:19.862540Z  INFO xinfer::core::block_manager: Prefix cache miss seq 0 (40793 tokens, 0 cached blocks, raw_match=0 blocks)
2026-05-27T06:50:24.670866Z  INFO xinfer::core::runner: User's thinking preference for reasoning models: None
2026-05-27T06:50:24.670907Z  WARN xinfer::core::runner: No generation_config, using default sampling (temperature=0.7, top_k=32, top_p=0.95)
2026-05-27T06:50:29.802789Z  INFO xinfer::core::scheduler: Chunk prefilled 1 seq(s) [0:8192/40793] (8192 total tokens processed)
2026-05-27T06:50:42.395029Z  INFO xinfer::core::scheduler: Chunk prefilled 1 seq(s) [0:16384/40793] (16384 total tokens processed)
2026-05-27T06:50:57.592192Z  INFO xinfer::core::scheduler: Chunk prefilled 1 seq(s) [0:24576/40793] (24576 total tokens processed)
2026-05-27T06:51:15.396268Z  INFO xinfer::core::scheduler: Chunk prefilled 1 seq(s) [0:32768/40793] (32768 total tokens processed)
2026-05-27T06:51:35.360806Z  WARN xinfer::core::scheduler: Chunk prefill finished for 1 seq(s) [0] (40793 total tokens)
2026-05-27T06:51:35.360939Z  INFO xinfer::core::engine: Prefilling 1 seq(s) [0]: 40794 total tokens in 75.60s (539.60 tokens/s, cache included)
```

<think>
The user wants me to continue the code. Looking at the provided code, it's a Rust implementation of a KVCache (Key-Value Cache) allocation module for an LLM inference engine. The code handles memory planning, allocation, and initialization of KV cache tensors across different platforms (CUDA, Metal, etc.).

The code appears to be complete and well-structured. There's no obvious place where I need to continue the code - it ends with the `init_cpu_tq_cache` method.

However, I notice there's a typo in the code:
- Line 1007: `if skvcache_dtype.is_turboquant()` should be `if self.kvcache_dtype.is_turboquant()`

Also, I should check if there are any other issues or if I should provide a summary/explanation of the code instead.

Looking at the request format, it seems like the user wants me to continue the code, but the code appears complete. I should check if there's anything that needs fixing or if I should provide a summary.

Given the context, I think the best response would be to:
1. Point out the typo I noticed
2. Provide a brief summary of what the code does
3. Offer to help with any specific improvements or additions

Let me provide a helpful response that addresses the code quality issues and summarizes the functionality.
</think>

This is a well-structured **KVCache Allocation Module** for LLM inference. I've identified one issue and can provide a summary of the code's functionality:

## 🔧 Code Issue Found

**Line 1007** has a typo:
```rust
if skvcache_dtype.is_turboquant() {  // ❌ Typo
```
Should be:
```rust
if self.kvcache_dtype.is_turboquant() {  // ✅ Correct
```

## 📋 Code Summary

### Purpose
This module provides **centralized, robust memory planning** for GPU KVCache allocation in LLM inference, handling:
- GPU memory estimation and allocation planning
- Multi-platform support (CUDA, Metal, CPU)
- Different KVCache data types (FP8, TurboQuant, MLA)
- Hybrid Mamba allocation strategies
- Per-layer heterogeneous cache configurations

### Key Components

| Component | Description |
|-----------|-------------|
| `KVCacheAllocator` | Main struct for memory planning and allocation |
| `KVCacheAllocation` | Struct containing allocation plan parameters |
| `KVCacheError` | Error types for allocation failures |
| `per_block_bytes()` | Calculates memory per block for different cache types |
| `plan_allocation()` | Main entry point for allocation planning |
| `init_kv_cache()` | Initializes GPU/CPU cache tensors |

### Important Features

1. **Platform-Aware Memory**
   - GPU-specific memory queries (CUDA `cuMemGetInfo_v2`, Metal)
   - CPU fallback using `sysinfo`
   - Platform-specific tensor allocation

2. **Hybrid Mamba Support**
   - Separate memory budget for Mamba layers
   - Configurable Mamba fraction (default 15-30%)
   - Slot-based capacity management

3. **TurboQuant Support**
   - FP8 compression (Turbo3/4/8 modes)
   - Separate buffer allocation for quantized KV cache
   - MLA (Mamba Linear Attention) compatibility

4. **Auto-Decide Scheduling**
   - Automatic `max_num_seqs` and `max_model_len` selection
   - Priority candidates: [config_model_len, 1/2, 1/4, 1/8, 16k, 8k, 4k, 1k]

### Usage Flow

```rust
// 1. Create allocator
let allocator = KVCacheAllocator::new(&econfig, &config, dtype)?;

// 2. Get available memory
let available_memory = allocator.get_available_memory(&device_ids)?;

// 3. Plan allocation
let allocation = allocator.plan_allocation(available_memory)?;

// 4. Initialize tensors
let (gpu_cache, cpu_cache) = allocator.init_kv_cache(&allocation, dtype, &device)?;
```

### Recommendation

**Fix the typo on line 1007** to ensure TurboQuant mode detection works correctly. The rest of the code appears well-structured and handles edge cases appropriately.

Would you like me to:
1. Fix the typo and provide the corrected code?
2. Add any additional error handling or logging?
3. Suggest performance optimizations?
4. Create unit tests for the allocation logic?<|im_end|>
```
2026-05-27T06:51:55.545662Z  INFO xinfer::core::block_manager: Prefix cache insert seq 0 (41780 tokens, 652 blocks)

Generation completed!
2026-05-27T06:51:55.565154Z  INFO xinfer: --- Performance Metrics ---
2026-05-27T06:51:55.565182Z  INFO xinfer: ⏱️ Prompt tokens: 40793 in 75.60s (539.58 tokens/s)
2026-05-27T06:51:55.565201Z  INFO xinfer: ⏱️ Decoded tokens: 987 in 20.18s (48.90 tokens/s)
🤖✨ Enter another prompt to continue current chat (Press Ctrl+C to start a new chat):
```

</details>