### PR TITLE
Support multi-token prediction (Eagle MTP)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.6.2", rev = "3c7578d" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.6.3", rev = "3c7578d" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["algorithms", "hardware-support", "science"]
 license = "MIT"
 
 [dependencies]
-candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "9202150" }
-candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "9202150" }
+candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "faf3696" }
+candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "faf3696" }
 serde = { version = "1.0.190", features = ["serde_derive"] }
 tokenizers = {version = "0.21.2", features = ["http"] }
 hf-hub = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.6.2", rev = "8eb0f9e" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.6.2", rev = "3c7578d" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"

--- a/ReadMe-CN.md
+++ b/ReadMe-CN.md
@@ -164,6 +164,9 @@ xinfer --m Qwen/Qwen3.6-35B-A3B-FP8 --kvcache-dtype fp8
 # 27B Dense + turbo4
 xinfer --m Qwen/Qwen3.6-27B-FP8 --kvcache-dtype turbo4
 
+# 26B Gemma4 (本地模型, 使用`--kv-fraction`选项增加kvcache占用)
+xinfer --w /data/gemma-4-26B-A4B-it --ui-server --port 9000 --kv-fraction 0.8
+
 # 30B MoE GGUF + turbo4
 xinfer --m unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF \
   --f Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf --kvcache-dtype turbo4

--- a/ReadMe-CN.md
+++ b/ReadMe-CN.md
@@ -14,7 +14,7 @@
 | **⚡** | 极致性能 | 原生 Flash Attention、FlashInfer、CUDA Graphs、持续批处理、前缀缓存、PD 分离。消费级 GPU 上 `30B+` 模型解码速度高达 **197 tok/s** |
 | **🪶** | 极简内核 | 核心调度 + 注意力逻辑仅 **< 5000 行** Rust 代码 |
 | **🌍** | 跨平台 | CUDA（Linux/Windows）、Metal（macOS），统一二进制，统一 API |
-| **🏭** | 生产就绪 | OpenAI/Anthropic 兼容 API、内置 ChatGPT 风格 Web UI、MCP 工具调用、结构化输出、Embedding + 分词器端点 |
+| **🏭** | 生产就绪 | OpenAI/Anthropic 兼容 API、内置 ChatGPT 风格 Web UI、MCP 工具调用、结构化输出、Embedding + 分词器端点、MTP |
 | **🗜️** | 极致 KV 压缩 | TurboQuant（`2–4 位` KV 缓存）以极小的质量损失将上下文扩展至 **4.3 倍**。单卡 24/32 GB GPU 即可运行 `30B+` MoE 模型并支持**百万级上下文** |
 | **🔥** | V100 + NVFP4 | 业界首创：V100 上运行 NVFP4 + 低位 KV 缓存推理 — 无需硬件 FP4，旧 GPU 重获新生 |
 | **🐍** | 轻量 Python 绑定 | 需要 Python 入口时可选 PyO3 wheel 包 |
@@ -55,6 +55,11 @@ xinfer --m /home/Qwen3.6-35B-A3B --d 0,1 --ui-server
 python3 -m xinfer.server --m Qwen/Qwen3.6-27B-FP8 --kvcache-dtype turbo4 --ui-server
 ```
 
+**MTP**
+```bash
+xinfer --w /home/Qwen3.6-35B-A3B --d 0,1 --ui-server --mtp 2
+```
+
 > **提示：** 浏览器打开 `http://IP:8001` 即可使用内置对话界面，或使用 `http://IP:8000/v1/` 作为 API 服务 `Base URL`。
 
 ---
@@ -77,7 +82,7 @@ python3 -m xinfer.server --m Qwen/Qwen3.6-27B-FP8 --kvcache-dtype turbo4 --ui-se
 
 > 测试平台：**V100-32G**、**A100-40G**、**Hopper-80G** 及 **RTX 5090**
 
-| 模型 | 格式 | 大小 | 输出速度 |
+| 模型 | 格式 | 大小 | 输出速度 (非MTP) |
 |---|---|---|---|
 | Ministral-3-3B (**多模态**) | ISQ (BF16→Q4K) | 3B | **193.67** tokens/s |
 | Qwen3-VL-8B-Instruct (**多模态**) | Q8_0 | 8B | **112.51** tokens/s |
@@ -479,6 +484,7 @@ xinfer --m unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF \
 | `--frequency-penalty` | 高频惩罚（−2 到 2） |
 | `--mcp-config` | MCP 服务器 JSON 配置 |
 | `--mcp-command` / `--mcp-args` | 单个 MCP 服务器命令及参数 |
+| `--mtp` | 启用MTP (只针对包含MTP层的模型) ，例如 `--mtp 2`，单次推理2个tokens |
 
 ### 环境变量
 
@@ -536,7 +542,7 @@ XINFER_NVFP4_FORCE_LUT=1 xinfer --m nvidia/Qwen3-30B-A3B-FP4 --ui-server
 * [x] **MXFP4/NVFP4 模型支持**
 * [x] **支持 Turboquant（4 位、3 位）KvCache**
 * [ ] TentorRT-LLM
-
+* [x] Multi-token Prediction (MTP)
 ---
 
 ## 📚 参考项目

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -164,6 +164,9 @@ xinfer --m Qwen/Qwen3.6-35B-A3B-FP8 --kvcache-dtype fp8
 # 27B Dense + turbo4
 xinfer --m Qwen/Qwen3.6-27B-FP8 --kvcache-dtype turbo4
 
+# 26B Gemma4 (local model, occupy more kvcache with --kv-fraction)
+xinfer --w /data/gemma-4-26B-A4B-it --ui-server --port 9000 --kv-fraction 0.8
+
 # 30B MoE GGUF + turbo4
 xinfer --m unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF \
   --f Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf --kvcache-dtype turbo4

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -14,7 +14,7 @@
 | **⚡** | Fast | Native Flash Attention, FlashInfer, CUDA Graphs, continuous batching, prefix caching, PD disaggregation. Up to **197 tok/s** decode for `30B+` models on consumer GPUs |
 | **🪶** | Tiny footprint | Core scheduling + attention logic in **< 5 000 lines** of Rust |
 | **🌍** | Cross-platform | CUDA (Linux/Windows), Metal (macOS). Same binary, same API |
-| **🏭** | Production-ready | OpenAI/Anthropic-compatible APIs, built-in ChatGPT-style Web UI, MCP tool calling, structured outputs, embedding + tokenizer endpoints |
+| **🏭** | Production-ready | OpenAI/Anthropic-compatible APIs, built-in ChatGPT-style Web UI, MCP tool calling, structured outputs, embedding + tokenizer endpoints, multi-token prediction (MTP) |
 | **🗜️** | Aggressive KV compression | TurboQuant (`2–4 bit` KV cache) extends context up to **4.3×** with minimal quality loss. Run `30B+` MoE models with **millions of context** on single 24/32 GB GPUs |
 | **🔥** | V100 + NVFP4 | First-ever NVFP4 + low-bit KV cache on V100 — no hardware FP4 needed, coherent output on legacy GPUs |
 | **🐍** | Lightweight Python bindings | Optional PyO3 wheel when you need a Python entry point |
@@ -55,6 +55,11 @@ xinfer --m /home/Qwen3.6-35B-A3B --d 0,1 --ui-server
 python3 -m xinfer.server --m Qwen/Qwen3.6-27B-FP8 --kvcache-dtype turbo4 --ui-server
 ```
 
+**MTP**
+```bash
+xinfer --w /home/Qwen3.6-35B-A3B --d 0,1 --ui-server --mtp 2
+```
+
 > **Tip:** Open `http://IP:8001` for the built-in chat UI, or use `http://IP:8000/v1/` as your API `Base URL`.
 
 ---
@@ -77,7 +82,7 @@ Add `--kvcache-dtype` to compress KV cache and extend context length:
 
 > Tested on **V100-32G**, **A100-40G**, **Hopper-80G** and **RTX 5090**
 
-| Model | Format | Size | Decoding Speed |
+| Model | Format | Size | Decoding Speed (without MTP) |
 |---|---|---|---|
 | Ministral-3-3B (**Multimodal**) | ISQ (BF16→Q4K) | 3B | **193.67** tokens/s |
 | Qwen3-VL-8B-Instruct (**Multimodal**) | Q8_0 | 8B | **112.51** tokens/s |
@@ -480,6 +485,7 @@ Constraint-based generation via llguidance — Lark grammars, regex, JSON Schema
 | `--frequency-penalty` | Penalize frequent tokens (−2 to 2) |
 | `--mcp-config` | MCP servers JSON config |
 | `--mcp-command` / `--mcp-args` | Single MCP server command + args |
+| `--mtp`| Multi-token prediction, usage `--mtp 2` for two-token prediction per forward pass |
 
 ### Environment Variables
 
@@ -537,6 +543,7 @@ XINFER_NVFP4_FORCE_LUT=1 xinfer --m nvidia/Qwen3-30B-A3B-FP4 --ui-server
 * [x] **MXFP4/NVFP4 Model Support**
 * [x] **Support Turboquant (4-bit, 3-bit) KvCache**
 * [ ] TentorRT-LLM
+* [x] **Multi-token Prediciton (MTP)**
 
 ---
 

--- a/src/core/block_manager.rs
+++ b/src/core/block_manager.rs
@@ -145,6 +145,13 @@ impl BlockManager {
         }
     }
 
+    /// Allocate a single free block and return its ID, or None if no blocks available.
+    pub fn alloc_free_block(&mut self) -> Option<usize> {
+        let block_id = self.free_block_ids.pop_front()?;
+        self.allocate_block(block_id);
+        Some(block_id)
+    }
+
     fn image_prefix_seed(images: &ImageData) -> u64 {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         images.raw.hash(&mut hasher);

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -1001,6 +1001,16 @@ impl LLMEngine {
             }
         }
 
+        // Pre-allocate blocks for MTP speculative positions before cloning sequences
+        if !is_prefill {
+            if let Some(mtp_tokens) = self.econfig.mtp_num_speculative_tokens {
+                if mtp_tokens > 0 {
+                    self.scheduler
+                        .pre_allocate_mtp_blocks(&scheduled_ids, mtp_tokens + 1);
+                }
+            }
+        }
+
         let seqs = self.scheduler.get_sequences(&scheduled_ids);
         let owned_seqs: Vec<Sequence> = seqs.iter().map(|s| (*s).clone()).collect();
         Ok(Some((scheduled_ids, is_prefill, owned_seqs)))
@@ -1123,6 +1133,194 @@ impl LLMEngine {
         } else {
             candle_core::bail!("No output ids received from model runners");
         }
+    }
+
+    /// Phase 2b: Run MTP speculative decode forward pass.
+    /// Returns Vec<Vec<u32>> where each inner vec contains all accepted tokens for that sequence.
+    pub fn run_forward_mtp(
+        runners: &Arc<RwLock<RunnerType>>,
+        owned_seqs: &[Sequence],
+    ) -> Result<Vec<Vec<u32>>> {
+        match &mut *runners.write() {
+            RunnerType::Thread(model_runner) => {
+                let seq_refs: Vec<&Sequence> = owned_seqs.iter().collect();
+                model_runner.run_mtp_decode(Seqs::SeqRefs(&seq_refs))
+            }
+            RunnerType::Process(ref mut runner_streams) => {
+                use crate::runner::{receive_local, send_local, MessageType};
+                use interprocess::TryClone;
+
+                let sequences = owned_seqs
+                    .iter()
+                    .map(|s| DecodeSequence::new(s))
+                    .collect::<Vec<_>>();
+                let request = MessageType::RunDecodeMTP(sequences);
+
+                let cloned_streams: Vec<LocalStream> = runner_streams
+                    .iter_mut()
+                    .map(|s| s.try_clone().expect("clone failed"))
+                    .collect();
+
+                if let Some(mut stream) = cloned_streams.into_iter().next() {
+                    send_local(&mut vec![stream.try_clone()?], &request, false)?;
+                    let response = receive_local(&mut stream, false)?;
+                    match response {
+                        MessageType::RunResponseMTP(multi_tokens) => {
+                            if multi_tokens.is_empty() {
+                                candle_core::bail!("MTP runner returned empty response")
+                            }
+                            Ok(multi_tokens)
+                        }
+                        other => {
+                            candle_core::bail!("Unexpected MTP response type: {:?}", other)
+                        }
+                    }
+                } else {
+                    candle_core::bail!("No runner streams available for MTP")
+                }
+            }
+            RunnerType::MultiNodeMaster {
+                ref mut local_streams,
+                ref mut remote_streams,
+            } => {
+                use crate::runner::{receive_local, send_local, MessageType};
+                use interprocess::TryClone;
+
+                let sequences = owned_seqs
+                    .iter()
+                    .map(|s| DecodeSequence::new(s))
+                    .collect::<Vec<_>>();
+                let request = MessageType::RunDecodeMTP(sequences);
+                let serialized =
+                    bincode::serialize(&request).expect("Bincode serialization failed");
+
+                for tcp_stream in remote_streams.iter_mut() {
+                    if let Err(e) = crate::utils::multi_node::send_tcp(tcp_stream, &serialized) {
+                        candle_core::bail!("Failed to send MTP forward to remote worker: {}", e);
+                    }
+                }
+
+                let cloned_streams: Vec<LocalStream> = local_streams
+                    .iter_mut()
+                    .map(|s| s.try_clone().expect("clone failed"))
+                    .collect();
+
+                let result = if let Some(mut stream) = cloned_streams.into_iter().next() {
+                    send_local(&mut vec![stream.try_clone()?], &request, false)?;
+                    let response = receive_local(&mut stream, false)?;
+                    match response {
+                        MessageType::RunResponseMTP(multi_tokens) => {
+                            if multi_tokens.is_empty() {
+                                candle_core::bail!("MTP runner returned empty response")
+                            }
+                            Ok(multi_tokens)
+                        }
+                        other => {
+                            candle_core::bail!("Unexpected MTP response type: {:?}", other)
+                        }
+                    }
+                } else {
+                    candle_core::bail!("No local runner streams available for MTP")
+                };
+
+                for tcp_stream in remote_streams.iter_mut() {
+                    let _ = crate::utils::multi_node::recv_tcp(tcp_stream);
+                }
+
+                result
+            }
+        }
+    }
+
+    /// Phase 3b: MTP-aware finish step that handles multiple tokens per sequence.
+    pub fn finish_step_mtp(
+        &mut self,
+        scheduled_ids: Vec<usize>,
+        multi_output_ids: Vec<Vec<u32>>,
+    ) -> Result<usize> {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        self.scheduler
+            .postprocess_multi(&scheduled_ids, &multi_output_ids);
+
+        let mut count = 0;
+        for (i, &idx) in scheduled_ids.iter().enumerate() {
+            let sq = self.scheduler.get_running(idx);
+            if let Some(s) = sq {
+                let seq_id = s.id;
+                let tokens = &multi_output_ids[i];
+
+                if s.is_finished() {
+                    if let Some(sender) = self.stream_senders.get_mut(&seq_id) {
+                        if let Some(request_type) = self.request_types.get(&seq_id) {
+                            let prompt_start_time = s.created_time();
+                            let decode_finish_time = SystemTime::now()
+                                .duration_since(UNIX_EPOCH)
+                                .expect("Time went backwards")
+                                .as_millis()
+                                as usize;
+                            let decode_start_time = self
+                                .decode_start_times
+                                .get(&seq_id)
+                                .copied()
+                                .unwrap_or(decode_finish_time);
+
+                            if *request_type == RequestType::Stream {
+                                for &tok in tokens {
+                                    if let Some(decoder) = self.stream_decoders.get_mut(&seq_id) {
+                                        if let Some(text) = decoder.step(tok)? {
+                                            let _ = sender.try_send(StreamItem::Token(text, tok));
+                                        }
+                                    }
+                                }
+                                let _ = sender.try_send(StreamItem::Done((
+                                    prompt_start_time,
+                                    decode_start_time,
+                                    decode_finish_time,
+                                    s.output_ids.len(),
+                                    s.stop_sequence.clone(),
+                                )));
+                            } else {
+                                let _ = sender.try_send(StreamItem::Completion((
+                                    prompt_start_time,
+                                    decode_start_time,
+                                    decode_finish_time,
+                                    s.output_ids.clone(),
+                                    s.stop_sequence.clone(),
+                                )));
+                            }
+                        }
+                    }
+                    count += 1;
+                } else {
+                    if !self.decode_start_times.contains_key(&seq_id) {
+                        let now = SystemTime::now()
+                            .duration_since(UNIX_EPOCH)
+                            .expect("Time went backwards")
+                            .as_millis() as usize;
+                        self.decode_start_times.insert(seq_id, now);
+                    }
+                    if let Some(sender) = self.stream_senders.get_mut(&seq_id) {
+                        if let Some(request_type) = self.request_types.get(&seq_id) {
+                            for &tok in tokens {
+                                if *request_type == RequestType::Stream {
+                                    if let Some(decoder) = self.stream_decoders.get_mut(&seq_id) {
+                                        if let Some(text) = decoder.step(tok)? {
+                                            let _ = sender.try_send(StreamItem::Token(text, tok));
+                                        }
+                                    }
+                                } else {
+                                    let _ = sender.try_send(StreamItem::TokenID(tok));
+                                }
+                            }
+                        }
+                    }
+                    count += 1;
+                }
+            }
+        }
+        self.check_canceled(None);
+        Ok(count)
     }
 
     /// Phase 3: Postprocess forward pass results, deliver tokens, and do maintenance.
@@ -1994,11 +2192,13 @@ impl LLMEngine {
     pub fn start_engine(engine: Arc<RwLock<Self>>) {
         GLOBAL_RT.spawn(async move {
             let engine = engine.clone();
-            let (is_pd_server, runners) = {
+            let (is_pd_server, runners, mtp_enabled) = {
                 let guard = engine.read();
+                let has_mtp = guard.econfig.mtp_num_speculative_tokens.is_some();
                 (
                     guard.is_pd_mode() && guard.is_pd_server(),
                     guard.runners.clone(),
+                    has_mtp,
                 )
             };
             loop {
@@ -2031,26 +2231,54 @@ impl LLMEngine {
                 // Engine lock released -- server can accept new requests during forward pass
 
                 if let Some((scheduled_ids, is_prefill, owned_seqs)) = prep {
-                    // Phase 2: Forward pass (only runner lock, engine lock FREE)
-                    match Self::run_forward(&runners, &owned_seqs, is_prefill) {
-                        Ok(output_ids) => {
-                            // Phase 3: Postprocess (engine lock held briefly)
-                            let mut guard = engine.write();
-                            match guard.finish_step(scheduled_ids, is_prefill, output_ids) {
-                                Ok(n) => task_processed = n,
-                                Err(e) => {
-                                    crate::log_error!("[Engine Loop] Finish error: {:?}", e);
-                                    if !guard.cancel_all_with_reason(Some(e.to_string())) {
-                                        std::process::exit(1);
+                    // Use MTP for decode steps when enabled (batch_size=1 only for now)
+                    if mtp_enabled && !is_prefill && owned_seqs.len() == 1 {
+                        match Self::run_forward_mtp(&runners, &owned_seqs) {
+                            Ok(multi_output_ids) => {
+                                let mut guard = engine.write();
+                                match guard.finish_step_mtp(scheduled_ids, multi_output_ids) {
+                                    Ok(n) => task_processed = n,
+                                    Err(e) => {
+                                        crate::log_error!(
+                                            "[Engine Loop] MTP Finish error: {:?}",
+                                            e
+                                        );
+                                        if !guard.cancel_all_with_reason(Some(e.to_string())) {
+                                            std::process::exit(1);
+                                        }
                                     }
                                 }
                             }
+                            Err(e) => {
+                                crate::log_error!("[Engine Loop] MTP Forward error: {:?}", e);
+                                let mut guard = engine.write();
+                                if !guard.cancel_all_with_reason(Some(e.to_string())) {
+                                    std::process::exit(1);
+                                }
+                            }
                         }
-                        Err(e) => {
-                            crate::log_error!("[Engine Loop] Forward error: {:?}", e);
-                            let mut guard = engine.write();
-                            if !guard.cancel_all_with_reason(Some(e.to_string())) {
-                                std::process::exit(1);
+                    } else {
+                        // Phase 2: Standard forward pass (only runner lock, engine lock FREE)
+                        match Self::run_forward(&runners, &owned_seqs, is_prefill) {
+                            Ok(output_ids) => {
+                                // Phase 3: Postprocess (engine lock held briefly)
+                                let mut guard = engine.write();
+                                match guard.finish_step(scheduled_ids, is_prefill, output_ids) {
+                                    Ok(n) => task_processed = n,
+                                    Err(e) => {
+                                        crate::log_error!("[Engine Loop] Finish error: {:?}", e);
+                                        if !guard.cancel_all_with_reason(Some(e.to_string())) {
+                                            std::process::exit(1);
+                                        }
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                crate::log_error!("[Engine Loop] Forward error: {:?}", e);
+                                let mut guard = engine.write();
+                                if !guard.cancel_all_with_reason(Some(e.to_string())) {
+                                    std::process::exit(1);
+                                }
                             }
                         }
                     }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -1251,6 +1251,9 @@ impl LLMEngine {
                 let tokens = &multi_output_ids[i];
 
                 if s.is_finished() {
+                    let num_appended =
+                        s.output_ids.len() - self.decode_length.get(&seq_id).copied().unwrap_or(0);
+                    let tokens_to_stream = &tokens[..num_appended.min(tokens.len())];
                     if let Some(sender) = self.stream_senders.get_mut(&seq_id) {
                         if let Some(request_type) = self.request_types.get(&seq_id) {
                             let prompt_start_time = s.created_time();
@@ -1265,8 +1268,21 @@ impl LLMEngine {
                                 .copied()
                                 .unwrap_or(decode_finish_time);
 
+                            if s.is_tool_call_end {
+                                if *request_type == RequestType::Stream {
+                                    if let Some(decoder) = self.stream_decoders.get_mut(&seq_id) {
+                                        if let Some(tok) = decoder.step(s.last_token)? {
+                                            let _ = sender
+                                                .try_send(StreamItem::Token(tok, s.last_token));
+                                        }
+                                    }
+                                } else {
+                                    let _ = sender.try_send(StreamItem::TokenID(s.last_token));
+                                }
+                            }
+
                             if *request_type == RequestType::Stream {
-                                for &tok in tokens {
+                                for &tok in tokens_to_stream {
                                     if let Some(decoder) = self.stream_decoders.get_mut(&seq_id) {
                                         if let Some(text) = decoder.step(tok)? {
                                             let _ = sender.try_send(StreamItem::Token(text, tok));
@@ -1291,6 +1307,10 @@ impl LLMEngine {
                             }
                         }
                     }
+                    self.decode_start_times.remove(&seq_id);
+                    self.decode_length.remove(&seq_id);
+                    self.active_requests.remove(&seq_id);
+                    let _ = self.notify_runner_finished(seq_id);
                     count += 1;
                 } else {
                     if !self.decode_start_times.contains_key(&seq_id) {
@@ -1299,6 +1319,11 @@ impl LLMEngine {
                             .expect("Time went backwards")
                             .as_millis() as usize;
                         self.decode_start_times.insert(seq_id, now);
+                    }
+                    if let Some(length) = self.decode_length.get_mut(&seq_id) {
+                        *length = s.output_len();
+                    } else {
+                        self.decode_length.insert(seq_id, s.output_len());
                     }
                     if let Some(sender) = self.stream_senders.get_mut(&seq_id) {
                         if let Some(request_type) = self.request_types.get(&seq_id) {
@@ -1318,6 +1343,9 @@ impl LLMEngine {
                     count += 1;
                 }
             }
+        }
+        if self.econfig.server_mode.unwrap_or(true) {
+            self.may_print_decoding_throughput(&scheduled_ids);
         }
         self.check_canceled(None);
         Ok(count)

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -1135,9 +1135,9 @@ impl LLMEngine {
         }
     }
 
-    /// Phase 2b: Run MTP speculative decode forward pass.
+    /// Run MTP speculative decode forward pass.
     /// Returns Vec<Vec<u32>> where each inner vec contains all accepted tokens for that sequence.
-    pub fn run_forward_mtp(
+    fn run_forward_mtp(
         runners: &Arc<RwLock<RunnerType>>,
         owned_seqs: &[Sequence],
     ) -> Result<Vec<Vec<u32>>> {
@@ -1232,131 +1232,13 @@ impl LLMEngine {
         }
     }
 
-    /// Phase 3b: MTP-aware finish step that handles multiple tokens per sequence.
-    pub fn finish_step_mtp(
-        &mut self,
-        scheduled_ids: Vec<usize>,
-        multi_output_ids: Vec<Vec<u32>>,
-    ) -> Result<usize> {
-        use std::time::{SystemTime, UNIX_EPOCH};
-
-        self.scheduler
-            .postprocess_multi(&scheduled_ids, &multi_output_ids);
-
-        let mut count = 0;
-        for (i, &idx) in scheduled_ids.iter().enumerate() {
-            let sq = self.scheduler.get_running(idx);
-            if let Some(s) = sq {
-                let seq_id = s.id;
-                let tokens = &multi_output_ids[i];
-
-                if s.is_finished() {
-                    let num_appended =
-                        s.output_ids.len() - self.decode_length.get(&seq_id).copied().unwrap_or(0);
-                    let tokens_to_stream = &tokens[..num_appended.min(tokens.len())];
-                    if let Some(sender) = self.stream_senders.get_mut(&seq_id) {
-                        if let Some(request_type) = self.request_types.get(&seq_id) {
-                            let prompt_start_time = s.created_time();
-                            let decode_finish_time = SystemTime::now()
-                                .duration_since(UNIX_EPOCH)
-                                .expect("Time went backwards")
-                                .as_millis()
-                                as usize;
-                            let decode_start_time = self
-                                .decode_start_times
-                                .get(&seq_id)
-                                .copied()
-                                .unwrap_or(decode_finish_time);
-
-                            if s.is_tool_call_end {
-                                if *request_type == RequestType::Stream {
-                                    if let Some(decoder) = self.stream_decoders.get_mut(&seq_id) {
-                                        if let Some(tok) = decoder.step(s.last_token)? {
-                                            let _ = sender
-                                                .try_send(StreamItem::Token(tok, s.last_token));
-                                        }
-                                    }
-                                } else {
-                                    let _ = sender.try_send(StreamItem::TokenID(s.last_token));
-                                }
-                            }
-
-                            if *request_type == RequestType::Stream {
-                                for &tok in tokens_to_stream {
-                                    if let Some(decoder) = self.stream_decoders.get_mut(&seq_id) {
-                                        if let Some(text) = decoder.step(tok)? {
-                                            let _ = sender.try_send(StreamItem::Token(text, tok));
-                                        }
-                                    }
-                                }
-                                let _ = sender.try_send(StreamItem::Done((
-                                    prompt_start_time,
-                                    decode_start_time,
-                                    decode_finish_time,
-                                    s.output_ids.len(),
-                                    s.stop_sequence.clone(),
-                                )));
-                            } else {
-                                let _ = sender.try_send(StreamItem::Completion((
-                                    prompt_start_time,
-                                    decode_start_time,
-                                    decode_finish_time,
-                                    s.output_ids.clone(),
-                                    s.stop_sequence.clone(),
-                                )));
-                            }
-                        }
-                    }
-                    self.decode_start_times.remove(&seq_id);
-                    self.decode_length.remove(&seq_id);
-                    self.active_requests.remove(&seq_id);
-                    let _ = self.notify_runner_finished(seq_id);
-                    count += 1;
-                } else {
-                    if !self.decode_start_times.contains_key(&seq_id) {
-                        let now = SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .expect("Time went backwards")
-                            .as_millis() as usize;
-                        self.decode_start_times.insert(seq_id, now);
-                    }
-                    if let Some(length) = self.decode_length.get_mut(&seq_id) {
-                        *length = s.output_len();
-                    } else {
-                        self.decode_length.insert(seq_id, s.output_len());
-                    }
-                    if let Some(sender) = self.stream_senders.get_mut(&seq_id) {
-                        if let Some(request_type) = self.request_types.get(&seq_id) {
-                            for &tok in tokens {
-                                if *request_type == RequestType::Stream {
-                                    if let Some(decoder) = self.stream_decoders.get_mut(&seq_id) {
-                                        if let Some(text) = decoder.step(tok)? {
-                                            let _ = sender.try_send(StreamItem::Token(text, tok));
-                                        }
-                                    }
-                                } else {
-                                    let _ = sender.try_send(StreamItem::TokenID(tok));
-                                }
-                            }
-                        }
-                    }
-                    count += 1;
-                }
-            }
-        }
-        if self.econfig.server_mode.unwrap_or(true) {
-            self.may_print_decoding_throughput(&scheduled_ids);
-        }
-        self.check_canceled(None);
-        Ok(count)
-    }
-
     /// Phase 3: Postprocess forward pass results, deliver tokens, and do maintenance.
+    /// Handles both single-token (normal decode/prefill) and multi-token (MTP) outputs.
     pub fn finish_step(
         &mut self,
         scheduled_ids: Vec<usize>,
         is_prefill: bool,
-        output_ids: Vec<u32>,
+        multi_output_ids: Vec<Vec<u32>>,
     ) -> Result<usize> {
         pub struct DecodedIds(Either<Vec<usize>, Vec<usize>>);
 
@@ -1367,12 +1249,16 @@ impl LLMEngine {
                 self.check_canceled(None);
                 return Ok(0);
             } else {
-                let output_ids: Vec<u32> = indices.iter().map(|&i| output_ids[i]).collect();
-                self.scheduler.postprocess(&finished_indices, &output_ids);
+                let wrapped: Vec<Vec<u32>> = indices
+                    .iter()
+                    .map(|&i| multi_output_ids[i].clone())
+                    .collect();
+                self.scheduler.postprocess(&finished_indices, &wrapped);
                 DecodedIds(Either::Left(finished_indices))
             }
         } else {
-            self.scheduler.postprocess(&scheduled_ids, &output_ids);
+            self.scheduler
+                .postprocess(&scheduled_ids, &multi_output_ids);
             DecodedIds(Either::Left(scheduled_ids))
         };
 
@@ -1391,8 +1277,6 @@ impl LLMEngine {
             if let Some(s) = sq {
                 let seq_id = s.id;
                 if s.is_finished() {
-                    // Normal finish handling
-
                     if let Some(sender) = self.stream_senders.get_mut(&seq_id) {
                         if let Some(request_type) = self.request_types.get(&seq_id) {
                             let prompt_start_time = s.created_time();
@@ -1411,7 +1295,6 @@ impl LLMEngine {
                             };
 
                             if s.is_tool_call_end {
-                                //finish early, we need to send the last token
                                 if *request_type == RequestType::Stream {
                                     if let Some(decoder) = self.stream_decoders.get_mut(&seq_id) {
                                         if let Some(tok) = decoder.step(s.last_token)? {
@@ -1425,6 +1308,17 @@ impl LLMEngine {
                             }
 
                             if *request_type == RequestType::Stream {
+                                let num_appended = s.output_ids.len()
+                                    - self.decode_length.get(&seq_id).copied().unwrap_or(0);
+                                let tokens_to_stream = &multi_output_ids[idx]
+                                    [..num_appended.min(multi_output_ids[idx].len())];
+                                for &tok in tokens_to_stream {
+                                    if let Some(decoder) = self.stream_decoders.get_mut(&seq_id) {
+                                        if let Some(text) = decoder.step(tok)? {
+                                            let _ = sender.try_send(StreamItem::Token(text, tok));
+                                        }
+                                    }
+                                }
                                 let _ = sender.try_send(StreamItem::Done((
                                     prompt_start_time,
                                     decode_start_time,
@@ -1481,13 +1375,15 @@ impl LLMEngine {
                         *length = s.output_len();
                     }
 
-                    let mut token_ids =
-                        if self.is_pd_mode() && s.pd_first_token.is_some() && s.output_len() == 2 {
-                            // Special case, the real first token is generated on PD server
-                            vec![s.pd_first_token.unwrap_or(s.last_token), s.last_token]
-                        } else {
-                            vec![s.last_token]
-                        };
+                    let tokens = &multi_output_ids[idx];
+                    let mut token_ids = if tokens.len() > 1 {
+                        tokens.to_vec()
+                    } else if self.is_pd_mode() && s.pd_first_token.is_some() && s.output_len() == 2
+                    {
+                        vec![s.pd_first_token.unwrap_or(s.last_token), s.last_token]
+                    } else {
+                        vec![s.last_token]
+                    };
                     if let Some(mut replay_ids) = self.take_prompt_replay_token_ids(seq_id) {
                         replay_ids.extend(token_ids);
                         token_ids = replay_ids;
@@ -1512,13 +1408,7 @@ impl LLMEngine {
                                     }
                                 }
                             } else {
-                                //completion request will be decoded at the final stage (at once)
                                 for token_id in token_ids {
-                                    /*
-                                        Check if the receiver is still active.
-                                        If the client disconnected, collect_sync_results will be dropped,
-                                        dropping the receiver, causing try_send to fail.
-                                    */
                                     if let Err(_) = sender.try_send(StreamItem::TokenID(token_id)) {
                                         crate::log_error!(
                                             "Error when sending token to client [seq_id {}]",
@@ -2259,54 +2149,33 @@ impl LLMEngine {
                 // Engine lock released -- server can accept new requests during forward pass
 
                 if let Some((scheduled_ids, is_prefill, owned_seqs)) = prep {
-                    // Use MTP for decode steps when enabled (batch_size=1 only for now)
-                    if mtp_enabled && !is_prefill && owned_seqs.len() == 1 {
-                        match Self::run_forward_mtp(&runners, &owned_seqs) {
-                            Ok(multi_output_ids) => {
-                                let mut guard = engine.write();
-                                match guard.finish_step_mtp(scheduled_ids, multi_output_ids) {
-                                    Ok(n) => task_processed = n,
-                                    Err(e) => {
-                                        crate::log_error!(
-                                            "[Engine Loop] MTP Finish error: {:?}",
-                                            e
-                                        );
-                                        if !guard.cancel_all_with_reason(Some(e.to_string())) {
-                                            std::process::exit(1);
-                                        }
+                    let use_mtp = mtp_enabled && !is_prefill && owned_seqs.len() == 1;
+
+                    let forward_result: Result<Vec<Vec<u32>>> = if use_mtp {
+                        Self::run_forward_mtp(&runners, &owned_seqs)
+                    } else {
+                        Self::run_forward(&runners, &owned_seqs, is_prefill)
+                            .map(|ids| ids.into_iter().map(|t| vec![t]).collect())
+                    };
+
+                    match forward_result {
+                        Ok(multi_output_ids) => {
+                            let mut guard = engine.write();
+                            match guard.finish_step(scheduled_ids, is_prefill, multi_output_ids) {
+                                Ok(n) => task_processed = n,
+                                Err(e) => {
+                                    crate::log_error!("[Engine Loop] Finish error: {:?}", e);
+                                    if !guard.cancel_all_with_reason(Some(e.to_string())) {
+                                        std::process::exit(1);
                                     }
-                                }
-                            }
-                            Err(e) => {
-                                crate::log_error!("[Engine Loop] MTP Forward error: {:?}", e);
-                                let mut guard = engine.write();
-                                if !guard.cancel_all_with_reason(Some(e.to_string())) {
-                                    std::process::exit(1);
                                 }
                             }
                         }
-                    } else {
-                        // Phase 2: Standard forward pass (only runner lock, engine lock FREE)
-                        match Self::run_forward(&runners, &owned_seqs, is_prefill) {
-                            Ok(output_ids) => {
-                                // Phase 3: Postprocess (engine lock held briefly)
-                                let mut guard = engine.write();
-                                match guard.finish_step(scheduled_ids, is_prefill, output_ids) {
-                                    Ok(n) => task_processed = n,
-                                    Err(e) => {
-                                        crate::log_error!("[Engine Loop] Finish error: {:?}", e);
-                                        if !guard.cancel_all_with_reason(Some(e.to_string())) {
-                                            std::process::exit(1);
-                                        }
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                crate::log_error!("[Engine Loop] Forward error: {:?}", e);
-                                let mut guard = engine.write();
-                                if !guard.cancel_all_with_reason(Some(e.to_string())) {
-                                    std::process::exit(1);
-                                }
+                        Err(e) => {
+                            crate::log_error!("[Engine Loop] Forward error: {:?}", e);
+                            let mut guard = engine.write();
+                            if !guard.cancel_all_with_reason(Some(e.to_string())) {
+                                std::process::exit(1);
                             }
                         }
                     }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -31,7 +31,6 @@ use crate::utils::{get_runner_path, init_config_tokenizer, spawn_runner};
 use crate::{log_info, log_warn};
 use candle_core::{DType, Result};
 use colored::Colorize;
-use either::Either;
 use futures::future::join_all;
 use interprocess::local_socket::traits::Listener;
 use interprocess::local_socket::{GenericNamespaced, ToNsName};
@@ -1240,40 +1239,71 @@ impl LLMEngine {
         is_prefill: bool,
         multi_output_ids: Vec<Vec<u32>>,
     ) -> Result<usize> {
-        pub struct DecodedIds(Either<Vec<usize>, Vec<usize>>);
+        if scheduled_ids.len() != multi_output_ids.len() {
+            candle_core::bail!(
+                "Forward output count mismatch: {} scheduled sequence(s), {} output row(s)",
+                scheduled_ids.len(),
+                multi_output_ids.len()
+            );
+        }
 
-        let decoded_ids = if is_prefill {
+        // `scheduled_ids` are indexes into scheduler.running, while
+        // `multi_output_ids` is dense and ordered by position in scheduled_ids.
+        // Keep that association explicit; a running index is not an output index.
+        let (indices, output_by_running_index) = if is_prefill {
             let (indices, finished_indices) =
                 self.scheduler.filter_prefill_finished(&scheduled_ids);
             if indices.is_empty() {
                 self.check_canceled(None);
                 return Ok(0);
             } else {
+                if indices.len() != finished_indices.len() {
+                    candle_core::bail!(
+                        "Prefill result mapping mismatch: {} output position(s), {} running sequence(s)",
+                        indices.len(),
+                        finished_indices.len()
+                    );
+                }
                 let wrapped: Vec<Vec<u32>> = indices
                     .iter()
-                    .map(|&i| multi_output_ids[i].clone())
-                    .collect();
+                    .map(|&output_idx| {
+                        multi_output_ids.get(output_idx).cloned().ok_or_else(|| {
+                            candle_core::Error::msg(format!(
+                                "Prefill output index {} out of range for {} output row(s)",
+                                output_idx,
+                                multi_output_ids.len()
+                            ))
+                        })
+                    })
+                    .collect::<Result<_>>()?;
                 self.scheduler.postprocess(&finished_indices, &wrapped);
-                DecodedIds(Either::Left(finished_indices))
+                let output_map = finished_indices
+                    .iter()
+                    .copied()
+                    .zip(wrapped)
+                    .collect::<HashMap<_, _>>();
+                (finished_indices, output_map)
             }
         } else {
             self.scheduler
                 .postprocess(&scheduled_ids, &multi_output_ids);
-            DecodedIds(Either::Left(scheduled_ids))
-        };
-
-        let (indices, is_running): (&Vec<usize>, bool) = match &decoded_ids.0 {
-            Either::Left(indices) => (indices, true),
-            Either::Right(indices) => (indices, false),
+            let output_map = scheduled_ids
+                .iter()
+                .copied()
+                .zip(multi_output_ids)
+                .collect::<HashMap<_, _>>();
+            (scheduled_ids, output_map)
         };
 
         let mut prefill_batch: Vec<(usize, usize, f32, bool)> = Vec::new();
-        for &idx in indices {
-            let sq = if is_running {
-                self.scheduler.get_running(idx)
-            } else {
-                self.scheduler.get_waiting(idx)
-            };
+        for &idx in &indices {
+            let step_tokens = output_by_running_index.get(&idx).ok_or_else(|| {
+                candle_core::Error::msg(format!(
+                    "Missing forward output for running sequence index {}",
+                    idx
+                ))
+            })?;
+            let sq = self.scheduler.get_running(idx);
             if let Some(s) = sq {
                 let seq_id = s.id;
                 if s.is_finished() {
@@ -1310,8 +1340,8 @@ impl LLMEngine {
                             if *request_type == RequestType::Stream {
                                 let num_appended = s.output_ids.len()
                                     - self.decode_length.get(&seq_id).copied().unwrap_or(0);
-                                let tokens_to_stream = &multi_output_ids[idx]
-                                    [..num_appended.min(multi_output_ids[idx].len())];
+                                let tokens_to_stream =
+                                    &step_tokens[..num_appended.min(step_tokens.len())];
                                 for &tok in tokens_to_stream {
                                     if let Some(decoder) = self.stream_decoders.get_mut(&seq_id) {
                                         if let Some(text) = decoder.step(tok)? {
@@ -1375,9 +1405,8 @@ impl LLMEngine {
                         *length = s.output_len();
                     }
 
-                    let tokens = &multi_output_ids[idx];
-                    let mut token_ids = if tokens.len() > 1 {
-                        tokens.to_vec()
+                    let mut token_ids = if step_tokens.len() > 1 {
+                        step_tokens.to_vec()
                     } else if self.is_pd_mode() && s.pd_first_token.is_some() && s.output_len() == 2
                     {
                         vec![s.pd_first_token.unwrap_or(s.last_token), s.last_token]
@@ -1468,7 +1497,7 @@ impl LLMEngine {
         } else {
             self.check_canceled(None);
         }
-        if self.econfig.server_mode.unwrap_or(true) && is_running {
+        if self.econfig.server_mode.unwrap_or(true) {
             self.may_print_decoding_throughput(&indices);
         }
         Ok(indices.len())

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,5 +1,6 @@
 pub mod block_manager;
 pub mod engine;
+pub mod mtp;
 pub mod prefix_cache;
 pub mod runner;
 pub mod scheduler;

--- a/src/core/mtp.rs
+++ b/src/core/mtp.rs
@@ -1,0 +1,161 @@
+// src/core/mtp.rs
+// Multi-Token Prediction (MTP) speculative decoding support.
+//
+// MTP uses lightweight prediction heads built into the model (e.g. Qwen3.5, DeepSeek-V3)
+// to draft future tokens using the backbone's hidden states and KV cache.
+// Accepted draft tokens are verified in a single target-model forward pass.
+
+use candle_core::{Result, Tensor, D};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Configuration for MTP speculative decoding at the engine level.
+#[derive(Debug, Clone)]
+pub struct MtpEngineConfig {
+    /// Number of speculative tokens to propose per step.
+    pub num_speculative_tokens: usize,
+}
+
+impl MtpEngineConfig {
+    pub fn new(num_speculative_tokens: usize) -> Self {
+        Self {
+            num_speculative_tokens: num_speculative_tokens.max(1),
+        }
+    }
+}
+
+/// Outcome of MTP verification for a single sequence.
+#[derive(Debug, Clone)]
+pub struct MtpVerifyResult {
+    /// All accepted tokens (draft tokens that matched the target model).
+    pub accepted_tokens: Vec<u32>,
+    /// The continuation token sampled from the first rejection point.
+    pub continuation_token: u32,
+    /// How many of the proposed drafts were accepted.
+    pub num_accepted: usize,
+    /// Total number proposed.
+    pub num_proposed: usize,
+}
+
+/// Verify draft tokens against target model logits (greedy / argmax).
+///
+/// `verify_logits`: shape [N+1, vocab_size] where N = len(draft_tokens).
+///   - Position 0 predicts draft_tokens[0]
+///   - Position i predicts draft_tokens[i] (for i < N)
+///   - Position N provides the continuation token after last accepted draft
+///
+/// Returns the verification result with accepted tokens and continuation.
+pub fn verify_draft_greedy(
+    verify_logits: &Tensor,
+    draft_tokens: &[u32],
+) -> Result<MtpVerifyResult> {
+    let num_positions = verify_logits.dim(0)?;
+    let num_proposed = draft_tokens.len();
+
+    if num_positions == 0 || num_proposed == 0 {
+        let first_token = if num_positions > 0 {
+            verify_logits
+                .get(0)?
+                .argmax(D::Minus1)?
+                .to_scalar::<u32>()?
+        } else {
+            0
+        };
+        return Ok(MtpVerifyResult {
+            accepted_tokens: vec![],
+            continuation_token: first_token,
+            num_accepted: 0,
+            num_proposed,
+        });
+    }
+
+    let mut accepted_tokens = Vec::with_capacity(num_proposed);
+
+    for (i, &draft_token) in draft_tokens.iter().enumerate() {
+        if i >= num_positions {
+            break;
+        }
+        let row_logits = verify_logits.get(i)?;
+        let target_token = row_logits.argmax(D::Minus1)?.to_scalar::<u32>()?;
+
+        if target_token == draft_token {
+            accepted_tokens.push(draft_token);
+        } else {
+            return Ok(MtpVerifyResult {
+                accepted_tokens,
+                continuation_token: target_token,
+                num_accepted: i,
+                num_proposed,
+            });
+        }
+    }
+
+    let num_accepted = accepted_tokens.len();
+    let continuation_idx = num_accepted.min(num_positions - 1);
+    let continuation_logits = verify_logits.get(continuation_idx)?;
+    let continuation_token = if num_accepted < num_positions {
+        verify_logits
+            .get(num_accepted)?
+            .argmax(D::Minus1)?
+            .to_scalar::<u32>()?
+    } else {
+        continuation_logits.argmax(D::Minus1)?.to_scalar::<u32>()?
+    };
+
+    Ok(MtpVerifyResult {
+        accepted_tokens,
+        continuation_token,
+        num_accepted,
+        num_proposed,
+    })
+}
+
+/// Global MTP statistics tracker.
+pub static MTP_TOTAL_PROPOSED: AtomicUsize = AtomicUsize::new(0);
+pub static MTP_TOTAL_ACCEPTED: AtomicUsize = AtomicUsize::new(0);
+pub static MTP_TOTAL_STEPS: AtomicUsize = AtomicUsize::new(0);
+
+pub fn mtp_stats_update(proposed: usize, accepted: usize) {
+    MTP_TOTAL_PROPOSED.fetch_add(proposed, Ordering::Relaxed);
+    MTP_TOTAL_ACCEPTED.fetch_add(accepted, Ordering::Relaxed);
+    MTP_TOTAL_STEPS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn mtp_stats_acceptance_rate() -> f64 {
+    let proposed = MTP_TOTAL_PROPOSED.load(Ordering::Relaxed);
+    let accepted = MTP_TOTAL_ACCEPTED.load(Ordering::Relaxed);
+    if proposed == 0 {
+        0.0
+    } else {
+        accepted as f64 / proposed as f64
+    }
+}
+
+pub fn mtp_stats_avg_tokens_per_step() -> f64 {
+    let steps = MTP_TOTAL_STEPS.load(Ordering::Relaxed);
+    let accepted = MTP_TOTAL_ACCEPTED.load(Ordering::Relaxed);
+    if steps == 0 {
+        1.0
+    } else {
+        (accepted + steps) as f64 / steps as f64
+    }
+}
+
+pub fn mtp_stats_summary() -> String {
+    let steps = MTP_TOTAL_STEPS.load(Ordering::Relaxed);
+    let proposed = MTP_TOTAL_PROPOSED.load(Ordering::Relaxed);
+    let accepted = MTP_TOTAL_ACCEPTED.load(Ordering::Relaxed);
+    format!(
+        "MTP Stats: steps={}, proposed={}, accepted={}, acceptance_rate={:.2}%, avg_tokens/step={:.2}",
+        steps,
+        proposed,
+        accepted,
+        if proposed > 0 { accepted as f64 / proposed as f64 * 100.0 } else { 0.0 },
+        if steps > 0 { (accepted + steps) as f64 / steps as f64 } else { 1.0 },
+    )
+}
+
+pub fn mtp_stats_reset() {
+    MTP_TOTAL_PROPOSED.store(0, Ordering::Relaxed);
+    MTP_TOTAL_ACCEPTED.store(0, Ordering::Relaxed);
+    MTP_TOTAL_STEPS.store(0, Ordering::Relaxed);
+}

--- a/src/core/mtp.rs
+++ b/src/core/mtp.rs
@@ -136,21 +136,29 @@ pub fn mtp_stats_avg_tokens_per_step() -> f64 {
     if steps == 0 {
         1.0
     } else {
-        (accepted + steps) as f64 / steps as f64
+        // Each step produces: 1 anchor + accepted drafts + 1 continuation
+        (accepted + 2 * steps) as f64 / steps as f64
     }
 }
 
 pub fn mtp_stats_summary() -> String {
-    let steps = MTP_TOTAL_STEPS.load(Ordering::Relaxed);
     let proposed = MTP_TOTAL_PROPOSED.load(Ordering::Relaxed);
     let accepted = MTP_TOTAL_ACCEPTED.load(Ordering::Relaxed);
+    let steps = MTP_TOTAL_STEPS.load(Ordering::Relaxed);
     format!(
-        "MTP Stats: steps={}, proposed={}, accepted={}, acceptance_rate={:.2}%, avg_tokens/step={:.2}",
-        steps,
+        "MTP Stats: proposed={}, accepted={}, acceptance_rate={:.2}%, avg_tokens/step={:.2}",
         proposed,
         accepted,
-        if proposed > 0 { accepted as f64 / proposed as f64 * 100.0 } else { 0.0 },
-        if steps > 0 { (accepted + steps) as f64 / steps as f64 } else { 1.0 },
+        if proposed > 0 {
+            accepted as f64 / proposed as f64 * 100.0
+        } else {
+            0.0
+        },
+        if steps > 0 {
+            (accepted + 2 * steps) as f64 / steps as f64
+        } else {
+            1.0
+        },
     )
 }
 

--- a/src/core/mtp.rs
+++ b/src/core/mtp.rs
@@ -4,24 +4,16 @@
 // MTP uses lightweight prediction heads built into the model (e.g. Qwen3.5, DeepSeek-V3)
 // to draft future tokens using the backbone's hidden states and KV cache.
 // Accepted draft tokens are verified in a single target-model forward pass.
+//
+// The speculative decode pipeline (step1 anchor, step2 draft, step3 verify) lives here,
+// keeping runner.rs and engine.rs focused on the standard inference path.
 
 use candle_core::{Result, Tensor, D};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-/// Configuration for MTP speculative decoding at the engine level.
-#[derive(Debug, Clone)]
-pub struct MtpEngineConfig {
-    /// Number of speculative tokens to propose per step.
-    pub num_speculative_tokens: usize,
-}
-
-impl MtpEngineConfig {
-    pub fn new(num_speculative_tokens: usize) -> Self {
-        Self {
-            num_speculative_tokens: num_speculative_tokens.max(1),
-        }
-    }
-}
+// ---------------------------------------------------------------------------
+// Verification & stats (pure functions, no model dependencies)
+// ---------------------------------------------------------------------------
 
 /// Outcome of MTP verification for a single sequence.
 #[derive(Debug, Clone)]
@@ -157,4 +149,507 @@ pub fn mtp_stats_reset() {
     MTP_TOTAL_PROPOSED.store(0, Ordering::Relaxed);
     MTP_TOTAL_ACCEPTED.store(0, Ordering::Relaxed);
     MTP_TOTAL_STEPS.store(0, Ordering::Relaxed);
+}
+
+// ---------------------------------------------------------------------------
+// MTP speculative decode pipeline (impl ModelRunner)
+// ---------------------------------------------------------------------------
+
+use crate::core::runner::{Model, ModelRunner, Seqs};
+use crate::models::layers::linear::set_linear_is_prefill;
+use attention_rs::InputMetadata;
+
+pub(crate) struct MtpSeqInfo {
+    pub id: usize,
+    pub len: usize,
+    pub block_table: Vec<u32>,
+}
+
+impl ModelRunner {
+    pub(crate) fn compute_slot_mappings(
+        &self,
+        seq_info: &MtpSeqInfo,
+        num_tokens: usize,
+        block_size: usize,
+        ctx: &str,
+    ) -> Result<Vec<i64>> {
+        let mut slots = Vec::with_capacity(num_tokens);
+        for i in 0..num_tokens {
+            let pos = seq_info.len + i;
+            let block_idx = pos / block_size;
+            let block_offset = pos % block_size;
+            if block_idx < seq_info.block_table.len() {
+                let physical_block = seq_info.block_table[block_idx] as i64;
+                slots.push(physical_block * block_size as i64 + block_offset as i64);
+            } else {
+                candle_core::bail!(
+                    "MTP {} missing KV block: block_idx {} >= block_table.len() {}. \
+                     Blocks must be pre-allocated before MTP.",
+                    ctx,
+                    block_idx,
+                    seq_info.block_table.len()
+                );
+            }
+        }
+        Ok(slots)
+    }
+
+    pub(crate) fn build_mtp_metadata(
+        &self,
+        seq_info: &MtpSeqInfo,
+        slot_mappings: &[i64],
+        q_len: usize,
+    ) -> Result<InputMetadata> {
+        let total_kv_len = (seq_info.len + q_len) as u32;
+        let mamba_slot_mapping = self.prepare_mamba_slot_mapping(&[seq_info.id], false)?;
+
+        #[cfg(feature = "flashinfer")]
+        let flashinfer_metadata = if let Some(params) = self.flashinfer_kv_params() {
+            let num_pages = seq_info.block_table.len();
+            let indptr_host = vec![0u32, num_pages as u32];
+            let indices_vec: Vec<u32> = seq_info.block_table.clone();
+            let last_page_tokens =
+                total_kv_len as usize - (num_pages.saturating_sub(1)) * params.page_size;
+            let last_len_host = vec![last_page_tokens as u32];
+            let kv_len_arr_host = vec![total_kv_len];
+            let q_cu_seqlens_host = vec![0u32, q_len as u32];
+
+            #[cfg(all(feature = "cuda", feature = "graph"))]
+            let use_graph = self
+                .mtp_capturer
+                .as_ref()
+                .map_or(false, |c| c.is_mtp_captured(q_len));
+            #[cfg(not(all(feature = "cuda", feature = "graph")))]
+            let use_graph = false;
+
+            let prefill_plan_info = if use_graph {
+                None
+            } else {
+                Some(attention_rs::flashinfer::prefill_plan(
+                    self.device(),
+                    &q_cu_seqlens_host,
+                    &indptr_host,
+                    &kv_len_arr_host,
+                    q_len as u32,
+                    1,
+                    params.num_qo_heads,
+                    params.num_kv_heads,
+                    params.head_dim,
+                    params.page_size,
+                    params.out_dtype,
+                    None,
+                    Some(params.kv_dtype),
+                    false,
+                )?)
+            };
+
+            Some(attention_rs::FlashInferMetadata {
+                indptr: Tensor::from_vec(indptr_host.clone(), (2,), self.device())?,
+                indptr_host,
+                indices: Tensor::from_vec(indices_vec, (num_pages,), self.device())?,
+                last_len: Tensor::from_vec(last_len_host.clone(), (1,), self.device())?,
+                last_len_host: Some(last_len_host),
+                kv_len_arr_host: Some(kv_len_arr_host),
+                total_num_rows: Some(q_len as u32),
+                batch_indices: None,
+                positions: None,
+                use_cuda_graph: use_graph,
+                decode_plan_info: None,
+                prefill_plan_info,
+                mla_decode_plan_info: None,
+                mla_prefill_plan_info: None,
+            })
+        } else {
+            None
+        };
+        #[cfg(not(feature = "flashinfer"))]
+        let flashinfer_metadata = None;
+
+        Ok(InputMetadata {
+            is_prefill: true,
+            is_mla: self.is_mla_model(),
+            sequence_ids: Some(vec![seq_info.id]),
+            mamba_slot_mapping,
+            slot_mapping: Tensor::from_vec(slot_mappings.to_vec(), (q_len,), self.device())?,
+            context_lens: Some(Tensor::from_vec(vec![total_kv_len], (1,), self.device())?),
+            block_tables: Some(Tensor::from_vec(
+                seq_info.block_table.clone(),
+                (1, seq_info.block_table.len()),
+                self.device(),
+            )?),
+            seqlens: None,
+            cu_seqlens_q: Some(Tensor::from_vec(
+                vec![0u32, q_len as u32],
+                (2,),
+                self.device(),
+            )?),
+            cu_seqlens_k: Some(Tensor::from_vec(
+                vec![0u32, total_kv_len],
+                (2,),
+                self.device(),
+            )?),
+            max_seqlen_q: q_len,
+            max_seqlen_k: seq_info.len + q_len,
+            max_context_len: seq_info.len + q_len,
+            flashinfer_metadata,
+            is_mtp_verify: true,
+        })
+    }
+
+    fn mtp_rollback_mamba(&self, seq_id: usize, keep_tokens: usize) -> Result<bool> {
+        match self.model() {
+            Model::Qwen3_5(m) => m.mtp_rollback_mamba(seq_id, keep_tokens),
+            Model::Qwen3_5MoE(m) => m.mtp_rollback_mamba(seq_id, keep_tokens),
+            Model::Qwen3VL(m) => m.mtp_rollback_mamba(seq_id, keep_tokens),
+            _ => Ok(false),
+        }
+    }
+
+    /// MTP Step 1: single-token decode to get anchor token + hidden state.
+    /// Tries CUDA graph replay first (the graph's internal buffer for the
+    /// post-norm hidden state is accessible via take_last_hidden_for_mtp),
+    /// falling back to eager forward_with_hidden.
+    fn mtp_decode_step1(&self, seqs: Seqs, _seq_info: &MtpSeqInfo) -> Result<(u32, Tensor)> {
+        let (input_ids, positions, mut input_metadata) = match &seqs {
+            Seqs::SeqRefs(seqs_ref) => self.prepare_decode(*seqs_ref)?,
+            Seqs::DecodeVec(decode_seqs) => self.prepare_decode(decode_seqs.iter())?,
+        };
+
+        let _decode_guard = set_linear_is_prefill(false);
+
+        // Try CUDA graph replay for the decode forward. The model's forward()
+        // stores hidden states in last_hidden_for_mtp during both capture and
+        // replay (the cached tensor shares GPU storage with the graph output,
+        // so it's updated in-place on replay).
+        #[cfg(all(feature = "cuda", feature = "graph"))]
+        {
+            let input_batch = input_ids.dim(0)?;
+            let require_exact_graph = input_metadata.mamba_slot_mapping.is_some();
+            let can_replay = if require_exact_graph {
+                self.decode_capturer.is_exact_captured(input_batch)
+            } else {
+                self.decode_capturer.is_captured(input_batch)
+            };
+            if can_replay {
+                let logits = match self.model() {
+                    Model::Qwen3_5(model) => {
+                        let _guard = model.lock_mamba_cache_for_graph();
+                        self.decode_capturer
+                            .replay(&input_ids, &positions, &input_metadata)?
+                    }
+                    Model::Qwen3_5MoE(model) => {
+                        let _guard = model.lock_mamba_cache_for_graph();
+                        self.decode_capturer
+                            .replay(&input_ids, &positions, &input_metadata)?
+                    }
+                    Model::Qwen3VL(model) => {
+                        if let Some(_guard) = model.lock_mamba_cache_for_graph() {
+                            self.decode_capturer
+                                .replay(&input_ids, &positions, &input_metadata)?
+                        } else {
+                            self.decode_capturer
+                                .replay(&input_ids, &positions, &input_metadata)?
+                        }
+                    }
+                    _ => self
+                        .decode_capturer
+                        .replay(&input_ids, &positions, &input_metadata)?,
+                };
+
+                let hidden_states = match self.model() {
+                    Model::Qwen3_5(model) => model.take_last_hidden_for_mtp(),
+                    Model::Qwen3_5MoE(model) => model.take_last_hidden_for_mtp(),
+                    Model::Qwen3VL(model) => model.take_last_hidden_for_mtp(),
+                    _ => None,
+                };
+
+                if let Some(hidden_states) = hidden_states {
+                    let anchor_token = self.sample(&logits, seqs, false)?[0];
+                    let seq_hidden = if hidden_states.dims().len() == 2 && hidden_states.dim(0)? > 1
+                    {
+                        hidden_states.get(hidden_states.dim(0)? - 1)?
+                    } else if hidden_states.dims().len() == 2 {
+                        hidden_states.get(0)?
+                    } else {
+                        hidden_states
+                    };
+                    return Ok((anchor_token, seq_hidden));
+                }
+            }
+        }
+
+        // Fallback: eager forward_with_hidden (no graph available or hidden state extraction failed)
+        #[cfg(feature = "flashinfer")]
+        if let Some(fm) = input_metadata.flashinfer_metadata.as_mut() {
+            if input_metadata.is_mla {
+                if fm.mla_decode_plan_info.is_none() {
+                    if let Some(params) = self.flashinfer_kv_params() {
+                        fm.mla_decode_plan_info = Some(attention_rs::mla::mla_decode_plan(
+                            self.device(),
+                            params.kv_dtype,
+                            &fm.indptr_host,
+                            input_ids.dim(0)?,
+                            params.num_qo_heads,
+                            params.page_size,
+                            fm.use_cuda_graph,
+                        )?);
+                    }
+                }
+            } else if fm.decode_plan_info.is_none() {
+                if let Some(params) = self.flashinfer_kv_params() {
+                    fm.decode_plan_info = Some(attention_rs::flashinfer::decode_plan(
+                        self.device(),
+                        params.kv_dtype,
+                        params.out_dtype,
+                        &fm.indptr_host,
+                        fm.last_len_host.as_deref(),
+                        fm.kv_len_arr_host.as_deref(),
+                        input_ids.dim(0)?,
+                        params.num_qo_heads,
+                        params.num_kv_heads,
+                        params.head_dim,
+                        params.page_size,
+                        fm.use_cuda_graph,
+                    )?);
+                }
+            }
+        }
+
+        let kv_cache = self.get_kv_cache();
+        let (logits, hidden_states) = match self.model() {
+            Model::Qwen3_5(model) => model.forward_with_hidden(
+                &input_ids,
+                &positions,
+                Some(&kv_cache),
+                &input_metadata,
+                false,
+            )?,
+            Model::Qwen3_5MoE(model) => model.forward_with_hidden(
+                &input_ids,
+                &positions,
+                Some(&kv_cache),
+                &input_metadata,
+                false,
+            )?,
+            Model::Qwen3VL(model) => model.forward_with_hidden(
+                &input_ids,
+                &positions,
+                Some(&kv_cache),
+                &input_metadata,
+                false,
+            )?,
+            _ => {
+                drop(kv_cache);
+                candle_core::bail!("MTP Step 1 requires Qwen3.5 model");
+            }
+        };
+        drop(kv_cache);
+
+        let anchor_token = self.sample(&logits, seqs, false)?[0];
+
+        let seq_hidden = if hidden_states.dims().len() == 2 && hidden_states.dim(0)? > 1 {
+            hidden_states.get(hidden_states.dim(0)? - 1)?
+        } else if hidden_states.dims().len() == 2 {
+            hidden_states.get(0)?
+        } else {
+            hidden_states.clone()
+        };
+
+        Ok((anchor_token, seq_hidden))
+    }
+
+    /// Run MTP speculative decode for a batch of sequences.
+    /// Returns Vec<Vec<u32>> where each inner vec contains all accepted tokens for that sequence
+    /// (anchor + accepted drafts + bonus token).
+    ///
+    /// Optimized flow:
+    ///   1. Run main model decode via CUDA graph replay (when available) + extract hidden state
+    ///   2. Sample anchor token from logits
+    ///   3. MTP head drafts K tokens autoregressively (no KV cache)
+    ///   4. Verify: run main model on [anchor, draft_0, ..., draft_{K-1}] using native flash
+    ///   5. On partial rejection: roll back GDN state to the accepted token boundary
+    ///   6. Greedy-accept matching prefix; take bonus token at first mismatch
+    pub fn run_mtp_decode(&self, seqs: Seqs) -> Result<Vec<Vec<u32>>> {
+        let mtp_head = match &self.mtp_head {
+            Some(h) => h.clone(),
+            None => {
+                let output = self.run(seqs, false)?;
+                return Ok(output.into_iter().map(|t| vec![t]).collect());
+            }
+        };
+
+        let (batch_size, seq_infos) = match &seqs {
+            Seqs::SeqRefs(s) => {
+                let infos: Vec<MtpSeqInfo> = s
+                    .iter()
+                    .map(|seq| MtpSeqInfo {
+                        id: seq.id,
+                        len: seq.len(),
+                        block_table: seq.block_table.clone(),
+                    })
+                    .collect();
+                (s.len(), infos)
+            }
+            Seqs::DecodeVec(d) => {
+                let infos: Vec<MtpSeqInfo> = d
+                    .iter()
+                    .map(|ds| MtpSeqInfo {
+                        id: ds.id,
+                        len: ds.len,
+                        block_table: ds.block_tables.clone(),
+                    })
+                    .collect();
+                (d.len(), infos)
+            }
+        };
+
+        if batch_size != 1 {
+            let output = self.run(seqs, false)?;
+            return Ok(output.into_iter().map(|t| vec![t]).collect());
+        }
+
+        let seq_info = &seq_infos[0];
+        let num_draft = self.mtp_num_speculative;
+
+        // Step 1: Main model decode for logits + hidden state.
+        let (anchor_token, seq_hidden) = self.mtp_decode_step1(seqs, seq_info)?;
+
+        // Step 2: Draft K tokens using MTP head (GPU-resident, no per-step CPU sync)
+        let embed_weight = match self.model() {
+            Model::Qwen3_5(m) => m.embed_weight().clone(),
+            Model::Qwen3_5MoE(m) => m.embed_weight().clone(),
+            Model::Qwen3VL(m) => m
+                .embed_weight()
+                .expect("Qwen3VL MTP requires Qwen3.5 text backbone")
+                .clone(),
+            _ => unreachable!(),
+        };
+        let lm_head_fn = |hidden: &Tensor| -> Result<Tensor> {
+            match self.model() {
+                Model::Qwen3_5(m) => m.forward_lm_head(hidden),
+                Model::Qwen3_5MoE(m) => m.forward_lm_head(hidden),
+                Model::Qwen3VL(m) => m.forward_lm_head(hidden),
+                _ => unreachable!(),
+            }
+        };
+
+        let base_position = seq_info.len.saturating_sub(1);
+        let anchor_token_tensor = Tensor::from_vec(vec![anchor_token], (1,), self.device())?;
+        let (draft_tokens, _last_hidden) = mtp_head.draft_tokens_gpu(
+            &seq_hidden,
+            &anchor_token_tensor,
+            num_draft,
+            &embed_weight,
+            lm_head_fn,
+            base_position,
+        )?;
+
+        if draft_tokens.is_empty() {
+            return Ok(vec![vec![anchor_token]]);
+        }
+
+        // Step 3: Verify draft tokens via prefill-style forward on [anchor, draft_0..K-1].
+        let mut verify_tokens = vec![anchor_token];
+        verify_tokens.extend_from_slice(&draft_tokens);
+        let verify_len = verify_tokens.len();
+
+        let block_size = self.block_size();
+        let slot_mappings =
+            self.compute_slot_mappings(seq_info, verify_len, block_size, "verify")?;
+
+        let verify_input_ids = Tensor::from_vec(verify_tokens, (verify_len,), self.device())?;
+        let verify_positions_tensor = Tensor::from_vec(
+            (0..verify_len)
+                .map(|i| (seq_info.len + i) as i64)
+                .collect::<Vec<_>>(),
+            (verify_len,),
+            self.device(),
+        )?;
+
+        let verify_metadata =
+            self.build_mtp_metadata(seq_info, &slot_mappings[..verify_len], verify_len)?;
+
+        let _prefill_guard = set_linear_is_prefill(true);
+
+        #[cfg(all(feature = "cuda", feature = "graph"))]
+        let use_mtp_graph = self
+            .mtp_capturer
+            .as_ref()
+            .map_or(false, |c| c.is_mtp_captured(verify_len));
+        #[cfg(not(all(feature = "cuda", feature = "graph")))]
+        let use_mtp_graph = false;
+
+        let all_logits_result = if use_mtp_graph {
+            #[cfg(all(feature = "cuda", feature = "graph"))]
+            {
+                self.mtp_capturer.as_ref().unwrap().replay_mtp(
+                    &verify_input_ids,
+                    &verify_positions_tensor,
+                    &verify_metadata,
+                )
+            }
+            #[cfg(not(all(feature = "cuda", feature = "graph")))]
+            {
+                unreachable!()
+            }
+        } else {
+            let kv_cache = self.get_kv_cache();
+            let res = match self.model() {
+                Model::Qwen3_5(model) => model.forward(
+                    &verify_input_ids,
+                    &verify_positions_tensor,
+                    Some(&kv_cache),
+                    &verify_metadata,
+                    false,
+                ),
+                Model::Qwen3_5MoE(model) => model.forward(
+                    &verify_input_ids,
+                    &verify_positions_tensor,
+                    Some(&kv_cache),
+                    &verify_metadata,
+                    false,
+                ),
+                Model::Qwen3VL(model) => model.forward(
+                    &verify_input_ids,
+                    &verify_positions_tensor,
+                    Some(&kv_cache),
+                    &verify_metadata,
+                    None,
+                ),
+                _ => unreachable!(),
+            };
+            drop(kv_cache);
+            res
+        };
+        let all_logits = all_logits_result?;
+
+        let verify_result = verify_draft_greedy(&all_logits, &draft_tokens)?;
+
+        if verify_result.num_accepted < verify_result.num_proposed {
+            let commit_len = 1 + verify_result.num_accepted;
+            // KV cache does not need explicit rollback because the next decode writes
+            // the continuation token at the first rejected slot and stale later slots
+            // are outside the sequence length.
+            let restored = self.mtp_rollback_mamba(seq_info.id, commit_len)?;
+            if !restored {
+                candle_core::bail!(
+                    "MTP failed to roll back mamba-state snapshot for seq {} to {} verified token(s)",
+                    seq_info.id,
+                    commit_len
+                );
+            }
+        }
+
+        let mut result_tokens = Vec::with_capacity(2 + verify_result.num_accepted);
+        result_tokens.push(anchor_token);
+        result_tokens.extend_from_slice(&verify_result.accepted_tokens);
+        result_tokens.push(verify_result.continuation_token);
+
+        mtp_stats_update(verify_result.num_proposed, verify_result.num_accepted);
+        if MTP_TOTAL_STEPS.load(Ordering::Relaxed) % 256 == 0 {
+            crate::log_info!("{}", mtp_stats_summary());
+        }
+
+        Ok(vec![result_tokens])
+    }
 }

--- a/src/core/mtp.rs
+++ b/src/core/mtp.rs
@@ -38,12 +38,13 @@ pub struct MtpVerifyResult {
 
 /// Verify draft tokens against target model logits (greedy / argmax).
 ///
+/// Uses a single batched argmax over all rows + vectorized comparison on GPU,
+/// then transfers results to CPU in one shot.
+///
 /// `verify_logits`: shape [N+1, vocab_size] where N = len(draft_tokens).
 ///   - Position 0 predicts draft_tokens[0]
 ///   - Position i predicts draft_tokens[i] (for i < N)
 ///   - Position N provides the continuation token after last accepted draft
-///
-/// Returns the verification result with accepted tokens and continuation.
 pub fn verify_draft_greedy(
     verify_logits: &Tensor,
     draft_tokens: &[u32],
@@ -68,37 +69,27 @@ pub fn verify_draft_greedy(
         });
     }
 
-    let mut accepted_tokens = Vec::with_capacity(num_proposed);
+    // Keep verifier argmax aligned with the normal sampler path, which promotes
+    // logits to F32 before selecting tokens.
+    let verify_logits = verify_logits.to_dtype(candle_core::DType::F32)?;
+    let all_target_tokens = verify_logits.argmax(D::Minus1)?;
+    let target_vec: Vec<u32> = all_target_tokens.to_vec1()?;
 
-    for (i, &draft_token) in draft_tokens.iter().enumerate() {
-        if i >= num_positions {
-            break;
-        }
-        let row_logits = verify_logits.get(i)?;
-        let target_token = row_logits.argmax(D::Minus1)?.to_scalar::<u32>()?;
-
-        if target_token == draft_token {
-            accepted_tokens.push(draft_token);
+    let compare_len = num_proposed.min(num_positions);
+    let mut num_accepted = 0;
+    for i in 0..compare_len {
+        if target_vec[i] == draft_tokens[i] {
+            num_accepted += 1;
         } else {
-            return Ok(MtpVerifyResult {
-                accepted_tokens,
-                continuation_token: target_token,
-                num_accepted: i,
-                num_proposed,
-            });
+            break;
         }
     }
 
-    let num_accepted = accepted_tokens.len();
-    let continuation_idx = num_accepted.min(num_positions - 1);
-    let continuation_logits = verify_logits.get(continuation_idx)?;
+    let accepted_tokens = draft_tokens[..num_accepted].to_vec();
     let continuation_token = if num_accepted < num_positions {
-        verify_logits
-            .get(num_accepted)?
-            .argmax(D::Minus1)?
-            .to_scalar::<u32>()?
+        target_vec[num_accepted]
     } else {
-        continuation_logits.argmax(D::Minus1)?.to_scalar::<u32>()?
+        target_vec[num_positions - 1]
     };
 
     Ok(MtpVerifyResult {

--- a/src/core/mtp.rs
+++ b/src/core/mtp.rs
@@ -205,14 +205,31 @@ impl ModelRunner {
 
         #[cfg(feature = "flashinfer")]
         let flashinfer_metadata = if let Some(params) = self.flashinfer_kv_params() {
-            let num_pages = seq_info.block_table.len();
+            let num_pages = (total_kv_len as usize).div_ceil(params.page_size);
+            if num_pages > seq_info.block_table.len() {
+                candle_core::bail!(
+                    "MTP verify needs {} KV pages for {} tokens, but only {} pages are allocated",
+                    num_pages,
+                    total_kv_len,
+                    seq_info.block_table.len()
+                );
+            }
             let indptr_host = vec![0u32, num_pages as u32];
-            let indices_vec: Vec<u32> = seq_info.block_table.clone();
-            let last_page_tokens =
-                total_kv_len as usize - (num_pages.saturating_sub(1)) * params.page_size;
+            let indices_vec = seq_info.block_table[..num_pages].to_vec();
+            let last_page_tokens = if total_kv_len == 0 {
+                0
+            } else {
+                (total_kv_len as usize - 1) % params.page_size + 1
+            };
             let last_len_host = vec![last_page_tokens as u32];
             let kv_len_arr_host = vec![total_kv_len];
             let q_cu_seqlens_host = vec![0u32, q_len as u32];
+            let batch_indices = Tensor::zeros((q_len,), candle_core::DType::U32, self.device())?;
+            let append_positions = Tensor::from_vec(
+                (seq_info.len as u32..total_kv_len).collect::<Vec<_>>(),
+                (q_len,),
+                self.device(),
+            )?;
 
             #[cfg(all(feature = "cuda", feature = "graph"))]
             let use_graph = self
@@ -251,8 +268,11 @@ impl ModelRunner {
                 last_len_host: Some(last_len_host),
                 kv_len_arr_host: Some(kv_len_arr_host),
                 total_num_rows: Some(q_len as u32),
-                batch_indices: None,
-                positions: None,
+                // FlashInfer's multi-token append path is selected only when both
+                // tensors are present. Without them it falls back to decode append,
+                // which writes one KV row per sequence instead of all verify rows.
+                batch_indices: Some(batch_indices),
+                positions: Some(append_positions),
                 use_cuda_graph: use_graph,
                 decode_plan_info: None,
                 prefill_plan_info,
@@ -627,9 +647,10 @@ impl ModelRunner {
 
         if verify_result.num_accepted < verify_result.num_proposed {
             let commit_len = 1 + verify_result.num_accepted;
-            // KV cache does not need explicit rollback because the next decode writes
-            // the continuation token at the first rejected slot and stale later slots
-            // are outside the sequence length.
+            // Full-attention KV cache does not need explicit rollback: the next cycle's
+            // verify will overwrite rejected positions via append_kv_cache before the
+            // attention kernel reads them, and FlashInfer uses kCausal masking.
+            // GDN/Mamba state, however, is mutated in-place and must be rolled back.
             let restored = self.mtp_rollback_mamba(seq_info.id, commit_len)?;
             if !restored {
                 candle_core::bail!(

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -1531,7 +1531,7 @@ impl ModelRunner {
         result_tokens.push(verify_result.continuation_token);
 
         crate::core::mtp::mtp_stats_update(verify_result.num_proposed, verify_result.num_accepted);
-        if crate::core::mtp::MTP_TOTAL_STEPS.load(std::sync::atomic::Ordering::Relaxed) % 16 == 0 {
+        if crate::core::mtp::MTP_TOTAL_STEPS.load(std::sync::atomic::Ordering::Relaxed) % 256 == 0 {
             crate::log_info!("{}", crate::core::mtp::mtp_stats_summary());
         }
 

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -146,6 +146,12 @@ pub struct ModelRunner {
     mtp_num_speculative: usize,
 }
 
+struct MtpSeqInfo {
+    id: usize,
+    len: usize,
+    block_table: Vec<u32>,
+}
+
 impl ModelRunner {
     // Mamba slots track concurrent sequence states (not KV token blocks).
     const MAMBA_CACHE_FIXED_CAPACITY: usize = 64;
@@ -574,14 +580,17 @@ impl ModelRunner {
             Model::Qwen3_5(model) => {
                 model.preallocate_mamba_cache(mamba_cache_capacity)?;
                 model.set_mamba_prefix_cache_capacity(mamba_prefix_capacity);
+                model.preallocate_mtp_hidden_buffer(econfig.max_num_seqs.max(8))?;
             }
             Model::Qwen3_5MoE(model) => {
                 model.preallocate_mamba_cache(mamba_cache_capacity)?;
                 model.set_mamba_prefix_cache_capacity(mamba_prefix_capacity);
+                model.preallocate_mtp_hidden_buffer(econfig.max_num_seqs.max(8))?;
             }
             Model::Qwen3VL(model) => {
                 model.preallocate_mamba_cache(mamba_cache_capacity)?;
                 model.set_mamba_prefix_cache_capacity(mamba_prefix_capacity);
+                model.preallocate_mtp_hidden_buffer(econfig.max_num_seqs.max(8))?;
             }
             _ => {}
         }
@@ -1086,73 +1095,80 @@ impl ModelRunner {
         Ok(output_ids)
     }
 
-    /// Run MTP speculative decode for a batch of sequences.
-    /// Returns Vec<Vec<u32>> where each inner vec contains all accepted tokens for that sequence
-    /// (anchor + accepted drafts + bonus token).
-    ///
-    /// MTP bypasses CUDA graph to get hidden states from the main model forward pass.
-    /// The flow is:
-    ///   1. Run main model forward (no graph) → logits + hidden_state
-    ///   2. Sample base token from logits
-    ///   3. MTP predictor drafts K tokens autoregressively (no KV cache)
-    ///   4. Verify: run main model on [base, draft_0, ..., draft_{K-1}] (prefill-like)
-    ///   5. Greedy-accept matching prefix; take bonus token at first mismatch
-    pub fn run_mtp_decode(&self, seqs: Seqs) -> Result<Vec<Vec<u32>>> {
-        let mtp_head = match &self.mtp_head {
-            Some(h) => h.clone(),
-            None => {
-                let output = self.run(seqs, false)?;
-                return Ok(output.into_iter().map(|t| vec![t]).collect());
-            }
-        };
-
-        struct MtpSeqInfo {
-            id: usize,
-            len: usize,
-            block_table: Vec<u32>,
-        }
-
-        let (batch_size, seq_infos) = match &seqs {
-            Seqs::SeqRefs(s) => {
-                let infos: Vec<MtpSeqInfo> = s
-                    .iter()
-                    .map(|seq| MtpSeqInfo {
-                        id: seq.id,
-                        len: seq.len(),
-                        block_table: seq.block_table.clone(),
-                    })
-                    .collect();
-                (s.len(), infos)
-            }
-            Seqs::DecodeVec(d) => {
-                let infos: Vec<MtpSeqInfo> = d
-                    .iter()
-                    .map(|ds| MtpSeqInfo {
-                        id: ds.id,
-                        len: ds.len,
-                        block_table: ds.block_tables.clone(),
-                    })
-                    .collect();
-                (d.len(), infos)
-            }
-        };
-
-        if batch_size != 1 {
-            let output = self.run(seqs, false)?;
-            return Ok(output.into_iter().map(|t| vec![t]).collect());
-        }
-
-        let seq_info = &seq_infos[0];
-        let num_draft = self.mtp_num_speculative;
-
-        // Step 1: Main model forward WITHOUT CUDA graph to obtain hidden states.
-        // We prepare decode metadata normally, then call forward_with_hidden directly.
+    /// MTP Step 1: single-token decode to get anchor token + hidden state.
+    /// Tries CUDA graph replay first (the graph's internal buffer for the
+    /// post-norm hidden state is accessible via take_last_hidden_for_mtp),
+    /// falling back to eager forward_with_hidden.
+    fn mtp_decode_step1(&self, seqs: Seqs, _seq_info: &MtpSeqInfo) -> Result<(u32, Tensor)> {
         let (input_ids, positions, mut input_metadata) = match &seqs {
             Seqs::SeqRefs(seqs_ref) => self.prepare_decode(*seqs_ref)?,
             Seqs::DecodeVec(decode_seqs) => self.prepare_decode(decode_seqs.iter())?,
         };
 
-        // FlashInfer decode plan (same as in run())
+        let _decode_guard = set_linear_is_prefill(false);
+
+        // Try CUDA graph replay for the decode forward. The model's forward()
+        // stores hidden states in last_hidden_for_mtp during both capture and
+        // replay (the cached tensor shares GPU storage with the graph output,
+        // so it's updated in-place on replay).
+        #[cfg(all(feature = "cuda", feature = "graph"))]
+        {
+            let input_batch = input_ids.dim(0)?;
+            let require_exact_graph = input_metadata.mamba_slot_mapping.is_some();
+            let can_replay = if require_exact_graph {
+                self.capturer.is_exact_captured(input_batch)
+            } else {
+                self.capturer.is_captured(input_batch)
+            };
+            if can_replay {
+                let logits = match &self.model {
+                    Model::Qwen3_5(model) => {
+                        let _guard = model.lock_mamba_cache_for_graph();
+                        self.capturer
+                            .replay(&input_ids, &positions, &input_metadata)?
+                    }
+                    Model::Qwen3_5MoE(model) => {
+                        let _guard = model.lock_mamba_cache_for_graph();
+                        self.capturer
+                            .replay(&input_ids, &positions, &input_metadata)?
+                    }
+                    Model::Qwen3VL(model) => {
+                        if let Some(_guard) = model.lock_mamba_cache_for_graph() {
+                            self.capturer
+                                .replay(&input_ids, &positions, &input_metadata)?
+                        } else {
+                            self.capturer
+                                .replay(&input_ids, &positions, &input_metadata)?
+                        }
+                    }
+                    _ => self
+                        .capturer
+                        .replay(&input_ids, &positions, &input_metadata)?,
+                };
+
+                let hidden_states = match &self.model {
+                    Model::Qwen3_5(model) => model.take_last_hidden_for_mtp(),
+                    Model::Qwen3_5MoE(model) => model.take_last_hidden_for_mtp(),
+                    Model::Qwen3VL(model) => model.take_last_hidden_for_mtp(),
+                    _ => None,
+                };
+
+                if let Some(hidden_states) = hidden_states {
+                    let anchor_token = self.sample(&logits, seqs, false)?[0];
+                    let seq_hidden = if hidden_states.dims().len() == 2 && hidden_states.dim(0)? > 1
+                    {
+                        hidden_states.get(hidden_states.dim(0)? - 1)?
+                    } else if hidden_states.dims().len() == 2 {
+                        hidden_states.get(0)?
+                    } else {
+                        hidden_states
+                    };
+                    return Ok((anchor_token, seq_hidden));
+                }
+            }
+        }
+
+        // Fallback: eager forward_with_hidden (no graph available or hidden state extraction failed)
         #[cfg(feature = "flashinfer")]
         if let Some(fm) = input_metadata.flashinfer_metadata.as_mut() {
             if input_metadata.is_mla {
@@ -1189,15 +1205,16 @@ impl ModelRunner {
             }
         }
 
-        let _decode_guard = set_linear_is_prefill(false);
-
-        // Run the standard model forward without CUDA graph and return the
-        // target hidden state consumed by the MTP head. Avoid the global
-        // last_hidden_for_mtp side-channel here because verification also calls
-        // the target model and would otherwise overwrite it.
         let kv_cache = self.get_kv_cache();
         let (logits, hidden_states) = match &self.model {
             Model::Qwen3_5(model) => model.forward_with_hidden(
+                &input_ids,
+                &positions,
+                Some(&kv_cache),
+                &input_metadata,
+                false,
+            )?,
+            Model::Qwen3_5MoE(model) => model.forward_with_hidden(
                 &input_ids,
                 &positions,
                 Some(&kv_cache),
@@ -1213,36 +1230,13 @@ impl ModelRunner {
             )?,
             _ => {
                 drop(kv_cache);
-                let output = self.run(seqs, false)?;
-                return Ok(output.into_iter().map(|t| vec![t]).collect());
+                candle_core::bail!("MTP Step 1 requires Qwen3.5 model");
             }
         };
         drop(kv_cache);
 
         let anchor_token = self.sample(&logits, seqs, false)?[0];
 
-        // Step 2: Draft K tokens using MTP head
-        let device = self.device.clone();
-        let embed_fn = |token: u32| -> Result<Tensor> {
-            let token_tensor = Tensor::from_vec(vec![token], (1,), &device)?;
-            match &self.model {
-                Model::Qwen3_5(m) => m.embed_forward(&token_tensor),
-                Model::Qwen3VL(m) => m.embed_forward(&token_tensor),
-                _ => unreachable!(),
-            }
-        };
-        let lm_head_fn = |hidden: &Tensor| -> Result<Tensor> {
-            match &self.model {
-                Model::Qwen3_5(m) => m.forward_lm_head(hidden),
-                Model::Qwen3VL(m) => m.forward_lm_head(hidden),
-                _ => unreachable!(),
-            }
-        };
-
-        // Match vLLM's EAGLE-style MTP wiring: first draft pass feeds the
-        // sampled token while keeping the target decode position. Later draft
-        // passes advance by one.
-        let base_position = seq_info.len.saturating_sub(1);
         let seq_hidden = if hidden_states.dims().len() == 2 && hidden_states.dim(0)? > 1 {
             hidden_states.get(hidden_states.dim(0)? - 1)?
         } else if hidden_states.dims().len() == 2 {
@@ -1251,6 +1245,86 @@ impl ModelRunner {
             hidden_states.clone()
         };
 
+        Ok((anchor_token, seq_hidden))
+    }
+
+    /// Run MTP speculative decode for a batch of sequences.
+    /// Returns Vec<Vec<u32>> where each inner vec contains all accepted tokens for that sequence
+    /// (anchor + accepted drafts + bonus token).
+    ///
+    /// Optimized flow:
+    ///   1. Run main model decode via CUDA graph replay (when available) + extract hidden state
+    ///   2. Sample anchor token from logits
+    ///   3. MTP head drafts K tokens autoregressively (no KV cache)
+    ///   4. Verify: run main model on [anchor, draft_0, ..., draft_{K-1}] using native flash
+    ///   5. On partial rejection: restore mamba state + replay accepted prefix (mamba-only commit)
+    ///   6. Greedy-accept matching prefix; take bonus token at first mismatch
+    pub fn run_mtp_decode(&self, seqs: Seqs) -> Result<Vec<Vec<u32>>> {
+        let mtp_head = match &self.mtp_head {
+            Some(h) => h.clone(),
+            None => {
+                let output = self.run(seqs, false)?;
+                return Ok(output.into_iter().map(|t| vec![t]).collect());
+            }
+        };
+
+        let (batch_size, seq_infos) = match &seqs {
+            Seqs::SeqRefs(s) => {
+                let infos: Vec<MtpSeqInfo> = s
+                    .iter()
+                    .map(|seq| MtpSeqInfo {
+                        id: seq.id,
+                        len: seq.len(),
+                        block_table: seq.block_table.clone(),
+                    })
+                    .collect();
+                (s.len(), infos)
+            }
+            Seqs::DecodeVec(d) => {
+                let infos: Vec<MtpSeqInfo> = d
+                    .iter()
+                    .map(|ds| MtpSeqInfo {
+                        id: ds.id,
+                        len: ds.len,
+                        block_table: ds.block_tables.clone(),
+                    })
+                    .collect();
+                (d.len(), infos)
+            }
+        };
+
+        if batch_size != 1 {
+            let output = self.run(seqs, false)?;
+            return Ok(output.into_iter().map(|t| vec![t]).collect());
+        }
+
+        let seq_info = &seq_infos[0];
+        let num_draft = self.mtp_num_speculative;
+
+        // Step 1: Main model decode for logits + hidden state.
+        let (anchor_token, seq_hidden) = self.mtp_decode_step1(seqs, seq_info)?;
+
+        // Step 2: Draft K tokens using MTP head
+        let device = self.device.clone();
+        let embed_fn = |token: u32| -> Result<Tensor> {
+            let token_tensor = Tensor::from_vec(vec![token], (1,), &device)?;
+            match &self.model {
+                Model::Qwen3_5(m) => m.embed_forward(&token_tensor),
+                Model::Qwen3_5MoE(m) => m.embed_forward(&token_tensor),
+                Model::Qwen3VL(m) => m.embed_forward(&token_tensor),
+                _ => unreachable!(),
+            }
+        };
+        let lm_head_fn = |hidden: &Tensor| -> Result<Tensor> {
+            match &self.model {
+                Model::Qwen3_5(m) => m.forward_lm_head(hidden),
+                Model::Qwen3_5MoE(m) => m.forward_lm_head(hidden),
+                Model::Qwen3VL(m) => m.forward_lm_head(hidden),
+                _ => unreachable!(),
+            }
+        };
+
+        let base_position = seq_info.len.saturating_sub(1);
         let (draft_tokens, _last_hidden) = mtp_head.draft_tokens(
             &seq_hidden,
             anchor_token,
@@ -1272,7 +1346,9 @@ impl ModelRunner {
             );
         }
 
-        // Step 3: Verify draft tokens using main model (prefill-style forward)
+        // Step 3: Verify draft tokens using main model (prefill-style forward).
+        // Use native flash attention instead of FlashInfer to avoid expensive
+        // prefill_plan() overhead for small verify sequences (2-8 tokens).
         let mut verify_tokens = vec![anchor_token];
         verify_tokens.extend_from_slice(&draft_tokens);
         let verify_len = verify_tokens.len();
@@ -1302,85 +1378,9 @@ impl ModelRunner {
             }
         }
 
-        let cu_seqlens_q_vec = vec![0u32, verify_len as u32];
-        let cu_seqlens_q = Tensor::from_vec(cu_seqlens_q_vec.clone(), (2,), &self.device)?;
         let total_kv_len = (seq_info.len + verify_len) as u32;
-        let cu_seqlens_k = Tensor::from_vec(vec![0u32, total_kv_len], (2,), &self.device)?;
 
-        #[cfg(feature = "flashinfer")]
-        let verify_flashinfer = {
-            let effective_len = seq_info.len + verify_len;
-            let num_blocks_needed = (effective_len + block_size - 1) / block_size;
-            let num_blocks = num_blocks_needed.min(seq_info.block_table.len());
-            let bt = &seq_info.block_table[..num_blocks];
-
-            let indices_vec: Vec<u32> = bt.iter().map(|&x| x as u32).collect();
-            let indptr_host = vec![0u32, indices_vec.len() as u32];
-            let last_len = if effective_len == 0 {
-                0u32
-            } else {
-                ((effective_len - 1) % block_size + 1) as u32
-            };
-            let last_len_host = vec![last_len];
-            let kv_len = if indptr_host[1] == 0 {
-                0u32
-            } else {
-                (indptr_host[1] - 1) * block_size as u32 + last_len
-            };
-            let kv_len_arr_host = vec![kv_len];
-
-            let indptr_len = indptr_host.len();
-            let indices_len = indices_vec.len();
-            let indptr = Tensor::from_vec(indptr_host.clone(), (indptr_len,), &self.device)?;
-            let indices = Tensor::from_vec(indices_vec, (indices_len,), &self.device)?;
-            let last_len_t = Tensor::from_vec(last_len_host.clone(), (1,), &self.device)?;
-
-            let batch_indices_vec: Vec<u32> = vec![0u32; verify_len];
-            let positions_vec: Vec<u32> =
-                (seq_info.len as u32..(seq_info.len + verify_len) as u32).collect();
-            let batch_indices = Tensor::from_vec(batch_indices_vec, (verify_len,), &self.device)?;
-            let positions_t = Tensor::from_vec(positions_vec, (verify_len,), &self.device)?;
-
-            let prefill_plan_info = if let Some(params) = self.flashinfer_kv_params {
-                Some(attention_rs::flashinfer::prefill_plan(
-                    &self.device,
-                    &cu_seqlens_q_vec,
-                    &indptr_host,
-                    &kv_len_arr_host,
-                    verify_len as u32,
-                    1,
-                    params.num_qo_heads,
-                    params.num_kv_heads,
-                    params.head_dim,
-                    params.page_size,
-                    params.out_dtype,
-                    None,
-                    Some(params.kv_dtype),
-                )?)
-            } else {
-                None
-            };
-
-            Some(FlashInferMetadata {
-                indptr,
-                indptr_host,
-                indices,
-                last_len: last_len_t,
-                last_len_host: Some(last_len_host),
-                kv_len_arr_host: Some(kv_len_arr_host),
-                total_num_rows: Some(verify_len as u32),
-                batch_indices: Some(batch_indices),
-                positions: Some(positions_t),
-                use_cuda_graph: false,
-                decode_plan_info: None,
-                prefill_plan_info,
-                mla_decode_plan_info: None,
-                mla_prefill_plan_info: None,
-            })
-        };
-        #[cfg(not(feature = "flashinfer"))]
-        let verify_flashinfer: Option<FlashInferMetadata> = None;
-
+        // Native flash path: skip FlashInfer prefill_plan entirely
         let verify_metadata = InputMetadata {
             is_prefill: true,
             is_mla: self.is_mla_model(),
@@ -1394,32 +1394,49 @@ impl ModelRunner {
                 &self.device,
             )?),
             seqlens: None,
-            cu_seqlens_q: Some(cu_seqlens_q),
-            cu_seqlens_k: Some(cu_seqlens_k),
+            cu_seqlens_q: Some(Tensor::from_vec(
+                vec![0u32, verify_len as u32],
+                (2,),
+                &self.device,
+            )?),
+            cu_seqlens_k: Some(Tensor::from_vec(
+                vec![0u32, total_kv_len],
+                (2,),
+                &self.device,
+            )?),
             max_seqlen_q: verify_len,
             max_seqlen_k: seq_info.len + verify_len,
             max_context_len: seq_info.len + verify_len,
-            flashinfer_metadata: verify_flashinfer,
+            flashinfer_metadata: None,
         };
 
         let _prefill_guard = set_linear_is_prefill(true);
+        let kv_cache = self.get_kv_cache();
         let all_logits = match &self.model {
             Model::Qwen3_5(model) => model.forward(
                 &verify_input_ids,
                 &verify_positions_tensor,
-                Some(&self.get_kv_cache()),
+                Some(&kv_cache),
+                &verify_metadata,
+                false,
+            )?,
+            Model::Qwen3_5MoE(model) => model.forward(
+                &verify_input_ids,
+                &verify_positions_tensor,
+                Some(&kv_cache),
                 &verify_metadata,
                 false,
             )?,
             Model::Qwen3VL(model) => model.forward(
                 &verify_input_ids,
                 &verify_positions_tensor,
-                Some(&self.get_kv_cache()),
+                Some(&kv_cache),
                 &verify_metadata,
                 None,
             )?,
             _ => unreachable!(),
         };
+        drop(kv_cache);
 
         let verify_result = crate::core::mtp::verify_draft_greedy(&all_logits, &draft_tokens)?;
 
@@ -1433,91 +1450,104 @@ impl ModelRunner {
             }
 
             let commit_len = 1 + verify_result.num_accepted;
-            let mut commit_tokens = vec![anchor_token];
-            commit_tokens.extend_from_slice(&verify_result.accepted_tokens);
+            if commit_len > 0 {
+                let mut commit_tokens = vec![anchor_token];
+                commit_tokens.extend_from_slice(&verify_result.accepted_tokens);
 
-            let commit_input_ids = Tensor::from_vec(commit_tokens, (commit_len,), &self.device)?;
-            let commit_positions: Vec<i64> =
-                (0..commit_len).map(|i| (seq_info.len + i) as i64).collect();
-            let commit_positions_tensor =
-                Tensor::from_vec(commit_positions, (commit_len,), &self.device)?;
+                let commit_input_ids =
+                    Tensor::from_vec(commit_tokens, (commit_len,), &self.device)?;
+                let commit_positions: Vec<i64> =
+                    (0..commit_len).map(|i| (seq_info.len + i) as i64).collect();
+                let commit_positions_tensor =
+                    Tensor::from_vec(commit_positions, (commit_len,), &self.device)?;
 
-            let mut commit_slot_mappings = Vec::with_capacity(commit_len);
-            for i in 0..commit_len {
-                let pos = seq_info.len + i;
-                let block_idx = pos / block_size;
-                let block_offset = pos % block_size;
-                if block_idx < seq_info.block_table.len() {
-                    let physical_block = seq_info.block_table[block_idx] as i64;
-                    commit_slot_mappings
-                        .push(physical_block * block_size as i64 + block_offset as i64);
-                } else {
-                    candle_core::bail!(
-                        "MTP commit missing KV block: block_idx {} >= block_table.len() {}",
-                        block_idx,
-                        seq_info.block_table.len()
-                    );
+                let mut commit_slot_mappings = Vec::with_capacity(commit_len);
+                for i in 0..commit_len {
+                    let pos = seq_info.len + i;
+                    let block_idx = pos / block_size;
+                    let block_offset = pos % block_size;
+                    if block_idx < seq_info.block_table.len() {
+                        let physical_block = seq_info.block_table[block_idx] as i64;
+                        commit_slot_mappings
+                            .push(physical_block * block_size as i64 + block_offset as i64);
+                    } else {
+                        candle_core::bail!(
+                            "MTP commit missing KV block: block_idx {} >= block_table.len() {}",
+                            block_idx,
+                            seq_info.block_table.len()
+                        );
+                    }
                 }
+
+                let commit_total_kv_len = (seq_info.len + commit_len) as u32;
+                let commit_metadata = InputMetadata {
+                    is_prefill: true,
+                    is_mla: self.is_mla_model(),
+                    sequence_ids: Some(vec![seq_info.id]),
+                    mamba_slot_mapping: None,
+                    slot_mapping: Tensor::from_vec(
+                        commit_slot_mappings,
+                        (commit_len,),
+                        &self.device,
+                    )?,
+                    context_lens: Some(Tensor::from_vec(
+                        vec![commit_total_kv_len],
+                        (1,),
+                        &self.device,
+                    )?),
+                    block_tables: Some(Tensor::from_vec(
+                        seq_info.block_table.clone(),
+                        (1, seq_info.block_table.len()),
+                        &self.device,
+                    )?),
+                    seqlens: None,
+                    cu_seqlens_q: Some(Tensor::from_vec(
+                        vec![0u32, commit_len as u32],
+                        (2,),
+                        &self.device,
+                    )?),
+                    cu_seqlens_k: Some(Tensor::from_vec(
+                        vec![0u32, commit_total_kv_len],
+                        (2,),
+                        &self.device,
+                    )?),
+                    max_seqlen_q: commit_len,
+                    max_seqlen_k: seq_info.len + commit_len,
+                    max_context_len: seq_info.len + commit_len,
+                    flashinfer_metadata: None,
+                };
+
+                let _commit_guard = set_linear_is_prefill(true);
+                let kv_cache = self.get_kv_cache();
+                match &self.model {
+                    Model::Qwen3_5(model) => {
+                        model.forward_mamba_only(
+                            &commit_input_ids,
+                            &commit_positions_tensor,
+                            Some(&kv_cache),
+                            &commit_metadata,
+                        )?;
+                    }
+                    Model::Qwen3_5MoE(model) => {
+                        model.forward_mamba_only(
+                            &commit_input_ids,
+                            &commit_positions_tensor,
+                            Some(&kv_cache),
+                            &commit_metadata,
+                        )?;
+                    }
+                    Model::Qwen3VL(model) => {
+                        model.forward_mamba_only(
+                            &commit_input_ids,
+                            &commit_positions_tensor,
+                            Some(&kv_cache),
+                            &commit_metadata,
+                        )?;
+                    }
+                    _ => unreachable!(),
+                }
+                drop(kv_cache);
             }
-
-            let commit_total_kv_len = (seq_info.len + commit_len) as u32;
-            let commit_metadata = InputMetadata {
-                is_prefill: true,
-                is_mla: self.is_mla_model(),
-                sequence_ids: Some(vec![seq_info.id]),
-                mamba_slot_mapping: None,
-                slot_mapping: Tensor::from_vec(commit_slot_mappings, (commit_len,), &self.device)?,
-                context_lens: Some(Tensor::from_vec(
-                    vec![commit_total_kv_len],
-                    (1,),
-                    &self.device,
-                )?),
-                block_tables: Some(Tensor::from_vec(
-                    seq_info.block_table.clone(),
-                    (1, seq_info.block_table.len()),
-                    &self.device,
-                )?),
-                seqlens: None,
-                cu_seqlens_q: Some(Tensor::from_vec(
-                    vec![0u32, commit_len as u32],
-                    (2,),
-                    &self.device,
-                )?),
-                cu_seqlens_k: Some(Tensor::from_vec(
-                    vec![0u32, commit_total_kv_len],
-                    (2,),
-                    &self.device,
-                )?),
-                max_seqlen_q: commit_len,
-                max_seqlen_k: seq_info.len + commit_len,
-                max_context_len: seq_info.len + commit_len,
-                flashinfer_metadata: None,
-            };
-
-            let _commit_guard = set_linear_is_prefill(true);
-            let kv_cache = self.get_kv_cache();
-            match &self.model {
-                Model::Qwen3_5(model) => {
-                    model.forward(
-                        &commit_input_ids,
-                        &commit_positions_tensor,
-                        Some(&kv_cache),
-                        &commit_metadata,
-                        false,
-                    )?;
-                }
-                Model::Qwen3VL(model) => {
-                    model.forward(
-                        &commit_input_ids,
-                        &commit_positions_tensor,
-                        Some(&kv_cache),
-                        &commit_metadata,
-                        None,
-                    )?;
-                }
-                _ => unreachable!(),
-            }
-            drop(kv_cache);
         }
 
         let mut result_tokens = vec![anchor_token];

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -155,7 +155,6 @@ struct MtpSeqInfo {
 impl ModelRunner {
     // Mamba slots track concurrent sequence states (not KV token blocks).
     const MAMBA_CACHE_FIXED_CAPACITY: usize = 64;
-    const MTP_MAMBA_SNAPSHOT_TAG: u64 = 0x4d54_5000_0000_0000;
     #[cfg(all(feature = "cuda", feature = "graph"))]
     const GRAPH_CAPTURE_MIN_BATCH: usize = 16;
 
@@ -166,8 +165,72 @@ impl ModelRunner {
         )
     }
 
-    fn mtp_mamba_snapshot_hash(seq_id: usize) -> u64 {
-        Self::MTP_MAMBA_SNAPSHOT_TAG ^ seq_id as u64
+    fn compute_slot_mappings(
+        &self,
+        seq_info: &MtpSeqInfo,
+        num_tokens: usize,
+        block_size: usize,
+        ctx: &str,
+    ) -> Result<Vec<i64>> {
+        let mut slots = Vec::with_capacity(num_tokens);
+        for i in 0..num_tokens {
+            let pos = seq_info.len + i;
+            let block_idx = pos / block_size;
+            let block_offset = pos % block_size;
+            if block_idx < seq_info.block_table.len() {
+                let physical_block = seq_info.block_table[block_idx] as i64;
+                slots.push(physical_block * block_size as i64 + block_offset as i64);
+            } else {
+                candle_core::bail!(
+                    "MTP {} missing KV block: block_idx {} >= block_table.len() {}. \
+                     Blocks must be pre-allocated before MTP.",
+                    ctx,
+                    block_idx,
+                    seq_info.block_table.len()
+                );
+            }
+        }
+        Ok(slots)
+    }
+
+    fn build_mtp_metadata(
+        &self,
+        seq_info: &MtpSeqInfo,
+        slot_mappings: &[i64],
+        q_len: usize,
+    ) -> Result<InputMetadata> {
+        let total_kv_len = (seq_info.len + q_len) as u32;
+        let mamba_slot_mapping =
+            self.prepare_mamba_slot_mapping(&[seq_info.id], false)?;
+        Ok(InputMetadata {
+            is_prefill: true,
+            is_mla: self.is_mla_model(),
+            sequence_ids: Some(vec![seq_info.id]),
+            mamba_slot_mapping,
+            slot_mapping: Tensor::from_vec(slot_mappings.to_vec(), (q_len,), &self.device)?,
+            context_lens: Some(Tensor::from_vec(vec![total_kv_len], (1,), &self.device)?),
+            block_tables: Some(Tensor::from_vec(
+                seq_info.block_table.clone(),
+                (1, seq_info.block_table.len()),
+                &self.device,
+            )?),
+            seqlens: None,
+            cu_seqlens_q: Some(Tensor::from_vec(
+                vec![0u32, q_len as u32],
+                (2,),
+                &self.device,
+            )?),
+            cu_seqlens_k: Some(Tensor::from_vec(
+                vec![0u32, total_kv_len],
+                (2,),
+                &self.device,
+            )?),
+            max_seqlen_q: q_len,
+            max_seqlen_k: seq_info.len + q_len,
+            max_context_len: seq_info.len + q_len,
+            flashinfer_metadata: None,
+            is_mtp_verify: true,
+        })
     }
 
     fn prepare_mamba_slot_mapping(
@@ -752,45 +815,60 @@ impl ModelRunner {
             }
         }
 
-        // MTP head initialization: load if model has MTP layers and user enabled MTP
-        let (mtp_head, mtp_num_speculative) =
-            if let Some(num_spec) = econfig.mtp_num_speculative_tokens {
-                if config.mtp_num_hidden_layers.unwrap_or(0) > 0
-                    && matches!(
-                        model_type,
-                        ModelType::Qwen3_5 | ModelType::Qwen3_5MoE | ModelType::Qwen3VL
-                    )
-                {
-                    match crate::models::qwen3_5_mtp::Qwen3_5MtpHead::new(
-                        vb,
-                        comm.clone(),
-                        config,
-                        dtype,
-                        is_rope_i,
-                        &device,
-                    ) {
-                        Ok(head) => {
-                            crate::log_info!(
-                                "MTP head loaded: {} speculative tokens per step",
-                                num_spec
-                            );
-                            (Some(Arc::new(head)), num_spec)
-                        }
-                        Err(e) => {
-                            crate::log_warn!("Failed to load MTP head: {}. MTP disabled.", e);
-                            (None, 0)
-                        }
+        let (mtp_head, mtp_num_speculative) = if let Some(num_spec) =
+            econfig.mtp_num_speculative_tokens
+        {
+            let is_mtp_model_type = matches!(
+                model_type,
+                ModelType::Qwen3_5 | ModelType::Qwen3_5MoE | ModelType::Qwen3VL
+            );
+            let has_mtp_config = config.mtp_num_hidden_layers.unwrap_or(0) > 0;
+            let has_mtp_weights = vb.pp("mtp").has_key("fc.weight")
+                || vb.pp("mtp").has_key("layers.0.mlp.gate_proj.weight")
+                || vb.pp("mtp").has_key("layers.0.mlp.gate.weight");
+
+            if is_mtp_model_type && has_mtp_config && has_mtp_weights {
+                match crate::models::qwen3_5_mtp::Qwen3_5MtpHead::new(
+                    vb,
+                    comm.clone(),
+                    config,
+                    dtype,
+                    is_rope_i,
+                    &device,
+                ) {
+                    Ok(head) => {
+                        crate::log_info!(
+                            "MTP head loaded: {} speculative tokens per step",
+                            num_spec
+                        );
+                        (Some(Arc::new(head)), num_spec)
                     }
-                } else {
-                    crate::log_warn!(
-                        "MTP requested but model has no MTP layers (mtp_num_hidden_layers={})",
+                    Err(e) => {
+                        crate::log_warn!("Failed to load MTP head: {}. MTP disabled.", e);
+                        (None, 0)
+                    }
+                }
+            } else if !is_mtp_model_type {
+                crate::log_info!(
+                    "MTP requested but model type {:?} does not support MTP. MTP disabled.",
+                    model_type
+                );
+                (None, 0)
+            } else if !has_mtp_weights {
+                crate::log_info!(
+                    "MTP requested but model weights do not contain MTP layers. MTP disabled."
+                );
+                (None, 0)
+            } else {
+                crate::log_info!(
+                        "MTP requested but model config has no MTP layers (mtp_num_hidden_layers={}). MTP disabled.",
                         config.mtp_num_hidden_layers.unwrap_or(0)
                     );
-                    (None, 0)
-                }
-            } else {
                 (None, 0)
-            };
+            }
+        } else {
+            (None, 0)
+        };
 
         Ok(Self {
             model,
@@ -936,6 +1014,15 @@ impl ModelRunner {
             Model::Qwen3_5MoE(model) => Ok(model.remove_mamba_prefix_state(hash)),
             Model::Qwen3VL(model) => Ok(model.remove_mamba_prefix_state(hash)),
             _ => Ok(true),
+        }
+    }
+
+    fn mtp_rollback_mamba(&self, seq_id: usize, keep_tokens: usize) -> Result<bool> {
+        match &self.model {
+            Model::Qwen3_5(m) => m.mtp_rollback_mamba(seq_id, keep_tokens),
+            Model::Qwen3_5MoE(m) => m.mtp_rollback_mamba(seq_id, keep_tokens),
+            Model::Qwen3VL(m) => m.mtp_rollback_mamba(seq_id, keep_tokens),
+            _ => Ok(false),
         }
     }
 
@@ -1257,7 +1344,7 @@ impl ModelRunner {
     ///   2. Sample anchor token from logits
     ///   3. MTP head drafts K tokens autoregressively (no KV cache)
     ///   4. Verify: run main model on [anchor, draft_0, ..., draft_{K-1}] using native flash
-    ///   5. On partial rejection: restore mamba state + replay accepted prefix (mamba-only commit)
+    ///   5. On partial rejection: roll back GDN state to the accepted token boundary
     ///   6. Greedy-accept matching prefix; take bonus token at first mismatch
     pub fn run_mtp_decode(&self, seqs: Seqs) -> Result<Vec<Vec<u32>>> {
         let mtp_head = match &self.mtp_head {
@@ -1304,16 +1391,15 @@ impl ModelRunner {
         // Step 1: Main model decode for logits + hidden state.
         let (anchor_token, seq_hidden) = self.mtp_decode_step1(seqs, seq_info)?;
 
-        // Step 2: Draft K tokens using MTP head
-        let device = self.device.clone();
-        let embed_fn = |token: u32| -> Result<Tensor> {
-            let token_tensor = Tensor::from_vec(vec![token], (1,), &device)?;
-            match &self.model {
-                Model::Qwen3_5(m) => m.embed_forward(&token_tensor),
-                Model::Qwen3_5MoE(m) => m.embed_forward(&token_tensor),
-                Model::Qwen3VL(m) => m.embed_forward(&token_tensor),
-                _ => unreachable!(),
-            }
+        // Step 2: Draft K tokens using MTP head (GPU-resident, no per-step CPU sync)
+        let embed_weight = match &self.model {
+            Model::Qwen3_5(m) => m.embed_weight().clone(),
+            Model::Qwen3_5MoE(m) => m.embed_weight().clone(),
+            Model::Qwen3VL(m) => m
+                .embed_weight()
+                .expect("Qwen3VL MTP requires Qwen3.5 text backbone")
+                .clone(),
+            _ => unreachable!(),
         };
         let lm_head_fn = |hidden: &Tensor| -> Result<Tensor> {
             match &self.model {
@@ -1325,11 +1411,12 @@ impl ModelRunner {
         };
 
         let base_position = seq_info.len.saturating_sub(1);
-        let (draft_tokens, _last_hidden) = mtp_head.draft_tokens(
+        let anchor_token_tensor = Tensor::from_vec(vec![anchor_token], (1,), &self.device)?;
+        let (draft_tokens, _last_hidden) = mtp_head.draft_tokens_gpu(
             &seq_hidden,
-            anchor_token,
+            &anchor_token_tensor,
             num_draft,
-            embed_fn,
+            &embed_weight,
             lm_head_fn,
             base_position,
         )?;
@@ -1338,219 +1425,108 @@ impl ModelRunner {
             return Ok(vec![vec![anchor_token]]);
         }
 
-        let snapshot_hash = Self::mtp_mamba_snapshot_hash(seq_info.id);
-        if !self.capture_mamba_prefix_state(seq_info.id, snapshot_hash, false)? {
-            candle_core::bail!(
-                "MTP requires a Qwen3.5 mamba-state snapshot for seq {}, but snapshot capture failed",
-                seq_info.id
-            );
-        }
-
-        // Step 3: Verify draft tokens using main model (prefill-style forward).
-        // Use native flash attention instead of FlashInfer to avoid expensive
-        // prefill_plan() overhead for small verify sequences (2-8 tokens).
+        // Step 3: Verify draft tokens via prefill-style forward on [anchor, draft_0..K-1].
         let mut verify_tokens = vec![anchor_token];
         verify_tokens.extend_from_slice(&draft_tokens);
         let verify_len = verify_tokens.len();
 
-        let verify_input_ids = Tensor::from_vec(verify_tokens, (verify_len,), &self.device)?;
-        let verify_positions: Vec<i64> =
-            (0..verify_len).map(|i| (seq_info.len + i) as i64).collect();
-        let verify_positions_tensor =
-            Tensor::from_vec(verify_positions, (verify_len,), &self.device)?;
-
         let block_size = self.config.block_size;
-        let mut slot_mappings = Vec::with_capacity(verify_len);
-        for i in 0..verify_len {
-            let pos = seq_info.len + i;
-            let block_idx = pos / block_size;
-            let block_offset = pos % block_size;
-            if block_idx < seq_info.block_table.len() {
-                let physical_block = seq_info.block_table[block_idx] as i64;
-                slot_mappings.push(physical_block * block_size as i64 + block_offset as i64);
-            } else {
-                candle_core::bail!(
-                    "MTP verify missing KV block: block_idx {} >= block_table.len() {}. \
-                     Blocks must be pre-allocated before MTP verification.",
-                    block_idx,
-                    seq_info.block_table.len()
-                );
-            }
-        }
+        let slot_mappings =
+            self.compute_slot_mappings(seq_info, verify_len, block_size, "verify")?;
 
-        let total_kv_len = (seq_info.len + verify_len) as u32;
+        let verify_input_ids = Tensor::from_vec(verify_tokens, (verify_len,), &self.device)?;
+        let verify_positions_tensor = Tensor::from_vec(
+            (0..verify_len)
+                .map(|i| (seq_info.len + i) as i64)
+                .collect::<Vec<_>>(),
+            (verify_len,),
+            &self.device,
+        )?;
 
-        // Native flash path: skip FlashInfer prefill_plan entirely
-        let verify_metadata = InputMetadata {
-            is_prefill: true,
-            is_mla: self.is_mla_model(),
-            sequence_ids: Some(vec![seq_info.id]),
-            mamba_slot_mapping: None,
-            slot_mapping: Tensor::from_vec(slot_mappings, (verify_len,), &self.device)?,
-            context_lens: Some(Tensor::from_vec(vec![total_kv_len], (1,), &self.device)?),
-            block_tables: Some(Tensor::from_vec(
-                seq_info.block_table.clone(),
-                (1, seq_info.block_table.len()),
-                &self.device,
-            )?),
-            seqlens: None,
-            cu_seqlens_q: Some(Tensor::from_vec(
-                vec![0u32, verify_len as u32],
-                (2,),
-                &self.device,
-            )?),
-            cu_seqlens_k: Some(Tensor::from_vec(
-                vec![0u32, total_kv_len],
-                (2,),
-                &self.device,
-            )?),
-            max_seqlen_q: verify_len,
-            max_seqlen_k: seq_info.len + verify_len,
-            max_context_len: seq_info.len + verify_len,
-            flashinfer_metadata: None,
-        };
+        let verify_metadata =
+            self.build_mtp_metadata(seq_info, &slot_mappings[..verify_len], verify_len)?;
 
         let _prefill_guard = set_linear_is_prefill(true);
-        let kv_cache = self.get_kv_cache();
-        let all_logits = match &self.model {
-            Model::Qwen3_5(model) => model.forward(
-                &verify_input_ids,
-                &verify_positions_tensor,
-                Some(&kv_cache),
-                &verify_metadata,
-                false,
-            )?,
-            Model::Qwen3_5MoE(model) => model.forward(
-                &verify_input_ids,
-                &verify_positions_tensor,
-                Some(&kv_cache),
-                &verify_metadata,
-                false,
-            )?,
-            Model::Qwen3VL(model) => model.forward(
-                &verify_input_ids,
-                &verify_positions_tensor,
-                Some(&kv_cache),
-                &verify_metadata,
-                None,
-            )?,
-            _ => unreachable!(),
-        };
-        drop(kv_cache);
 
-        let verify_result = crate::core::mtp::verify_draft_greedy(&all_logits, &draft_tokens)?;
+        #[cfg(all(feature = "cuda", feature = "graph"))]
+        let use_mtp_graph = self.capturer.is_mtp_captured(verify_len);
+        #[cfg(not(all(feature = "cuda", feature = "graph")))]
+        let use_mtp_graph = false;
+
+        let all_logits_result = if use_mtp_graph {
+            #[cfg(all(feature = "cuda", feature = "graph"))]
+            {
+                self.capturer.replay_mtp(
+                    &verify_input_ids,
+                    &verify_positions_tensor,
+                    &verify_metadata,
+                )
+            }
+            #[cfg(not(all(feature = "cuda", feature = "graph")))]
+            {
+                unreachable!()
+            }
+        } else {
+            let kv_cache = self.get_kv_cache();
+            let res = match &self.model {
+                Model::Qwen3_5(model) => model.forward(
+                    &verify_input_ids,
+                    &verify_positions_tensor,
+                    Some(&kv_cache),
+                    &verify_metadata,
+                    false,
+                ),
+                Model::Qwen3_5MoE(model) => model.forward(
+                    &verify_input_ids,
+                    &verify_positions_tensor,
+                    Some(&kv_cache),
+                    &verify_metadata,
+                    false,
+                ),
+                Model::Qwen3VL(model) => model.forward(
+                    &verify_input_ids,
+                    &verify_positions_tensor,
+                    Some(&kv_cache),
+                    &verify_metadata,
+                    None,
+                ),
+                _ => unreachable!(),
+            };
+            drop(kv_cache);
+            res
+        };
+        let all_logits = match all_logits_result {
+            Ok(logits) => logits,
+            Err(err) => {
+                return Err(err);
+            }
+        };
+
+        let verify_result = match crate::core::mtp::verify_draft_greedy(&all_logits, &draft_tokens)
+        {
+            Ok(result) => result,
+            Err(err) => {
+                return Err(err);
+            }
+        };
 
         if verify_result.num_accepted < verify_result.num_proposed {
-            let restored = self.restore_mamba_prefix_state(seq_info.id, snapshot_hash)?;
+            let commit_len = 1 + verify_result.num_accepted;
+            // KV cache does not need explicit rollback because the next decode writes
+            // the continuation token at the first rejected slot and stale later slots
+            // are outside the sequence length.
+            let restored = self.mtp_rollback_mamba(seq_info.id, commit_len)?;
             if !restored {
                 candle_core::bail!(
-                    "MTP failed to restore Qwen3.5 mamba-state snapshot for seq {}",
-                    seq_info.id
+                    "MTP failed to roll back mamba-state snapshot for seq {} to {} verified token(s)",
+                    seq_info.id,
+                    commit_len
                 );
-            }
-
-            let commit_len = 1 + verify_result.num_accepted;
-            if commit_len > 0 {
-                let mut commit_tokens = vec![anchor_token];
-                commit_tokens.extend_from_slice(&verify_result.accepted_tokens);
-
-                let commit_input_ids =
-                    Tensor::from_vec(commit_tokens, (commit_len,), &self.device)?;
-                let commit_positions: Vec<i64> =
-                    (0..commit_len).map(|i| (seq_info.len + i) as i64).collect();
-                let commit_positions_tensor =
-                    Tensor::from_vec(commit_positions, (commit_len,), &self.device)?;
-
-                let mut commit_slot_mappings = Vec::with_capacity(commit_len);
-                for i in 0..commit_len {
-                    let pos = seq_info.len + i;
-                    let block_idx = pos / block_size;
-                    let block_offset = pos % block_size;
-                    if block_idx < seq_info.block_table.len() {
-                        let physical_block = seq_info.block_table[block_idx] as i64;
-                        commit_slot_mappings
-                            .push(physical_block * block_size as i64 + block_offset as i64);
-                    } else {
-                        candle_core::bail!(
-                            "MTP commit missing KV block: block_idx {} >= block_table.len() {}",
-                            block_idx,
-                            seq_info.block_table.len()
-                        );
-                    }
-                }
-
-                let commit_total_kv_len = (seq_info.len + commit_len) as u32;
-                let commit_metadata = InputMetadata {
-                    is_prefill: true,
-                    is_mla: self.is_mla_model(),
-                    sequence_ids: Some(vec![seq_info.id]),
-                    mamba_slot_mapping: None,
-                    slot_mapping: Tensor::from_vec(
-                        commit_slot_mappings,
-                        (commit_len,),
-                        &self.device,
-                    )?,
-                    context_lens: Some(Tensor::from_vec(
-                        vec![commit_total_kv_len],
-                        (1,),
-                        &self.device,
-                    )?),
-                    block_tables: Some(Tensor::from_vec(
-                        seq_info.block_table.clone(),
-                        (1, seq_info.block_table.len()),
-                        &self.device,
-                    )?),
-                    seqlens: None,
-                    cu_seqlens_q: Some(Tensor::from_vec(
-                        vec![0u32, commit_len as u32],
-                        (2,),
-                        &self.device,
-                    )?),
-                    cu_seqlens_k: Some(Tensor::from_vec(
-                        vec![0u32, commit_total_kv_len],
-                        (2,),
-                        &self.device,
-                    )?),
-                    max_seqlen_q: commit_len,
-                    max_seqlen_k: seq_info.len + commit_len,
-                    max_context_len: seq_info.len + commit_len,
-                    flashinfer_metadata: None,
-                };
-
-                let _commit_guard = set_linear_is_prefill(true);
-                let kv_cache = self.get_kv_cache();
-                match &self.model {
-                    Model::Qwen3_5(model) => {
-                        model.forward_mamba_only(
-                            &commit_input_ids,
-                            &commit_positions_tensor,
-                            Some(&kv_cache),
-                            &commit_metadata,
-                        )?;
-                    }
-                    Model::Qwen3_5MoE(model) => {
-                        model.forward_mamba_only(
-                            &commit_input_ids,
-                            &commit_positions_tensor,
-                            Some(&kv_cache),
-                            &commit_metadata,
-                        )?;
-                    }
-                    Model::Qwen3VL(model) => {
-                        model.forward_mamba_only(
-                            &commit_input_ids,
-                            &commit_positions_tensor,
-                            Some(&kv_cache),
-                            &commit_metadata,
-                        )?;
-                    }
-                    _ => unreachable!(),
-                }
-                drop(kv_cache);
             }
         }
 
-        let mut result_tokens = vec![anchor_token];
+        let mut result_tokens = Vec::with_capacity(2 + verify_result.num_accepted);
+        result_tokens.push(anchor_token);
         result_tokens.extend_from_slice(&verify_result.accepted_tokens);
         result_tokens.push(verify_result.continuation_token);
 
@@ -1890,6 +1866,7 @@ impl ModelRunner {
             max_context_len,
             seqlens: Some(cu_seqlens_q_vec[1..].to_vec()),
             flashinfer_metadata,
+            is_mtp_verify: false,
         };
 
         Ok((input_ids, positions, input_metadata))
@@ -2039,6 +2016,7 @@ impl ModelRunner {
             max_context_len,
             seqlens: None,
             flashinfer_metadata,
+            is_mtp_verify: false,
         };
 
         Ok((input_ids, positions, input_metadata))
@@ -2268,7 +2246,7 @@ impl ModelRunner {
 
     #[cfg(all(feature = "cuda", feature = "graph"))]
     pub fn warmup_capture(&mut self) -> Result<()> {
-        let kv_cache_lock = self.gpu_kv_cache.lock().unwrap(); // no custom method call on `self`
+        let kv_cache_lock = self.gpu_kv_cache.lock().unwrap();
         self.capturer.capture(&self.device, Some(&kv_cache_lock))?;
         match &self.model {
             Model::Qwen3_5(model) => model.reset_mamba_cache()?,
@@ -2276,6 +2254,22 @@ impl ModelRunner {
             Model::Qwen3VL(model) => model.reset_mamba_cache()?,
             _ => {}
         }
+
+        if self.mtp_num_speculative > 0 {
+            crate::log_info!(
+                "Capturing MTP verify graphs for up to {} draft tokens...",
+                self.mtp_num_speculative
+            );
+            self.capturer
+                .capture_mtp(&self.device, Some(&kv_cache_lock), self.mtp_num_speculative)?;
+            match &self.model {
+                Model::Qwen3_5(model) => model.reset_mamba_cache()?,
+                Model::Qwen3_5MoE(model) => model.reset_mamba_cache()?,
+                Model::Qwen3VL(model) => model.reset_mamba_cache()?,
+                _ => {}
+            }
+        }
+
         self.restored_prefix_sequences.write().clear();
         Ok(())
     }

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -4,6 +4,7 @@ use crate::models::gemma4::Gemma4ForCausalLM;
 use crate::models::layers::distributed::Comm;
 use crate::models::layers::linear::set_linear_is_prefill;
 use crate::models::layers::VarBuilderX;
+use crate::models::qwen3_5_mtp::Qwen3_5MtpHead;
 use crate::server::EmbeddingStrategy;
 use crate::transfer::Transfer;
 #[cfg(all(feature = "cuda", feature = "graph"))]
@@ -55,6 +56,7 @@ pub struct CachedSamplingParams {
     pub presence_penalty: Option<f32>,
 }
 
+#[derive(Clone, Copy)]
 pub enum Seqs<'a> {
     SeqRefs(&'a [&'a Sequence]),
     DecodeVec(&'a Vec<DecodeSequence>),
@@ -138,11 +140,16 @@ pub struct ModelRunner {
     /// Whether this runner is on the first rank (for logging)
     is_first_rank: bool,
     model_type: ModelType,
+    /// MTP head for speculative decoding (Qwen3.5 only for now)
+    mtp_head: Option<Arc<Qwen3_5MtpHead>>,
+    /// Number of speculative tokens to draft per step
+    mtp_num_speculative: usize,
 }
 
 impl ModelRunner {
     // Mamba slots track concurrent sequence states (not KV token blocks).
     const MAMBA_CACHE_FIXED_CAPACITY: usize = 64;
+    const MTP_MAMBA_SNAPSHOT_TAG: u64 = 0x4d54_5000_0000_0000;
     #[cfg(all(feature = "cuda", feature = "graph"))]
     const GRAPH_CAPTURE_MIN_BATCH: usize = 16;
 
@@ -151,6 +158,10 @@ impl ModelRunner {
             self.model_type,
             ModelType::GLM4MoeLite | ModelType::DeepSeek
         )
+    }
+
+    fn mtp_mamba_snapshot_hash(seq_id: usize) -> u64 {
+        Self::MTP_MAMBA_SNAPSHOT_TAG ^ seq_id as u64
     }
 
     fn prepare_mamba_slot_mapping(
@@ -553,6 +564,12 @@ impl ModelRunner {
                 );
             }
         }
+        if is_hybrid_mamba_model && econfig.mtp_num_speculative_tokens.unwrap_or(0) > 0 {
+            // MTP verification mutates Qwen3.5 linear-attention state speculatively.
+            // Keep at least one snapshot per active sequence so rejected drafts can
+            // be rolled back before replaying only the accepted prefix.
+            mamba_prefix_capacity = mamba_prefix_capacity.max(mamba_cache_capacity.max(1));
+        }
         match &model {
             Model::Qwen3_5(model) => {
                 model.preallocate_mamba_cache(mamba_cache_capacity)?;
@@ -726,6 +743,46 @@ impl ModelRunner {
             }
         }
 
+        // MTP head initialization: load if model has MTP layers and user enabled MTP
+        let (mtp_head, mtp_num_speculative) =
+            if let Some(num_spec) = econfig.mtp_num_speculative_tokens {
+                if config.mtp_num_hidden_layers.unwrap_or(0) > 0
+                    && matches!(
+                        model_type,
+                        ModelType::Qwen3_5 | ModelType::Qwen3_5MoE | ModelType::Qwen3VL
+                    )
+                {
+                    match crate::models::qwen3_5_mtp::Qwen3_5MtpHead::new(
+                        vb,
+                        comm.clone(),
+                        config,
+                        dtype,
+                        is_rope_i,
+                        &device,
+                    ) {
+                        Ok(head) => {
+                            crate::log_info!(
+                                "MTP head loaded: {} speculative tokens per step",
+                                num_spec
+                            );
+                            (Some(Arc::new(head)), num_spec)
+                        }
+                        Err(e) => {
+                            crate::log_warn!("Failed to load MTP head: {}. MTP disabled.", e);
+                            (None, 0)
+                        }
+                    }
+                } else {
+                    crate::log_warn!(
+                        "MTP requested but model has no MTP layers (mtp_num_hidden_layers={})",
+                        config.mtp_num_hidden_layers.unwrap_or(0)
+                    );
+                    (None, 0)
+                }
+            } else {
+                (None, 0)
+            };
+
         Ok(Self {
             model,
             gpu_kv_cache: Arc::new(Mutex::new(gpu_kv_cache)),
@@ -757,7 +814,29 @@ impl ModelRunner {
             transfer,
             is_first_rank: comm.rank() == 0,
             model_type,
+            mtp_head,
+            mtp_num_speculative,
         })
+    }
+
+    /// Initialize MTP head for speculative decoding.
+    /// Should be called after model construction when MTP is enabled.
+    pub fn init_mtp(
+        &mut self,
+        mtp_head: Arc<Qwen3_5MtpHead>,
+        num_speculative: usize,
+    ) -> Result<()> {
+        self.mtp_head = Some(mtp_head);
+        self.mtp_num_speculative = num_speculative;
+        crate::log_info!(
+            "MTP initialized: {} speculative tokens per step",
+            num_speculative,
+        );
+        Ok(())
+    }
+
+    pub fn has_mtp(&self) -> bool {
+        self.mtp_head.is_some() && self.mtp_num_speculative > 0
     }
 
     pub fn get_kv_cache(&self) -> MutexGuard<'_, Vec<(Tensor, Tensor)>> {
@@ -1005,6 +1084,452 @@ impl ModelRunner {
         #[cfg(feature = "nvtx")]
         nvtx::range_pop!();
         Ok(output_ids)
+    }
+
+    /// Run MTP speculative decode for a batch of sequences.
+    /// Returns Vec<Vec<u32>> where each inner vec contains all accepted tokens for that sequence
+    /// (anchor + accepted drafts + bonus token).
+    ///
+    /// MTP bypasses CUDA graph to get hidden states from the main model forward pass.
+    /// The flow is:
+    ///   1. Run main model forward (no graph) → logits + hidden_state
+    ///   2. Sample base token from logits
+    ///   3. MTP predictor drafts K tokens autoregressively (no KV cache)
+    ///   4. Verify: run main model on [base, draft_0, ..., draft_{K-1}] (prefill-like)
+    ///   5. Greedy-accept matching prefix; take bonus token at first mismatch
+    pub fn run_mtp_decode(&self, seqs: Seqs) -> Result<Vec<Vec<u32>>> {
+        let mtp_head = match &self.mtp_head {
+            Some(h) => h.clone(),
+            None => {
+                let output = self.run(seqs, false)?;
+                return Ok(output.into_iter().map(|t| vec![t]).collect());
+            }
+        };
+
+        struct MtpSeqInfo {
+            id: usize,
+            len: usize,
+            block_table: Vec<u32>,
+        }
+
+        let (batch_size, seq_infos) = match &seqs {
+            Seqs::SeqRefs(s) => {
+                let infos: Vec<MtpSeqInfo> = s
+                    .iter()
+                    .map(|seq| MtpSeqInfo {
+                        id: seq.id,
+                        len: seq.len(),
+                        block_table: seq.block_table.clone(),
+                    })
+                    .collect();
+                (s.len(), infos)
+            }
+            Seqs::DecodeVec(d) => {
+                let infos: Vec<MtpSeqInfo> = d
+                    .iter()
+                    .map(|ds| MtpSeqInfo {
+                        id: ds.id,
+                        len: ds.len,
+                        block_table: ds.block_tables.clone(),
+                    })
+                    .collect();
+                (d.len(), infos)
+            }
+        };
+
+        if batch_size != 1 {
+            let output = self.run(seqs, false)?;
+            return Ok(output.into_iter().map(|t| vec![t]).collect());
+        }
+
+        let seq_info = &seq_infos[0];
+        let num_draft = self.mtp_num_speculative;
+
+        // Step 1: Main model forward WITHOUT CUDA graph to obtain hidden states.
+        // We prepare decode metadata normally, then call forward_with_hidden directly.
+        let (input_ids, positions, mut input_metadata) = match &seqs {
+            Seqs::SeqRefs(seqs_ref) => self.prepare_decode(*seqs_ref)?,
+            Seqs::DecodeVec(decode_seqs) => self.prepare_decode(decode_seqs.iter())?,
+        };
+
+        // FlashInfer decode plan (same as in run())
+        #[cfg(feature = "flashinfer")]
+        if let Some(fm) = input_metadata.flashinfer_metadata.as_mut() {
+            if input_metadata.is_mla {
+                if fm.mla_decode_plan_info.is_none() {
+                    if let Some(params) = self.flashinfer_kv_params {
+                        fm.mla_decode_plan_info = Some(attention_rs::mla::mla_decode_plan(
+                            &self.device,
+                            params.kv_dtype,
+                            &fm.indptr_host,
+                            input_ids.dim(0)?,
+                            params.num_qo_heads,
+                            params.page_size,
+                            fm.use_cuda_graph,
+                        )?);
+                    }
+                }
+            } else if fm.decode_plan_info.is_none() {
+                if let Some(params) = self.flashinfer_kv_params {
+                    fm.decode_plan_info = Some(attention_rs::flashinfer::decode_plan(
+                        &self.device,
+                        params.kv_dtype,
+                        params.out_dtype,
+                        &fm.indptr_host,
+                        fm.last_len_host.as_deref(),
+                        fm.kv_len_arr_host.as_deref(),
+                        input_ids.dim(0)?,
+                        params.num_qo_heads,
+                        params.num_kv_heads,
+                        params.head_dim,
+                        params.page_size,
+                        fm.use_cuda_graph,
+                    )?);
+                }
+            }
+        }
+
+        let _decode_guard = set_linear_is_prefill(false);
+
+        // Run the standard model forward without CUDA graph and return the
+        // target hidden state consumed by the MTP head. Avoid the global
+        // last_hidden_for_mtp side-channel here because verification also calls
+        // the target model and would otherwise overwrite it.
+        let kv_cache = self.get_kv_cache();
+        let (logits, hidden_states) = match &self.model {
+            Model::Qwen3_5(model) => model.forward_with_hidden(
+                &input_ids,
+                &positions,
+                Some(&kv_cache),
+                &input_metadata,
+                false,
+            )?,
+            Model::Qwen3VL(model) => model.forward_with_hidden(
+                &input_ids,
+                &positions,
+                Some(&kv_cache),
+                &input_metadata,
+                false,
+            )?,
+            _ => {
+                drop(kv_cache);
+                let output = self.run(seqs, false)?;
+                return Ok(output.into_iter().map(|t| vec![t]).collect());
+            }
+        };
+        drop(kv_cache);
+
+        let anchor_token = self.sample(&logits, seqs, false)?[0];
+
+        // Step 2: Draft K tokens using MTP head
+        let device = self.device.clone();
+        let embed_fn = |token: u32| -> Result<Tensor> {
+            let token_tensor = Tensor::from_vec(vec![token], (1,), &device)?;
+            match &self.model {
+                Model::Qwen3_5(m) => m.embed_forward(&token_tensor),
+                Model::Qwen3VL(m) => m.embed_forward(&token_tensor),
+                _ => unreachable!(),
+            }
+        };
+        let lm_head_fn = |hidden: &Tensor| -> Result<Tensor> {
+            match &self.model {
+                Model::Qwen3_5(m) => m.forward_lm_head(hidden),
+                Model::Qwen3VL(m) => m.forward_lm_head(hidden),
+                _ => unreachable!(),
+            }
+        };
+
+        // Match vLLM's EAGLE-style MTP wiring: first draft pass feeds the
+        // sampled token while keeping the target decode position. Later draft
+        // passes advance by one.
+        let base_position = seq_info.len.saturating_sub(1);
+        let seq_hidden = if hidden_states.dims().len() == 2 && hidden_states.dim(0)? > 1 {
+            hidden_states.get(hidden_states.dim(0)? - 1)?
+        } else if hidden_states.dims().len() == 2 {
+            hidden_states.get(0)?
+        } else {
+            hidden_states.clone()
+        };
+
+        let (draft_tokens, _last_hidden) = mtp_head.draft_tokens(
+            &seq_hidden,
+            anchor_token,
+            num_draft,
+            embed_fn,
+            lm_head_fn,
+            base_position,
+        )?;
+
+        if draft_tokens.is_empty() {
+            return Ok(vec![vec![anchor_token]]);
+        }
+
+        let snapshot_hash = Self::mtp_mamba_snapshot_hash(seq_info.id);
+        if !self.capture_mamba_prefix_state(seq_info.id, snapshot_hash, false)? {
+            candle_core::bail!(
+                "MTP requires a Qwen3.5 mamba-state snapshot for seq {}, but snapshot capture failed",
+                seq_info.id
+            );
+        }
+
+        // Step 3: Verify draft tokens using main model (prefill-style forward)
+        let mut verify_tokens = vec![anchor_token];
+        verify_tokens.extend_from_slice(&draft_tokens);
+        let verify_len = verify_tokens.len();
+
+        let verify_input_ids = Tensor::from_vec(verify_tokens, (verify_len,), &self.device)?;
+        let verify_positions: Vec<i64> =
+            (0..verify_len).map(|i| (seq_info.len + i) as i64).collect();
+        let verify_positions_tensor =
+            Tensor::from_vec(verify_positions, (verify_len,), &self.device)?;
+
+        let block_size = self.config.block_size;
+        let mut slot_mappings = Vec::with_capacity(verify_len);
+        for i in 0..verify_len {
+            let pos = seq_info.len + i;
+            let block_idx = pos / block_size;
+            let block_offset = pos % block_size;
+            if block_idx < seq_info.block_table.len() {
+                let physical_block = seq_info.block_table[block_idx] as i64;
+                slot_mappings.push(physical_block * block_size as i64 + block_offset as i64);
+            } else {
+                candle_core::bail!(
+                    "MTP verify missing KV block: block_idx {} >= block_table.len() {}. \
+                     Blocks must be pre-allocated before MTP verification.",
+                    block_idx,
+                    seq_info.block_table.len()
+                );
+            }
+        }
+
+        let cu_seqlens_q_vec = vec![0u32, verify_len as u32];
+        let cu_seqlens_q = Tensor::from_vec(cu_seqlens_q_vec.clone(), (2,), &self.device)?;
+        let total_kv_len = (seq_info.len + verify_len) as u32;
+        let cu_seqlens_k = Tensor::from_vec(vec![0u32, total_kv_len], (2,), &self.device)?;
+
+        #[cfg(feature = "flashinfer")]
+        let verify_flashinfer = {
+            let effective_len = seq_info.len + verify_len;
+            let num_blocks_needed = (effective_len + block_size - 1) / block_size;
+            let num_blocks = num_blocks_needed.min(seq_info.block_table.len());
+            let bt = &seq_info.block_table[..num_blocks];
+
+            let indices_vec: Vec<u32> = bt.iter().map(|&x| x as u32).collect();
+            let indptr_host = vec![0u32, indices_vec.len() as u32];
+            let last_len = if effective_len == 0 {
+                0u32
+            } else {
+                ((effective_len - 1) % block_size + 1) as u32
+            };
+            let last_len_host = vec![last_len];
+            let kv_len = if indptr_host[1] == 0 {
+                0u32
+            } else {
+                (indptr_host[1] - 1) * block_size as u32 + last_len
+            };
+            let kv_len_arr_host = vec![kv_len];
+
+            let indptr_len = indptr_host.len();
+            let indices_len = indices_vec.len();
+            let indptr = Tensor::from_vec(indptr_host.clone(), (indptr_len,), &self.device)?;
+            let indices = Tensor::from_vec(indices_vec, (indices_len,), &self.device)?;
+            let last_len_t = Tensor::from_vec(last_len_host.clone(), (1,), &self.device)?;
+
+            let batch_indices_vec: Vec<u32> = vec![0u32; verify_len];
+            let positions_vec: Vec<u32> =
+                (seq_info.len as u32..(seq_info.len + verify_len) as u32).collect();
+            let batch_indices = Tensor::from_vec(batch_indices_vec, (verify_len,), &self.device)?;
+            let positions_t = Tensor::from_vec(positions_vec, (verify_len,), &self.device)?;
+
+            let prefill_plan_info = if let Some(params) = self.flashinfer_kv_params {
+                Some(attention_rs::flashinfer::prefill_plan(
+                    &self.device,
+                    &cu_seqlens_q_vec,
+                    &indptr_host,
+                    &kv_len_arr_host,
+                    verify_len as u32,
+                    1,
+                    params.num_qo_heads,
+                    params.num_kv_heads,
+                    params.head_dim,
+                    params.page_size,
+                    params.out_dtype,
+                    None,
+                    Some(params.kv_dtype),
+                )?)
+            } else {
+                None
+            };
+
+            Some(FlashInferMetadata {
+                indptr,
+                indptr_host,
+                indices,
+                last_len: last_len_t,
+                last_len_host: Some(last_len_host),
+                kv_len_arr_host: Some(kv_len_arr_host),
+                total_num_rows: Some(verify_len as u32),
+                batch_indices: Some(batch_indices),
+                positions: Some(positions_t),
+                use_cuda_graph: false,
+                decode_plan_info: None,
+                prefill_plan_info,
+                mla_decode_plan_info: None,
+                mla_prefill_plan_info: None,
+            })
+        };
+        #[cfg(not(feature = "flashinfer"))]
+        let verify_flashinfer: Option<FlashInferMetadata> = None;
+
+        let verify_metadata = InputMetadata {
+            is_prefill: true,
+            is_mla: self.is_mla_model(),
+            sequence_ids: Some(vec![seq_info.id]),
+            mamba_slot_mapping: None,
+            slot_mapping: Tensor::from_vec(slot_mappings, (verify_len,), &self.device)?,
+            context_lens: Some(Tensor::from_vec(vec![total_kv_len], (1,), &self.device)?),
+            block_tables: Some(Tensor::from_vec(
+                seq_info.block_table.clone(),
+                (1, seq_info.block_table.len()),
+                &self.device,
+            )?),
+            seqlens: None,
+            cu_seqlens_q: Some(cu_seqlens_q),
+            cu_seqlens_k: Some(cu_seqlens_k),
+            max_seqlen_q: verify_len,
+            max_seqlen_k: seq_info.len + verify_len,
+            max_context_len: seq_info.len + verify_len,
+            flashinfer_metadata: verify_flashinfer,
+        };
+
+        let _prefill_guard = set_linear_is_prefill(true);
+        let all_logits = match &self.model {
+            Model::Qwen3_5(model) => model.forward(
+                &verify_input_ids,
+                &verify_positions_tensor,
+                Some(&self.get_kv_cache()),
+                &verify_metadata,
+                false,
+            )?,
+            Model::Qwen3VL(model) => model.forward(
+                &verify_input_ids,
+                &verify_positions_tensor,
+                Some(&self.get_kv_cache()),
+                &verify_metadata,
+                None,
+            )?,
+            _ => unreachable!(),
+        };
+
+        let verify_result = crate::core::mtp::verify_draft_greedy(&all_logits, &draft_tokens)?;
+
+        if verify_result.num_accepted < verify_result.num_proposed {
+            let restored = self.restore_mamba_prefix_state(seq_info.id, snapshot_hash)?;
+            if !restored {
+                candle_core::bail!(
+                    "MTP failed to restore Qwen3.5 mamba-state snapshot for seq {}",
+                    seq_info.id
+                );
+            }
+
+            let commit_len = 1 + verify_result.num_accepted;
+            let mut commit_tokens = vec![anchor_token];
+            commit_tokens.extend_from_slice(&verify_result.accepted_tokens);
+
+            let commit_input_ids = Tensor::from_vec(commit_tokens, (commit_len,), &self.device)?;
+            let commit_positions: Vec<i64> =
+                (0..commit_len).map(|i| (seq_info.len + i) as i64).collect();
+            let commit_positions_tensor =
+                Tensor::from_vec(commit_positions, (commit_len,), &self.device)?;
+
+            let mut commit_slot_mappings = Vec::with_capacity(commit_len);
+            for i in 0..commit_len {
+                let pos = seq_info.len + i;
+                let block_idx = pos / block_size;
+                let block_offset = pos % block_size;
+                if block_idx < seq_info.block_table.len() {
+                    let physical_block = seq_info.block_table[block_idx] as i64;
+                    commit_slot_mappings
+                        .push(physical_block * block_size as i64 + block_offset as i64);
+                } else {
+                    candle_core::bail!(
+                        "MTP commit missing KV block: block_idx {} >= block_table.len() {}",
+                        block_idx,
+                        seq_info.block_table.len()
+                    );
+                }
+            }
+
+            let commit_total_kv_len = (seq_info.len + commit_len) as u32;
+            let commit_metadata = InputMetadata {
+                is_prefill: true,
+                is_mla: self.is_mla_model(),
+                sequence_ids: Some(vec![seq_info.id]),
+                mamba_slot_mapping: None,
+                slot_mapping: Tensor::from_vec(commit_slot_mappings, (commit_len,), &self.device)?,
+                context_lens: Some(Tensor::from_vec(
+                    vec![commit_total_kv_len],
+                    (1,),
+                    &self.device,
+                )?),
+                block_tables: Some(Tensor::from_vec(
+                    seq_info.block_table.clone(),
+                    (1, seq_info.block_table.len()),
+                    &self.device,
+                )?),
+                seqlens: None,
+                cu_seqlens_q: Some(Tensor::from_vec(
+                    vec![0u32, commit_len as u32],
+                    (2,),
+                    &self.device,
+                )?),
+                cu_seqlens_k: Some(Tensor::from_vec(
+                    vec![0u32, commit_total_kv_len],
+                    (2,),
+                    &self.device,
+                )?),
+                max_seqlen_q: commit_len,
+                max_seqlen_k: seq_info.len + commit_len,
+                max_context_len: seq_info.len + commit_len,
+                flashinfer_metadata: None,
+            };
+
+            let _commit_guard = set_linear_is_prefill(true);
+            let kv_cache = self.get_kv_cache();
+            match &self.model {
+                Model::Qwen3_5(model) => {
+                    model.forward(
+                        &commit_input_ids,
+                        &commit_positions_tensor,
+                        Some(&kv_cache),
+                        &commit_metadata,
+                        false,
+                    )?;
+                }
+                Model::Qwen3VL(model) => {
+                    model.forward(
+                        &commit_input_ids,
+                        &commit_positions_tensor,
+                        Some(&kv_cache),
+                        &commit_metadata,
+                        None,
+                    )?;
+                }
+                _ => unreachable!(),
+            }
+            drop(kv_cache);
+        }
+
+        let mut result_tokens = vec![anchor_token];
+        result_tokens.extend_from_slice(&verify_result.accepted_tokens);
+        result_tokens.push(verify_result.continuation_token);
+
+        crate::core::mtp::mtp_stats_update(verify_result.num_proposed, verify_result.num_accepted);
+        if crate::core::mtp::MTP_TOTAL_STEPS.load(std::sync::atomic::Ordering::Relaxed) % 16 == 0 {
+            crate::log_info!("{}", crate::core::mtp::mtp_stats_summary());
+        }
+
+        Ok(vec![result_tokens])
     }
 
     pub fn embed(&self, seqs: &[&Sequence], strategy: &EmbeddingStrategy) -> Result<Vec<Vec<f32>>> {

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -919,7 +919,7 @@ impl ModelRunner {
                 || vb.pp("mtp").has_key("layers.0.mlp.gate_proj.weight")
                 || vb.pp("mtp").has_key("layers.0.mlp.gate.weight");
 
-            if is_mtp_model_type && has_mtp_config && has_mtp_weights {
+            if is_mtp_model_type && (has_mtp_config || has_mtp_weights) && has_mtp_weights {
                 match crate::models::qwen3_5_mtp::Qwen3_5MtpHead::new(
                     vb,
                     comm.clone(),
@@ -2358,33 +2358,28 @@ impl ModelRunner {
         let kv_cache_lock = self.gpu_kv_cache.lock().unwrap();
         self.decode_capturer
             .capture(&self.device, Some(&kv_cache_lock))?;
-        match &self.model {
-            Model::Qwen3_5(model) => model.reset_mamba_cache()?,
-            Model::Qwen3_5MoE(model) => model.reset_mamba_cache()?,
-            Model::Qwen3VL(model) => model.reset_mamba_cache()?,
-            _ => {}
-        }
 
         if self.mtp_num_speculative > 0 {
-            crate::log_info!(
-                "Capturing MTP verify graphs for up to {} draft tokens...",
-                self.mtp_num_speculative
-            );
+            // self.decode_capturer.model.sync()?;
             if let Some(mtp_cap) = &mut self.mtp_capturer {
+                crate::log_info!(
+                    "Capturing MTP verify graphs for up to {} draft tokens...",
+                    self.mtp_num_speculative
+                );
                 mtp_cap.capture_mtp(
                     &self.device,
                     Some(&kv_cache_lock),
                     self.mtp_num_speculative,
                 )?;
             }
-            match &self.model {
-                Model::Qwen3_5(model) => model.reset_mamba_cache()?,
-                Model::Qwen3_5MoE(model) => model.reset_mamba_cache()?,
-                Model::Qwen3VL(model) => model.reset_mamba_cache()?,
-                _ => {}
-            }
         }
 
+        match &self.model {
+            Model::Qwen3_5(model) => model.reset_mamba_cache()?,
+            Model::Qwen3_5MoE(model) => model.reset_mamba_cache()?,
+            Model::Qwen3VL(model) => model.reset_mamba_cache()?,
+            _ => {}
+        }
         self.restored_prefix_sequences.write().clear();
         Ok(())
     }

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -117,20 +117,19 @@ pub struct CpuTqLayerCache {
 }
 
 pub struct ModelRunner {
-    model: Model,
+    pub(crate) model: Model,
     gpu_kv_cache: Arc<Mutex<Vec<(Tensor, Tensor)>>>,
     cpu_kv_cache: Arc<Mutex<Vec<(Tensor, Tensor)>>>,
     cpu_tq_cache: Option<Vec<CpuTqLayerCache>>,
-    device: Device,
+    pub(crate) device: Device,
     config: EngineConfig,
     #[cfg(all(feature = "cuda", feature = "graph"))]
     pub decode_capturer: GraphCapturer<CudaGraphWrapper<CudaGraphFn>>,
     #[cfg(all(feature = "cuda", feature = "graph"))]
     pub mtp_capturer: Option<GraphCapturer<CudaGraphWrapper<CudaGraphFn>>>,
     #[cfg(feature = "flashinfer")]
-    flashinfer_kv_params: Option<FlashInferKvParams>,
+    pub(crate) flashinfer_kv_params: Option<FlashInferKvParams>,
     logit_processor: LogitsProcessor,
-    /// Cached sampling strategy computed once during prefill, reused during decode
     cached_sampling: RwLock<Option<CachedSamplingParams>>,
     seq_tokens: RwLock<HashMap<usize, Vec<u32>>>,
     restored_prefix_sequences: RwLock<HashSet<usize>>,
@@ -139,19 +138,12 @@ pub struct ModelRunner {
     guidance_mismatch: RwLock<HashSet<usize>>,
     llg_factory: Option<Arc<ParserFactory>>,
     transfer: Option<Arc<Transfer>>,
-    /// Whether this runner is on the first rank (for logging)
     is_first_rank: bool,
-    model_type: ModelType,
+    pub(crate) model_type: ModelType,
     /// MTP head for speculative decoding (Qwen3.5 only for now)
-    mtp_head: Option<Arc<Qwen3_5MtpHead>>,
+    pub(crate) mtp_head: Option<Arc<Qwen3_5MtpHead>>,
     /// Number of speculative tokens to draft per step
-    mtp_num_speculative: usize,
-}
-
-struct MtpSeqInfo {
-    id: usize,
-    len: usize,
-    block_table: Vec<u32>,
+    pub(crate) mtp_num_speculative: usize,
 }
 
 impl ModelRunner {
@@ -160,144 +152,31 @@ impl ModelRunner {
     #[cfg(all(feature = "cuda", feature = "graph"))]
     const GRAPH_CAPTURE_MIN_BATCH: usize = 16;
 
-    fn is_mla_model(&self) -> bool {
+    pub(crate) fn is_mla_model(&self) -> bool {
         matches!(
             self.model_type,
             ModelType::GLM4MoeLite | ModelType::DeepSeek
         )
     }
 
-    fn compute_slot_mappings(
-        &self,
-        seq_info: &MtpSeqInfo,
-        num_tokens: usize,
-        block_size: usize,
-        ctx: &str,
-    ) -> Result<Vec<i64>> {
-        let mut slots = Vec::with_capacity(num_tokens);
-        for i in 0..num_tokens {
-            let pos = seq_info.len + i;
-            let block_idx = pos / block_size;
-            let block_offset = pos % block_size;
-            if block_idx < seq_info.block_table.len() {
-                let physical_block = seq_info.block_table[block_idx] as i64;
-                slots.push(physical_block * block_size as i64 + block_offset as i64);
-            } else {
-                candle_core::bail!(
-                    "MTP {} missing KV block: block_idx {} >= block_table.len() {}. \
-                     Blocks must be pre-allocated before MTP.",
-                    ctx,
-                    block_idx,
-                    seq_info.block_table.len()
-                );
-            }
-        }
-        Ok(slots)
+    pub(crate) fn model(&self) -> &Model {
+        &self.model
     }
 
-    fn build_mtp_metadata(
-        &self,
-        seq_info: &MtpSeqInfo,
-        slot_mappings: &[i64],
-        q_len: usize,
-    ) -> Result<InputMetadata> {
-        let total_kv_len = (seq_info.len + q_len) as u32;
-        let mamba_slot_mapping = self.prepare_mamba_slot_mapping(&[seq_info.id], false)?;
-
-        #[cfg(feature = "flashinfer")]
-        let flashinfer_metadata = if let Some(params) = self.flashinfer_kv_params {
-            let num_pages = seq_info.block_table.len();
-            let indptr_host = vec![0u32, num_pages as u32];
-            let indices_vec: Vec<u32> = seq_info.block_table.clone();
-            let last_page_tokens =
-                total_kv_len as usize - (num_pages.saturating_sub(1)) * params.page_size;
-            let last_len_host = vec![last_page_tokens as u32];
-            let kv_len_arr_host = vec![total_kv_len];
-            let q_cu_seqlens_host = vec![0u32, q_len as u32];
-
-            #[cfg(all(feature = "cuda", feature = "graph"))]
-            let use_graph = self
-                .mtp_capturer
-                .as_ref()
-                .map_or(false, |c| c.is_mtp_captured(q_len));
-            #[cfg(not(all(feature = "cuda", feature = "graph")))]
-            let use_graph = false;
-
-            let prefill_plan_info = if use_graph {
-                None
-            } else {
-                Some(attention_rs::flashinfer::prefill_plan(
-                    &self.device,
-                    &q_cu_seqlens_host,
-                    &indptr_host,
-                    &kv_len_arr_host,
-                    q_len as u32,
-                    1,
-                    params.num_qo_heads,
-                    params.num_kv_heads,
-                    params.head_dim,
-                    params.page_size,
-                    params.out_dtype,
-                    None,
-                    Some(params.kv_dtype),
-                    false,
-                )?)
-            };
-
-            Some(attention_rs::FlashInferMetadata {
-                indptr: Tensor::from_vec(indptr_host.clone(), (2,), &self.device)?,
-                indptr_host,
-                indices: Tensor::from_vec(indices_vec, (num_pages,), &self.device)?,
-                last_len: Tensor::from_vec(last_len_host.clone(), (1,), &self.device)?,
-                last_len_host: Some(last_len_host),
-                kv_len_arr_host: Some(kv_len_arr_host),
-                total_num_rows: Some(q_len as u32),
-                batch_indices: None,
-                positions: None,
-                use_cuda_graph: use_graph,
-                decode_plan_info: None,
-                prefill_plan_info,
-                mla_decode_plan_info: None,
-                mla_prefill_plan_info: None,
-            })
-        } else {
-            None
-        };
-        #[cfg(not(feature = "flashinfer"))]
-        let flashinfer_metadata = None;
-
-        Ok(InputMetadata {
-            is_prefill: true,
-            is_mla: self.is_mla_model(),
-            sequence_ids: Some(vec![seq_info.id]),
-            mamba_slot_mapping,
-            slot_mapping: Tensor::from_vec(slot_mappings.to_vec(), (q_len,), &self.device)?,
-            context_lens: Some(Tensor::from_vec(vec![total_kv_len], (1,), &self.device)?),
-            block_tables: Some(Tensor::from_vec(
-                seq_info.block_table.clone(),
-                (1, seq_info.block_table.len()),
-                &self.device,
-            )?),
-            seqlens: None,
-            cu_seqlens_q: Some(Tensor::from_vec(
-                vec![0u32, q_len as u32],
-                (2,),
-                &self.device,
-            )?),
-            cu_seqlens_k: Some(Tensor::from_vec(
-                vec![0u32, total_kv_len],
-                (2,),
-                &self.device,
-            )?),
-            max_seqlen_q: q_len,
-            max_seqlen_k: seq_info.len + q_len,
-            max_context_len: seq_info.len + q_len,
-            flashinfer_metadata,
-            is_mtp_verify: true,
-        })
+    pub(crate) fn device(&self) -> &Device {
+        &self.device
     }
 
-    fn prepare_mamba_slot_mapping(
+    pub(crate) fn block_size(&self) -> usize {
+        self.config.block_size
+    }
+
+    #[cfg(feature = "flashinfer")]
+    pub(crate) fn flashinfer_kv_params(&self) -> Option<crate::utils::FlashInferKvParams> {
+        self.flashinfer_kv_params
+    }
+
+    pub(crate) fn prepare_mamba_slot_mapping(
         &self,
         sequence_ids: &[usize],
         is_prefill: bool,
@@ -1122,15 +1001,6 @@ impl ModelRunner {
         }
     }
 
-    fn mtp_rollback_mamba(&self, seq_id: usize, keep_tokens: usize) -> Result<bool> {
-        match &self.model {
-            Model::Qwen3_5(m) => m.mtp_rollback_mamba(seq_id, keep_tokens),
-            Model::Qwen3_5MoE(m) => m.mtp_rollback_mamba(seq_id, keep_tokens),
-            Model::Qwen3VL(m) => m.mtp_rollback_mamba(seq_id, keep_tokens),
-            _ => Ok(false),
-        }
-    }
-
     #[allow(unused)]
     pub fn run(&self, seqs: Seqs, is_prefill: bool) -> Result<Vec<u32>> {
         #[cfg(feature = "nvtx")]
@@ -1285,365 +1155,6 @@ impl ModelRunner {
         #[cfg(feature = "nvtx")]
         nvtx::range_pop!();
         Ok(output_ids)
-    }
-
-    /// MTP Step 1: single-token decode to get anchor token + hidden state.
-    /// Tries CUDA graph replay first (the graph's internal buffer for the
-    /// post-norm hidden state is accessible via take_last_hidden_for_mtp),
-    /// falling back to eager forward_with_hidden.
-    fn mtp_decode_step1(&self, seqs: Seqs, _seq_info: &MtpSeqInfo) -> Result<(u32, Tensor)> {
-        let (input_ids, positions, mut input_metadata) = match &seqs {
-            Seqs::SeqRefs(seqs_ref) => self.prepare_decode(*seqs_ref)?,
-            Seqs::DecodeVec(decode_seqs) => self.prepare_decode(decode_seqs.iter())?,
-        };
-
-        let _decode_guard = set_linear_is_prefill(false);
-
-        // Try CUDA graph replay for the decode forward. The model's forward()
-        // stores hidden states in last_hidden_for_mtp during both capture and
-        // replay (the cached tensor shares GPU storage with the graph output,
-        // so it's updated in-place on replay).
-        #[cfg(all(feature = "cuda", feature = "graph"))]
-        {
-            let input_batch = input_ids.dim(0)?;
-            let require_exact_graph = input_metadata.mamba_slot_mapping.is_some();
-            let can_replay = if require_exact_graph {
-                self.decode_capturer.is_exact_captured(input_batch)
-            } else {
-                self.decode_capturer.is_captured(input_batch)
-            };
-            if can_replay {
-                let logits = match &self.model {
-                    Model::Qwen3_5(model) => {
-                        let _guard = model.lock_mamba_cache_for_graph();
-                        self.decode_capturer
-                            .replay(&input_ids, &positions, &input_metadata)?
-                    }
-                    Model::Qwen3_5MoE(model) => {
-                        let _guard = model.lock_mamba_cache_for_graph();
-                        self.decode_capturer
-                            .replay(&input_ids, &positions, &input_metadata)?
-                    }
-                    Model::Qwen3VL(model) => {
-                        if let Some(_guard) = model.lock_mamba_cache_for_graph() {
-                            self.decode_capturer
-                                .replay(&input_ids, &positions, &input_metadata)?
-                        } else {
-                            self.decode_capturer
-                                .replay(&input_ids, &positions, &input_metadata)?
-                        }
-                    }
-                    _ => self
-                        .decode_capturer
-                        .replay(&input_ids, &positions, &input_metadata)?,
-                };
-
-                let hidden_states = match &self.model {
-                    Model::Qwen3_5(model) => model.take_last_hidden_for_mtp(),
-                    Model::Qwen3_5MoE(model) => model.take_last_hidden_for_mtp(),
-                    Model::Qwen3VL(model) => model.take_last_hidden_for_mtp(),
-                    _ => None,
-                };
-
-                if let Some(hidden_states) = hidden_states {
-                    let anchor_token = self.sample(&logits, seqs, false)?[0];
-                    let seq_hidden = if hidden_states.dims().len() == 2 && hidden_states.dim(0)? > 1
-                    {
-                        hidden_states.get(hidden_states.dim(0)? - 1)?
-                    } else if hidden_states.dims().len() == 2 {
-                        hidden_states.get(0)?
-                    } else {
-                        hidden_states
-                    };
-                    return Ok((anchor_token, seq_hidden));
-                }
-            }
-        }
-
-        // Fallback: eager forward_with_hidden (no graph available or hidden state extraction failed)
-        #[cfg(feature = "flashinfer")]
-        if let Some(fm) = input_metadata.flashinfer_metadata.as_mut() {
-            if input_metadata.is_mla {
-                if fm.mla_decode_plan_info.is_none() {
-                    if let Some(params) = self.flashinfer_kv_params {
-                        fm.mla_decode_plan_info = Some(attention_rs::mla::mla_decode_plan(
-                            &self.device,
-                            params.kv_dtype,
-                            &fm.indptr_host,
-                            input_ids.dim(0)?,
-                            params.num_qo_heads,
-                            params.page_size,
-                            fm.use_cuda_graph,
-                        )?);
-                    }
-                }
-            } else if fm.decode_plan_info.is_none() {
-                if let Some(params) = self.flashinfer_kv_params {
-                    fm.decode_plan_info = Some(attention_rs::flashinfer::decode_plan(
-                        &self.device,
-                        params.kv_dtype,
-                        params.out_dtype,
-                        &fm.indptr_host,
-                        fm.last_len_host.as_deref(),
-                        fm.kv_len_arr_host.as_deref(),
-                        input_ids.dim(0)?,
-                        params.num_qo_heads,
-                        params.num_kv_heads,
-                        params.head_dim,
-                        params.page_size,
-                        fm.use_cuda_graph,
-                    )?);
-                }
-            }
-        }
-
-        let kv_cache = self.get_kv_cache();
-        let (logits, hidden_states) = match &self.model {
-            Model::Qwen3_5(model) => model.forward_with_hidden(
-                &input_ids,
-                &positions,
-                Some(&kv_cache),
-                &input_metadata,
-                false,
-            )?,
-            Model::Qwen3_5MoE(model) => model.forward_with_hidden(
-                &input_ids,
-                &positions,
-                Some(&kv_cache),
-                &input_metadata,
-                false,
-            )?,
-            Model::Qwen3VL(model) => model.forward_with_hidden(
-                &input_ids,
-                &positions,
-                Some(&kv_cache),
-                &input_metadata,
-                false,
-            )?,
-            _ => {
-                drop(kv_cache);
-                candle_core::bail!("MTP Step 1 requires Qwen3.5 model");
-            }
-        };
-        drop(kv_cache);
-
-        let anchor_token = self.sample(&logits, seqs, false)?[0];
-
-        let seq_hidden = if hidden_states.dims().len() == 2 && hidden_states.dim(0)? > 1 {
-            hidden_states.get(hidden_states.dim(0)? - 1)?
-        } else if hidden_states.dims().len() == 2 {
-            hidden_states.get(0)?
-        } else {
-            hidden_states.clone()
-        };
-
-        Ok((anchor_token, seq_hidden))
-    }
-
-    /// Run MTP speculative decode for a batch of sequences.
-    /// Returns Vec<Vec<u32>> where each inner vec contains all accepted tokens for that sequence
-    /// (anchor + accepted drafts + bonus token).
-    ///
-    /// Optimized flow:
-    ///   1. Run main model decode via CUDA graph replay (when available) + extract hidden state
-    ///   2. Sample anchor token from logits
-    ///   3. MTP head drafts K tokens autoregressively (no KV cache)
-    ///   4. Verify: run main model on [anchor, draft_0, ..., draft_{K-1}] using native flash
-    ///   5. On partial rejection: roll back GDN state to the accepted token boundary
-    ///   6. Greedy-accept matching prefix; take bonus token at first mismatch
-    pub fn run_mtp_decode(&self, seqs: Seqs) -> Result<Vec<Vec<u32>>> {
-        let mtp_head = match &self.mtp_head {
-            Some(h) => h.clone(),
-            None => {
-                let output = self.run(seqs, false)?;
-                return Ok(output.into_iter().map(|t| vec![t]).collect());
-            }
-        };
-
-        let (batch_size, seq_infos) = match &seqs {
-            Seqs::SeqRefs(s) => {
-                let infos: Vec<MtpSeqInfo> = s
-                    .iter()
-                    .map(|seq| MtpSeqInfo {
-                        id: seq.id,
-                        len: seq.len(),
-                        block_table: seq.block_table.clone(),
-                    })
-                    .collect();
-                (s.len(), infos)
-            }
-            Seqs::DecodeVec(d) => {
-                let infos: Vec<MtpSeqInfo> = d
-                    .iter()
-                    .map(|ds| MtpSeqInfo {
-                        id: ds.id,
-                        len: ds.len,
-                        block_table: ds.block_tables.clone(),
-                    })
-                    .collect();
-                (d.len(), infos)
-            }
-        };
-
-        if batch_size != 1 {
-            let output = self.run(seqs, false)?;
-            return Ok(output.into_iter().map(|t| vec![t]).collect());
-        }
-
-        let seq_info = &seq_infos[0];
-        let num_draft = self.mtp_num_speculative;
-
-        // Step 1: Main model decode for logits + hidden state.
-        let (anchor_token, seq_hidden) = self.mtp_decode_step1(seqs, seq_info)?;
-
-        // Step 2: Draft K tokens using MTP head (GPU-resident, no per-step CPU sync)
-        let embed_weight = match &self.model {
-            Model::Qwen3_5(m) => m.embed_weight().clone(),
-            Model::Qwen3_5MoE(m) => m.embed_weight().clone(),
-            Model::Qwen3VL(m) => m
-                .embed_weight()
-                .expect("Qwen3VL MTP requires Qwen3.5 text backbone")
-                .clone(),
-            _ => unreachable!(),
-        };
-        let lm_head_fn = |hidden: &Tensor| -> Result<Tensor> {
-            match &self.model {
-                Model::Qwen3_5(m) => m.forward_lm_head(hidden),
-                Model::Qwen3_5MoE(m) => m.forward_lm_head(hidden),
-                Model::Qwen3VL(m) => m.forward_lm_head(hidden),
-                _ => unreachable!(),
-            }
-        };
-
-        let base_position = seq_info.len.saturating_sub(1);
-        let anchor_token_tensor = Tensor::from_vec(vec![anchor_token], (1,), &self.device)?;
-        let (draft_tokens, _last_hidden) = mtp_head.draft_tokens_gpu(
-            &seq_hidden,
-            &anchor_token_tensor,
-            num_draft,
-            &embed_weight,
-            lm_head_fn,
-            base_position,
-        )?;
-
-        if draft_tokens.is_empty() {
-            return Ok(vec![vec![anchor_token]]);
-        }
-
-        // Step 3: Verify draft tokens via prefill-style forward on [anchor, draft_0..K-1].
-        let mut verify_tokens = vec![anchor_token];
-        verify_tokens.extend_from_slice(&draft_tokens);
-        let verify_len = verify_tokens.len();
-
-        let block_size = self.config.block_size;
-        let slot_mappings =
-            self.compute_slot_mappings(seq_info, verify_len, block_size, "verify")?;
-
-        let verify_input_ids = Tensor::from_vec(verify_tokens, (verify_len,), &self.device)?;
-        let verify_positions_tensor = Tensor::from_vec(
-            (0..verify_len)
-                .map(|i| (seq_info.len + i) as i64)
-                .collect::<Vec<_>>(),
-            (verify_len,),
-            &self.device,
-        )?;
-
-        let verify_metadata =
-            self.build_mtp_metadata(seq_info, &slot_mappings[..verify_len], verify_len)?;
-
-        let _prefill_guard = set_linear_is_prefill(true);
-
-        #[cfg(all(feature = "cuda", feature = "graph"))]
-        let use_mtp_graph = self
-            .mtp_capturer
-            .as_ref()
-            .map_or(false, |c| c.is_mtp_captured(verify_len));
-        #[cfg(not(all(feature = "cuda", feature = "graph")))]
-        let use_mtp_graph = false;
-
-        let all_logits_result = if use_mtp_graph {
-            #[cfg(all(feature = "cuda", feature = "graph"))]
-            {
-                self.mtp_capturer.as_ref().unwrap().replay_mtp(
-                    &verify_input_ids,
-                    &verify_positions_tensor,
-                    &verify_metadata,
-                )
-            }
-            #[cfg(not(all(feature = "cuda", feature = "graph")))]
-            {
-                unreachable!()
-            }
-        } else {
-            let kv_cache = self.get_kv_cache();
-            let res = match &self.model {
-                Model::Qwen3_5(model) => model.forward(
-                    &verify_input_ids,
-                    &verify_positions_tensor,
-                    Some(&kv_cache),
-                    &verify_metadata,
-                    false,
-                ),
-                Model::Qwen3_5MoE(model) => model.forward(
-                    &verify_input_ids,
-                    &verify_positions_tensor,
-                    Some(&kv_cache),
-                    &verify_metadata,
-                    false,
-                ),
-                Model::Qwen3VL(model) => model.forward(
-                    &verify_input_ids,
-                    &verify_positions_tensor,
-                    Some(&kv_cache),
-                    &verify_metadata,
-                    None,
-                ),
-                _ => unreachable!(),
-            };
-            drop(kv_cache);
-            res
-        };
-        let all_logits = match all_logits_result {
-            Ok(logits) => logits,
-            Err(err) => {
-                return Err(err);
-            }
-        };
-
-        let verify_result = match crate::core::mtp::verify_draft_greedy(&all_logits, &draft_tokens)
-        {
-            Ok(result) => result,
-            Err(err) => {
-                return Err(err);
-            }
-        };
-
-        if verify_result.num_accepted < verify_result.num_proposed {
-            let commit_len = 1 + verify_result.num_accepted;
-            // KV cache does not need explicit rollback because the next decode writes
-            // the continuation token at the first rejected slot and stale later slots
-            // are outside the sequence length.
-            let restored = self.mtp_rollback_mamba(seq_info.id, commit_len)?;
-            if !restored {
-                candle_core::bail!(
-                    "MTP failed to roll back mamba-state snapshot for seq {} to {} verified token(s)",
-                    seq_info.id,
-                    commit_len
-                );
-            }
-        }
-
-        let mut result_tokens = Vec::with_capacity(2 + verify_result.num_accepted);
-        result_tokens.push(anchor_token);
-        result_tokens.extend_from_slice(&verify_result.accepted_tokens);
-        result_tokens.push(verify_result.continuation_token);
-
-        crate::core::mtp::mtp_stats_update(verify_result.num_proposed, verify_result.num_accepted);
-        if crate::core::mtp::MTP_TOTAL_STEPS.load(std::sync::atomic::Ordering::Relaxed) % 256 == 0 {
-            crate::log_info!("{}", crate::core::mtp::mtp_stats_summary());
-        }
-
-        Ok(vec![result_tokens])
     }
 
     pub fn embed(&self, seqs: &[&Sequence], strategy: &EmbeddingStrategy) -> Result<Vec<Vec<f32>>> {
@@ -1981,7 +1492,10 @@ impl ModelRunner {
         Ok((input_ids, positions, input_metadata))
     }
 
-    fn prepare_decode<'a, I, S>(&self, seqs: I) -> Result<(Tensor, Tensor, InputMetadata)>
+    pub(crate) fn prepare_decode<'a, I, S>(
+        &self,
+        seqs: I,
+    ) -> Result<(Tensor, Tensor, InputMetadata)>
     where
         I: IntoIterator<Item = &'a S>,
         S: ToDecodeInput + 'a,
@@ -2131,7 +1645,7 @@ impl ModelRunner {
         Ok((input_ids, positions, input_metadata))
     }
 
-    fn sample(&self, logits: &Tensor, seqs: Seqs, is_prefill: bool) -> Result<Vec<u32>> {
+    pub(crate) fn sample(&self, logits: &Tensor, seqs: Seqs, is_prefill: bool) -> Result<Vec<u32>> {
         let seq_ids: Vec<usize> = match &seqs {
             Seqs::SeqRefs(seqs) => seqs.iter().map(|s| s.id()).collect(),
             Seqs::DecodeVec(v) => v.iter().map(|s| s.id()).collect(),

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -1506,15 +1506,34 @@ impl ModelRunner {
         let mut context_lens = Vec::new();
 
         let seq_refs: Vec<&'a S> = seqs.into_iter().collect(); // only references, no clone
+        let mut active_block_tables = Vec::with_capacity(seq_refs.len());
 
         for seq in &seq_refs {
+            let seq_len = seq.len();
+            if seq_len == 0 {
+                candle_core::bail!("Cannot decode an empty sequence");
+            }
+            let active_num_blocks = seq_len.div_ceil(self.config.block_size);
+            let block_table = seq.block_table();
+            if active_num_blocks > block_table.len() {
+                candle_core::bail!(
+                    "Decode sequence {} needs {} KV blocks for {} tokens, but only {} are allocated",
+                    seq.id(),
+                    active_num_blocks,
+                    seq_len,
+                    block_table.len()
+                );
+            }
+            let active_block_table = block_table[..active_num_blocks].to_vec();
+            let last_block_tokens = (seq_len - 1) % self.config.block_size + 1;
+            let last_block = active_block_table[active_num_blocks - 1];
+
             input_ids.push(seq.last_token());
-            positions.push((seq.len() - 1) as i64);
-            context_lens.push(seq.len() as u32);
-            let slot = seq.block_table_last() * self.config.block_size as u32
-                + seq.last_block_tokens() as u32
-                - 1;
+            positions.push((seq_len - 1) as i64);
+            context_lens.push(seq_len as u32);
+            let slot = last_block * self.config.block_size as u32 + last_block_tokens as u32 - 1;
             slot_mapping.push(slot as i64);
+            active_block_tables.push(active_block_table);
         }
 
         // Create tensors
@@ -1527,7 +1546,20 @@ impl ModelRunner {
 
         let slot_mapping = Tensor::from_vec(slot_mapping, (s_len,), &self.device)?;
         let context_lens = Tensor::from_vec(context_lens, (c_len,), &self.device)?;
-        let block_tables = self.prepare_block_tables(seq_refs.clone())?;
+        let max_active_blocks = active_block_tables.iter().map(Vec::len).max().unwrap_or(0);
+        let mut flat_block_tables = Vec::with_capacity(seq_refs.len() * max_active_blocks);
+        for block_table in &active_block_tables {
+            flat_block_tables.extend_from_slice(block_table);
+            flat_block_tables.resize(
+                flat_block_tables.len() + max_active_blocks - block_table.len(),
+                0,
+            );
+        }
+        let block_tables = Tensor::from_vec(
+            flat_block_tables,
+            (seq_refs.len(), max_active_blocks),
+            &self.device,
+        )?;
 
         #[cfg(feature = "flashinfer")]
         let flashinfer_metadata = if self.flashinfer_kv_params.is_some() {
@@ -1550,8 +1582,7 @@ impl ModelRunner {
             let mut indptr = vec![0u32];
             let mut indices = Vec::new();
             let mut last_len = Vec::new();
-            for seq in &seq_refs {
-                let bt = seq.block_table();
+            for (seq, bt) in seq_refs.iter().zip(active_block_tables.iter()) {
                 indices.extend(bt.iter().map(|&x| x as u32));
                 indptr.push(indices.len() as u32);
                 let len = seq.len();

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -124,7 +124,9 @@ pub struct ModelRunner {
     device: Device,
     config: EngineConfig,
     #[cfg(all(feature = "cuda", feature = "graph"))]
-    pub capturer: GraphCapturer<CudaGraphWrapper<CudaGraphFn>>,
+    pub decode_capturer: GraphCapturer<CudaGraphWrapper<CudaGraphFn>>,
+    #[cfg(all(feature = "cuda", feature = "graph"))]
+    pub mtp_capturer: Option<GraphCapturer<CudaGraphWrapper<CudaGraphFn>>>,
     #[cfg(feature = "flashinfer")]
     flashinfer_kv_params: Option<FlashInferKvParams>,
     logit_processor: LogitsProcessor,
@@ -200,8 +202,70 @@ impl ModelRunner {
         q_len: usize,
     ) -> Result<InputMetadata> {
         let total_kv_len = (seq_info.len + q_len) as u32;
-        let mamba_slot_mapping =
-            self.prepare_mamba_slot_mapping(&[seq_info.id], false)?;
+        let mamba_slot_mapping = self.prepare_mamba_slot_mapping(&[seq_info.id], false)?;
+
+        #[cfg(feature = "flashinfer")]
+        let flashinfer_metadata = if let Some(params) = self.flashinfer_kv_params {
+            let num_pages = seq_info.block_table.len();
+            let indptr_host = vec![0u32, num_pages as u32];
+            let indices_vec: Vec<u32> = seq_info.block_table.clone();
+            let last_page_tokens =
+                total_kv_len as usize - (num_pages.saturating_sub(1)) * params.page_size;
+            let last_len_host = vec![last_page_tokens as u32];
+            let kv_len_arr_host = vec![total_kv_len];
+            let q_cu_seqlens_host = vec![0u32, q_len as u32];
+
+            #[cfg(all(feature = "cuda", feature = "graph"))]
+            let use_graph = self
+                .mtp_capturer
+                .as_ref()
+                .map_or(false, |c| c.is_mtp_captured(q_len));
+            #[cfg(not(all(feature = "cuda", feature = "graph")))]
+            let use_graph = false;
+
+            let prefill_plan_info = if use_graph {
+                None
+            } else {
+                Some(attention_rs::flashinfer::prefill_plan(
+                    &self.device,
+                    &q_cu_seqlens_host,
+                    &indptr_host,
+                    &kv_len_arr_host,
+                    q_len as u32,
+                    1,
+                    params.num_qo_heads,
+                    params.num_kv_heads,
+                    params.head_dim,
+                    params.page_size,
+                    params.out_dtype,
+                    None,
+                    Some(params.kv_dtype),
+                    false,
+                )?)
+            };
+
+            Some(attention_rs::FlashInferMetadata {
+                indptr: Tensor::from_vec(indptr_host.clone(), (2,), &self.device)?,
+                indptr_host,
+                indices: Tensor::from_vec(indices_vec, (num_pages,), &self.device)?,
+                last_len: Tensor::from_vec(last_len_host.clone(), (1,), &self.device)?,
+                last_len_host: Some(last_len_host),
+                kv_len_arr_host: Some(kv_len_arr_host),
+                total_num_rows: Some(q_len as u32),
+                batch_indices: None,
+                positions: None,
+                use_cuda_graph: use_graph,
+                decode_plan_info: None,
+                prefill_plan_info,
+                mla_decode_plan_info: None,
+                mla_prefill_plan_info: None,
+            })
+        } else {
+            None
+        };
+        #[cfg(not(feature = "flashinfer"))]
+        let flashinfer_metadata = None;
+
         Ok(InputMetadata {
             is_prefill: true,
             is_mla: self.is_mla_model(),
@@ -228,7 +292,7 @@ impl ModelRunner {
             max_seqlen_q: q_len,
             max_seqlen_k: seq_info.len + q_len,
             max_context_len: seq_info.len + q_len,
-            flashinfer_metadata: None,
+            flashinfer_metadata,
             is_mtp_verify: true,
         })
     }
@@ -533,6 +597,34 @@ impl ModelRunner {
                 MiniMax => EmbedInputs,
             }
         );
+
+        #[cfg(all(feature = "cuda", feature = "graph"))]
+        let mtp_wrapper = if econfig.mtp_num_speculative_tokens.unwrap_or(0) > 0 {
+            Some(crate::graph_wrapper!(
+                &model,
+                device,
+                {
+                    Qwen3 => EmbedInputs,
+                    Qwen3MoE => EmbedInputs,
+                    Qwen3_5 => EmbedInputs,
+                    Qwen3_5MoE => EmbedInputs,
+                    LLaMa => EmbedInputs,
+                    LLaMa4 => NoneArg,
+                    Phi4 => EmbedInputs,
+                    GLM4 => EmbedInputs,
+                    GLM4MoE => EmbedInputs,
+                    GLM4MoeLite => EmbedInputs,
+                    DeepSeek => EmbedInputs,
+                    Mistral3VL => NoneArg,
+                    Gemma3 => NoneArg,
+                    Gemma4 => EmbedInputs,
+                    Qwen3VL => NoneArg,
+                    MiniMax => EmbedInputs,
+                }
+            ))
+        } else {
+            None
+        };
 
         let allocator = if let Some(s) = stream {
             use crate::runner::{receive_local, send_local, MessageType};
@@ -878,7 +970,7 @@ impl ModelRunner {
             device,
             config: econfig.clone(),
             #[cfg(all(feature = "cuda", feature = "graph"))]
-            capturer: GraphCapturer::new(
+            decode_capturer: GraphCapturer::new(
                 wrapper,
                 graph_capture_max_num_seqs,
                 econfig.max_model_len.unwrap_or(32768),
@@ -888,6 +980,19 @@ impl ModelRunner {
                 &flashinfer_kv_params,
                 matches!(model_type, ModelType::GLM4MoeLite | ModelType::DeepSeek),
             ),
+            #[cfg(all(feature = "cuda", feature = "graph"))]
+            mtp_capturer: mtp_wrapper.map(|w| {
+                GraphCapturer::new(
+                    w,
+                    graph_capture_max_num_seqs,
+                    econfig.max_model_len.unwrap_or(32768),
+                    econfig.block_size,
+                    config.hidden_size,
+                    #[cfg(feature = "flashinfer")]
+                    &flashinfer_kv_params,
+                    matches!(model_type, ModelType::GLM4MoeLite | ModelType::DeepSeek),
+                )
+            }),
             #[cfg(feature = "flashinfer")]
             flashinfer_kv_params,
             logit_processor: LogitsProcessor::new(seed, temperature, top_k, top_p),
@@ -1057,33 +1162,33 @@ impl ModelRunner {
             let input_batch = input_ids.dim(0)?;
             let require_exact_graph = input_metadata.mamba_slot_mapping.is_some();
             let can_replay = if require_exact_graph {
-                self.capturer.is_exact_captured(input_batch)
+                self.decode_capturer.is_exact_captured(input_batch)
             } else {
-                self.capturer.is_captured(input_batch)
+                self.decode_capturer.is_captured(input_batch)
             };
             if !is_prefill && can_replay {
                 let logits = match &self.model {
                     Model::Qwen3_5(model) => {
                         let _guard = model.lock_mamba_cache_for_graph();
-                        self.capturer
+                        self.decode_capturer
                             .replay(&input_ids, &positions, &input_metadata)?
                     }
                     Model::Qwen3_5MoE(model) => {
                         let _guard = model.lock_mamba_cache_for_graph();
-                        self.capturer
+                        self.decode_capturer
                             .replay(&input_ids, &positions, &input_metadata)?
                     }
                     Model::Qwen3VL(model) => {
                         if let Some(_guard) = model.lock_mamba_cache_for_graph() {
-                            self.capturer
+                            self.decode_capturer
                                 .replay(&input_ids, &positions, &input_metadata)?
                         } else {
-                            self.capturer
+                            self.decode_capturer
                                 .replay(&input_ids, &positions, &input_metadata)?
                         }
                     }
                     _ => self
-                        .capturer
+                        .decode_capturer
                         .replay(&input_ids, &positions, &input_metadata)?,
                 };
                 let output_ids = self.sample(&logits, seqs, is_prefill)?;
@@ -1203,33 +1308,33 @@ impl ModelRunner {
             let input_batch = input_ids.dim(0)?;
             let require_exact_graph = input_metadata.mamba_slot_mapping.is_some();
             let can_replay = if require_exact_graph {
-                self.capturer.is_exact_captured(input_batch)
+                self.decode_capturer.is_exact_captured(input_batch)
             } else {
-                self.capturer.is_captured(input_batch)
+                self.decode_capturer.is_captured(input_batch)
             };
             if can_replay {
                 let logits = match &self.model {
                     Model::Qwen3_5(model) => {
                         let _guard = model.lock_mamba_cache_for_graph();
-                        self.capturer
+                        self.decode_capturer
                             .replay(&input_ids, &positions, &input_metadata)?
                     }
                     Model::Qwen3_5MoE(model) => {
                         let _guard = model.lock_mamba_cache_for_graph();
-                        self.capturer
+                        self.decode_capturer
                             .replay(&input_ids, &positions, &input_metadata)?
                     }
                     Model::Qwen3VL(model) => {
                         if let Some(_guard) = model.lock_mamba_cache_for_graph() {
-                            self.capturer
+                            self.decode_capturer
                                 .replay(&input_ids, &positions, &input_metadata)?
                         } else {
-                            self.capturer
+                            self.decode_capturer
                                 .replay(&input_ids, &positions, &input_metadata)?
                         }
                     }
                     _ => self
-                        .capturer
+                        .decode_capturer
                         .replay(&input_ids, &positions, &input_metadata)?,
                 };
 
@@ -1449,14 +1554,17 @@ impl ModelRunner {
         let _prefill_guard = set_linear_is_prefill(true);
 
         #[cfg(all(feature = "cuda", feature = "graph"))]
-        let use_mtp_graph = self.capturer.is_mtp_captured(verify_len);
+        let use_mtp_graph = self
+            .mtp_capturer
+            .as_ref()
+            .map_or(false, |c| c.is_mtp_captured(verify_len));
         #[cfg(not(all(feature = "cuda", feature = "graph")))]
         let use_mtp_graph = false;
 
         let all_logits_result = if use_mtp_graph {
             #[cfg(all(feature = "cuda", feature = "graph"))]
             {
-                self.capturer.replay_mtp(
+                self.mtp_capturer.as_ref().unwrap().replay_mtp(
                     &verify_input_ids,
                     &verify_positions_tensor,
                     &verify_metadata,
@@ -1820,6 +1928,7 @@ impl ModelRunner {
                         params.out_dtype,
                         None,
                         Some(params.kv_dtype),
+                        false,
                     )?)
                 }
             };
@@ -1916,9 +2025,9 @@ impl ModelRunner {
                     _ => false,
                 };
                 if require_exact_graph {
-                    self.capturer.is_exact_captured(seq_refs.len())
+                    self.decode_capturer.is_exact_captured(seq_refs.len())
                 } else {
-                    self.capturer.is_captured(seq_refs.len())
+                    self.decode_capturer.is_captured(seq_refs.len())
                 }
             };
             #[cfg(not(all(feature = "cuda", feature = "graph")))]
@@ -2247,7 +2356,8 @@ impl ModelRunner {
     #[cfg(all(feature = "cuda", feature = "graph"))]
     pub fn warmup_capture(&mut self) -> Result<()> {
         let kv_cache_lock = self.gpu_kv_cache.lock().unwrap();
-        self.capturer.capture(&self.device, Some(&kv_cache_lock))?;
+        self.decode_capturer
+            .capture(&self.device, Some(&kv_cache_lock))?;
         match &self.model {
             Model::Qwen3_5(model) => model.reset_mamba_cache()?,
             Model::Qwen3_5MoE(model) => model.reset_mamba_cache()?,
@@ -2260,8 +2370,13 @@ impl ModelRunner {
                 "Capturing MTP verify graphs for up to {} draft tokens...",
                 self.mtp_num_speculative
             );
-            self.capturer
-                .capture_mtp(&self.device, Some(&kv_cache_lock), self.mtp_num_speculative)?;
+            if let Some(mtp_cap) = &mut self.mtp_capturer {
+                mtp_cap.capture_mtp(
+                    &self.device,
+                    Some(&kv_cache_lock),
+                    self.mtp_num_speculative,
+                )?;
+            }
             match &self.model {
                 Model::Qwen3_5(model) => model.reset_mamba_cache()?,
                 Model::Qwen3_5MoE(model) => model.reset_mamba_cache()?,

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -642,6 +642,98 @@ impl Scheduler {
         }
     }
 
+    /// MTP-aware postprocess: accepts multiple tokens per sequence.
+    /// For each sequence in `ids`, `multi_output_ids[i]` contains all accepted tokens
+    /// (anchor + drafts + continuation). Each token is appended and checked for EOS/stop.
+    pub fn postprocess_multi(&mut self, ids: &[usize], multi_output_ids: &[Vec<u32>]) {
+        for (i, &idx) in ids.iter().enumerate() {
+            if idx >= self.running.len() {
+                continue;
+            }
+            let tokens = &multi_output_ids[i];
+            for &token in tokens {
+                let _seq_id = self.running[idx].id;
+
+                if self.is_pd_server() {
+                    break;
+                }
+
+                if self.running[idx].sampling_params.mcp_mode.is_some() {
+                    let is_end = self.is_tool_call_end(token, idx);
+                    if is_end {
+                        let seq = &mut self.running[idx];
+                        seq.append_token(token);
+                        seq.is_tool_call_end = true;
+                        seq.status = SequenceStatus::Finished;
+                        self.block_manager
+                            .capture_mamba_prefix_state(seq, seq.len());
+                        self.block_manager.cache_sequence(seq);
+                        self.block_manager.deallocate(seq);
+                        break;
+                    }
+                }
+
+                let matched_stop_sequence_idx =
+                    self.stop_sequence_match_index(token, &self.running[idx]);
+                let hit_stop_sequence = matched_stop_sequence_idx.is_some();
+                let seq = &mut self.running[idx];
+
+                if hit_stop_sequence
+                    || self.eos_token_id.contains(&token)
+                    || seq.output_len() >= seq.sampling_params.max_tokens.unwrap_or(16384)
+                    || seq.len() > self.cfg.max_num_batched_tokens
+                {
+                    if hit_stop_sequence {
+                        seq.hit_stop_sequence = true;
+                        seq.stop_sequence = matched_stop_sequence_idx.and_then(|stop_idx| {
+                            seq.sampling_params
+                                .stop_sequences
+                                .as_ref()
+                                .and_then(|stops| stops.get(stop_idx))
+                                .cloned()
+                        });
+                    }
+                    seq.status = SequenceStatus::Finished;
+                    self.block_manager
+                        .capture_mamba_prefix_state(seq, seq.len());
+                    self.block_manager.cache_sequence(seq);
+                    self.block_manager.deallocate(seq);
+                    break;
+                } else {
+                    seq.append_token(token);
+                    if seq.len() % self.cfg.block_size == 1 && seq.len() > 1 {
+                        let _ = self.block_manager.may_append(seq);
+                    }
+                    if seq.len() % self.cfg.block_size == 0 {
+                        self.block_manager
+                            .capture_mamba_prefix_state(seq, seq.len());
+                    }
+                }
+            }
+        }
+    }
+
+    /// Pre-allocate KV cache blocks for MTP speculative tokens.
+    /// Called before MTP runs to ensure the verification forward has room
+    /// to write KV for speculative positions.
+    pub fn pre_allocate_mtp_blocks(&mut self, ids: &[usize], extra_tokens: usize) {
+        for &idx in ids {
+            if idx >= self.running.len() {
+                continue;
+            }
+            let seq = &mut self.running[idx];
+            let needed_len = seq.len() + extra_tokens;
+            let needed_blocks = needed_len.div_ceil(self.cfg.block_size);
+            while seq.block_table.len() < needed_blocks {
+                if let Some(block_id) = self.block_manager.alloc_free_block() {
+                    seq.block_table.push(block_id as u32);
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
     pub fn clear_finished(&mut self) {
         let is_pd_server = self.is_pd_server();
         let mut finished_counts = Vec::new();

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -506,166 +506,86 @@ impl Scheduler {
             .map(|seq| (seq.id, seq.status))
     }
 
-    /// Postprocess output tokens and modify sequences by indexes
-    pub fn postprocess(&mut self, ids: &[usize], output_ids: &[u32]) {
-        for (i, &idx) in ids.iter().enumerate() {
-            // Sequence may swapped out
-            if idx >= self.running.len() {
-                continue;
-            }
-            let seq_id = self.running[idx].id;
-            let token = output_ids[i];
-
-            // Since all reqeusts in PD server are prefill request, we need to finish and transfer
-            // the kvcache in the first postprocess for each request.
-            if self.is_pd_server() {
-                match self
-                    .block_manager
-                    .try_send_kvcache(&self.running[idx], token)
-                {
-                    Ok(success) => {
-                        crate::log_warn!(
-                            "PD Server: transferred KV cache for seq {} ({})",
-                            seq_id,
-                            if success { "success" } else { "faild" }
-                        );
-                        let seq = &mut self.running[idx];
-                        if success {
-                            // Insert into prefix cache so future requests can benefit
-                            // LRU eviction will handle memory pressure automatically
-                            let _ = self
-                                .block_manager
-                                .capture_mamba_prefix_state(seq, seq.len());
-                            self.block_manager.cache_sequence(seq);
-                            // Maintain resources until client asks to release or cache eviction
-                            seq.status = SequenceStatus::Cached;
-                            let cur_time = SystemTime::now()
-                                .duration_since(UNIX_EPOCH)
-                                .expect("Time went backwards")
-                                .as_millis() as usize;
-                            let time_costs = cur_time - seq.created_time();
-                            if time_costs / 100 > 0 && seq.len() > 0 {
-                                crate::log_info!(
-                                    "PD Prefilling [seq_id {}]: {} tokens in {:.2}s ({:.2} tokens/s)",
-                                    seq_id,
-                                    seq.len(),
-                                    time_costs as f32 / 1000f32,
-                                    seq.len() as f32 / (time_costs as f32 * 1.0f32 / 1000f32),
-                                )
-                            }
-                        } else {
-                            // release resources immediately if failed
-                            seq.status = SequenceStatus::Finished;
-                            self.block_manager.deallocate(seq);
-                        }
-                    }
-                    Err(e) => {
-                        crate::log_error!(
-                            "PD Server: failed to transfer KV cache for seq {}: {}",
-                            seq_id,
-                            e
-                        );
-                        let seq = &mut self.running[idx];
-                        seq.status = SequenceStatus::Finished;
-                        self.block_manager.deallocate(seq);
-                    }
-                }
-
-                continue; // Go to next sequence in postprocess
-            }
-
-            // Check for tool call end token BEFORE checking EOS
-            // When tools are enabled (mcp_mode.is_some()), finish stream at </tool_call>
-            if self.running[idx].sampling_params.mcp_mode.is_some() {
-                // Check if this is a tool call end (supports both XML </tool_call> and JSON } patterns)
-                // We check BEFORE borrowing seq mutably
-                let is_end = self.is_tool_call_end(token, idx);
-                if is_end {
-                    crate::log_info!(
-                        "[Seq {}] Detected </tool_call> token {}, finishing for external handling",
-                        seq_id,
-                        token
-                    );
-                    let seq = &mut self.running[idx];
-                    seq.append_token(token);
-                    seq.is_tool_call_end = true;
-                    // External tool mode: finish stream so client can handle tool calls
-                    seq.status = SequenceStatus::Finished;
-                    let _ = self
-                        .block_manager
-                        .capture_mamba_prefix_state(seq, seq.len());
-                    self.block_manager.cache_sequence(seq);
-                    self.block_manager.deallocate(seq);
-                    continue;
-                }
-            }
-
-            let matched_stop_sequence_idx =
-                self.stop_sequence_match_index(token, &self.running[idx]);
-            let hit_stop_sequence = matched_stop_sequence_idx.is_some();
-            let seq = &mut self.running[idx];
-
-            if hit_stop_sequence
-                || self.eos_token_id.contains(&token)
-                || seq.output_len() >= seq.sampling_params.max_tokens.unwrap_or(16384)
-                || seq.len() > self.cfg.max_num_batched_tokens
-            {
-                if hit_stop_sequence {
-                    crate::log_info!(
-                        "[Seq {}] Detected stop sequence token {}, finishing",
-                        seq_id,
-                        token
-                    );
-                    seq.hit_stop_sequence = true;
-                    seq.stop_sequence = matched_stop_sequence_idx.and_then(|stop_idx| {
-                        seq.sampling_params
-                            .stop_sequences
-                            .as_ref()
-                            .and_then(|stops| stops.get(stop_idx))
-                            .cloned()
-                    });
-                }
-                seq.status = SequenceStatus::Finished;
-                let _ = self
-                    .block_manager
-                    .capture_mamba_prefix_state(seq, seq.len());
-                self.block_manager.cache_sequence(seq);
-                self.block_manager.deallocate(seq);
-            } else {
-                seq.append_token(token);
-                if seq.len() % self.cfg.block_size == 0 {
-                    let _ = self
-                        .block_manager
-                        .capture_mamba_prefix_state(seq, seq.len());
-                }
-            }
-        }
-    }
-
-    /// MTP-aware postprocess: accepts multiple tokens per sequence.
-    /// For each sequence in `ids`, `multi_output_ids[i]` contains all accepted tokens
-    /// (anchor + drafts + continuation). Each token is appended and checked for EOS/stop.
-    pub fn postprocess_multi(&mut self, ids: &[usize], multi_output_ids: &[Vec<u32>]) {
+    /// Postprocess output tokens for each sequence. Handles both single-token (normal decode)
+    /// and multi-token (MTP speculative decode) outputs uniformly.
+    pub fn postprocess(&mut self, ids: &[usize], multi_output_ids: &[Vec<u32>]) {
         for (i, &idx) in ids.iter().enumerate() {
             if idx >= self.running.len() {
                 continue;
             }
             let tokens = &multi_output_ids[i];
-            for &token in tokens {
-                let _seq_id = self.running[idx].id;
+            let seq_id = self.running[idx].id;
 
-                if self.is_pd_server() {
-                    break;
+            // PD server: transfer KV cache on first token, then move to next sequence.
+            if self.is_pd_server() {
+                if let Some(&first_token) = tokens.first() {
+                    match self
+                        .block_manager
+                        .try_send_kvcache(&self.running[idx], first_token)
+                    {
+                        Ok(success) => {
+                            crate::log_warn!(
+                                "PD Server: transferred KV cache for seq {} ({})",
+                                seq_id,
+                                if success { "success" } else { "faild" }
+                            );
+                            let seq = &mut self.running[idx];
+                            if success {
+                                let _ = self
+                                    .block_manager
+                                    .capture_mamba_prefix_state(seq, seq.len());
+                                self.block_manager.cache_sequence(seq);
+                                seq.status = SequenceStatus::Cached;
+                                let cur_time = SystemTime::now()
+                                    .duration_since(UNIX_EPOCH)
+                                    .expect("Time went backwards")
+                                    .as_millis()
+                                    as usize;
+                                let time_costs = cur_time - seq.created_time();
+                                if time_costs / 100 > 0 && seq.len() > 0 {
+                                    crate::log_info!(
+                                        "PD Prefilling [seq_id {}]: {} tokens in {:.2}s ({:.2} tokens/s)",
+                                        seq_id,
+                                        seq.len(),
+                                        time_costs as f32 / 1000f32,
+                                        seq.len() as f32 / (time_costs as f32 * 1.0f32 / 1000f32),
+                                    )
+                                }
+                            } else {
+                                seq.status = SequenceStatus::Finished;
+                                self.block_manager.deallocate(seq);
+                            }
+                        }
+                        Err(e) => {
+                            crate::log_error!(
+                                "PD Server: failed to transfer KV cache for seq {}: {}",
+                                seq_id,
+                                e
+                            );
+                            let seq = &mut self.running[idx];
+                            seq.status = SequenceStatus::Finished;
+                            self.block_manager.deallocate(seq);
+                        }
+                    }
                 }
+                continue;
+            }
 
+            for &token in tokens {
                 if self.running[idx].sampling_params.mcp_mode.is_some() {
                     let is_end = self.is_tool_call_end(token, idx);
                     if is_end {
+                        crate::log_info!(
+                            "[Seq {}] Detected </tool_call> token {}, finishing for external handling",
+                            seq_id,
+                            token
+                        );
                         let seq = &mut self.running[idx];
                         seq.append_token(token);
                         seq.is_tool_call_end = true;
                         seq.status = SequenceStatus::Finished;
-                        self.block_manager
+                        let _ = self
+                            .block_manager
                             .capture_mamba_prefix_state(seq, seq.len());
                         self.block_manager.cache_sequence(seq);
                         self.block_manager.deallocate(seq);
@@ -684,6 +604,11 @@ impl Scheduler {
                     || seq.len() > self.cfg.max_num_batched_tokens
                 {
                     if hit_stop_sequence {
+                        crate::log_info!(
+                            "[Seq {}] Detected stop sequence token {}, finishing",
+                            seq_id,
+                            token
+                        );
                         seq.hit_stop_sequence = true;
                         seq.stop_sequence = matched_stop_sequence_idx.and_then(|stop_idx| {
                             seq.sampling_params
@@ -694,7 +619,8 @@ impl Scheduler {
                         });
                     }
                     seq.status = SequenceStatus::Finished;
-                    self.block_manager
+                    let _ = self
+                        .block_manager
                         .capture_mamba_prefix_state(seq, seq.len());
                     self.block_manager.cache_sequence(seq);
                     self.block_manager.deallocate(seq);
@@ -705,7 +631,8 @@ impl Scheduler {
                         let _ = self.block_manager.may_append(seq);
                     }
                     if seq.len() % self.cfg.block_size == 0 {
-                        self.block_manager
+                        let _ = self
+                            .block_manager
                             .capture_mamba_prefix_state(seq, seq.len());
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,7 +246,8 @@ async fn main() -> Result<()> {
         args.node_rank,
         args.master_addr.clone(),
         args.master_port,
-    );
+    )
+    .with_mtp(args.mtp);
 
     // Multi-node worker nodes run a daemon loop instead of the full engine
     if econfig.num_nodes > 1 && econfig.node_rank > 0 {

--- a/src/models/layers/attention.rs
+++ b/src/models/layers/attention.rs
@@ -848,6 +848,89 @@ impl Attention {
         };
         self.o_proj.forward(&y)
     }
+
+    /// Optimized single-token attention without KV cache or paged attention.
+    /// For seq_len=1, self-attention is trivially: softmax([1x1]) * V = V.
+    /// We still compute Q/K/V projections and apply RoPE for correctness of
+    /// the output projection, but skip the attention kernel entirely.
+    pub fn forward_single_token_no_cache(
+        &self,
+        xs: &Tensor,
+        rotary_emb: &Arc<dyn ApplyRotaryEmbedding>,
+        positions: &Tensor,
+    ) -> Result<Tensor> {
+        let (seq_len, _) = xs.dims2()?;
+
+        let (q_raw, k, v) = match &self.qkv_proj {
+            QkvProjection::Separate {
+                q_proj,
+                k_proj,
+                v_proj,
+            } => (
+                q_proj.forward(xs)?,
+                k_proj.forward(xs)?,
+                v_proj.forward(xs)?,
+            ),
+            QkvProjection::Packed(qkv_proj) => {
+                let qkv = qkv_proj.forward(xs)?;
+                (qkv[0].clone(), qkv[1].clone(), qkv[2].clone())
+            }
+        };
+
+        // Handle attn_output_gate (Qwen3.5 uses gated attention: Q proj outputs Q + gate)
+        let local_q_dim = self.num_heads * self.head_dim;
+        let (q_linear, gate) = if self.attn_output_gate {
+            let q_gate = q_raw.reshape((seq_len, self.num_heads, self.head_dim * 2))?;
+            let q = q_gate.narrow(2, 0, self.head_dim)?;
+            let gate = q_gate.narrow(2, self.head_dim, self.head_dim)?;
+            (
+                q.reshape((seq_len, local_q_dim))?,
+                Some(gate.reshape((seq_len, local_q_dim))?),
+            )
+        } else {
+            (q_raw, None)
+        };
+
+        let q = q_linear.reshape((seq_len, self.num_heads, self.head_dim))?;
+        let k = k.reshape((seq_len, self.num_kv_heads, self.head_dim))?;
+        let v = v.reshape((seq_len, self.num_kv_heads, self.head_dim))?;
+
+        // Apply rotary embeddings (needed even for single token for positional encoding)
+        let (_q, _k) = match rotary_emb.apply_rotary_emb_qkv(&q, &k, positions)? {
+            Some((q_new, k_new)) => (q_new, k_new),
+            None => (q, k),
+        };
+
+        // For seq_len=1: softmax(Q*K^T / sqrt(d)) * V = V (single element softmax = 1.0)
+        // Output shape: (seq_len, num_heads * head_dim) after GQA expansion
+        let n_rep = self.num_heads / self.num_kv_heads;
+        let y = if n_rep > 1 {
+            v.unsqueeze(2)?
+                .expand((seq_len, self.num_kv_heads, n_rep, self.head_dim))?
+                .reshape((seq_len, self.num_heads * self.head_dim))?
+        } else {
+            v.reshape((seq_len, self.num_heads * self.head_dim))?
+        };
+
+        // Apply gated attention if needed
+        let y = if let Some(gate) = gate {
+            let gate = if gate.dtype() != y.dtype() {
+                gate.to_dtype(y.dtype())?
+            } else {
+                gate
+            };
+            y.broadcast_mul(&candle_nn::ops::sigmoid(&gate)?)?
+        } else {
+            y
+        };
+
+        let y = if self.is_qvar_builder {
+            y
+        } else {
+            y.to_dtype(xs.dtype())?
+        };
+        self.o_proj.forward(&y)
+    }
 }
 
 pub struct NaiveAttention {

--- a/src/models/layers/deltanet.rs
+++ b/src/models/layers/deltanet.rs
@@ -67,6 +67,8 @@ pub struct GatedDeltaNet {
     /// The model's native dtype (BF16/F16). Used for projection input and weight loading.
     /// Quantized projections (FP8/NVFP4/QLinear) handle dtype internally.
     model_dtype: DType,
+    conv_mtp_state: Tensor,
+    recurrent_mtp_state: Tensor,
 }
 
 impl GatedDeltaNet {
@@ -709,7 +711,18 @@ impl GatedDeltaNet {
             )
             .ok();
         let scale = 1.0f64 / (head_k_dim as f64).sqrt();
-
+        let d_conv = key_dim * 2 + value_dim;
+        let max_verify_tokens = 16;
+        let conv_mtp_state = Tensor::zeros(
+            (max_verify_tokens, d_conv, conv_kernel_size - 1),
+            gdn_dtype,
+            &vb.device(),
+        )?;
+        let recurrent_mtp_state = Tensor::zeros(
+            (max_verify_tokens, num_v_heads, head_k_dim, head_v_dim),
+            DType::F32,
+            &vb.device(),
+        )?;
         Ok(Self {
             projection,
             out_proj,
@@ -735,6 +748,8 @@ impl GatedDeltaNet {
             } else {
                 dtype
             },
+            conv_mtp_state,
+            recurrent_mtp_state,
         })
     }
 
@@ -755,9 +770,6 @@ impl GatedDeltaNet {
         let is_prefill = input_metadata.is_prefill;
         let (q, k, v, z, b, a) = self.project_inputs(xs)?;
 
-        // Upcast projection outputs to gdn_dtype for GDN core ops (conv1d, gating, recurrence).
-        // For GGUF/F16 mode (gdn_dtype=F32), this promotes BF16 outputs to F32.
-        // For standard BF16 models (gdn_dtype=BF16), this is a no-op.
         let (q, k, v, z, b, a) = if q.dtype() != self.gdn_dtype {
             (
                 q.to_dtype(self.gdn_dtype)?,
@@ -779,13 +791,19 @@ impl GatedDeltaNet {
                 .as_ref()
                 .expect("cu_seqlens_q must be present in prefill!");
 
+            let conv_snapshots = if input_metadata.is_mtp_verify {
+                Some(self.conv_mtp_state.narrow(0, 0, token_count)?)
+            } else {
+                None
+            };
             let out = gdn::causal_conv1d_fwd(
                 &mixed_qkv,
                 &self.conv_weight,
                 self.conv_bias.as_ref(),
                 &mut conv_state,
+                conv_snapshots.as_ref(),
                 Some(cu_seqlens),
-                true, // SiLU activation
+                true,
             )?;
             (out, Some(conv_state))
         } else {
@@ -834,6 +852,11 @@ impl GatedDeltaNet {
                 .expect("cu_seqlens_q must be present in prefill!");
 
             let global_state = mamba_cache.recurrent_state_mut(self.gdn_layer_idx);
+            let recurrent_snapshots = if input_metadata.is_mtp_verify {
+                Some(self.recurrent_mtp_state.narrow(0, 0, token_count)?)
+            } else {
+                None
+            };
 
             if self.num_k_heads != self.num_v_heads {
                 gdn::gated_delta_rule_recurrence_varlen_gqa(
@@ -858,6 +881,7 @@ impl GatedDeltaNet {
                     global_state,
                     seq_slots,
                     &cu_seqlens,
+                    recurrent_snapshots.as_ref(),
                 )?
             }
         } else {
@@ -904,5 +928,28 @@ impl GatedDeltaNet {
         } else {
             Ok(out)
         }
+    }
+
+    /// Roll back this layer's GDN state to the position after `keep_tokens` tokens
+    /// were processed during MTP verification. Indexes into the per-token snapshot
+    /// buffers written by the prefill kernels and restores the slot state.
+    pub fn rollback_mtp_verify(
+        &self,
+        mamba_cache: &mut MambaCache,
+        seq_slots: &Tensor,
+        keep_tokens: usize,
+    ) -> Result<()> {
+        if keep_tokens == 0 {
+            return Ok(());
+        }
+        let idx = keep_tokens - 1;
+
+        let conv_snapshot = self.conv_mtp_state.narrow(0, idx, 1)?;
+        mamba_cache.set_batch_conv_state(self.gdn_layer_idx, seq_slots, &conv_snapshot)?;
+
+        let rec_snapshot = self.recurrent_mtp_state.narrow(0, idx, 1)?;
+        mamba_cache.set_batch_recurrent_state(self.gdn_layer_idx, seq_slots, &rec_snapshot)?;
+
+        Ok(())
     }
 }

--- a/src/models/layers/deltanet.rs
+++ b/src/models/layers/deltanet.rs
@@ -869,6 +869,7 @@ impl GatedDeltaNet {
                     seq_slots,
                     &cu_seqlens,
                     self.scale as f32,
+                    recurrent_snapshots.as_ref(),
                 )?
             } else {
                 let q_scaled = (&q * self.scale)?;
@@ -945,6 +946,12 @@ impl GatedDeltaNet {
         let idx = keep_tokens - 1;
 
         let conv_snapshot = self.conv_mtp_state.narrow(0, idx, 1)?;
+        let conv_state_dtype = mamba_cache.conv_state(self.gdn_layer_idx).dtype();
+        let conv_snapshot = if conv_snapshot.dtype() != conv_state_dtype {
+            conv_snapshot.to_dtype(conv_state_dtype)?
+        } else {
+            conv_snapshot
+        };
         mamba_cache.set_batch_conv_state(self.gdn_layer_idx, seq_slots, &conv_snapshot)?;
 
         let rec_snapshot = self.recurrent_mtp_state.narrow(0, idx, 1)?;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -13,5 +13,6 @@ pub mod phi4;
 pub mod qwen3;
 pub mod qwen3_5;
 pub mod qwen3_5_moe;
+pub mod qwen3_5_mtp;
 pub mod qwen3_moe;
 pub mod qwen3_vl;

--- a/src/models/qwen3_5.rs
+++ b/src/models/qwen3_5.rs
@@ -194,8 +194,10 @@ pub struct Qwen3_5ForCausalLM {
     dtype: DType,
     vocab_size: usize,
     is_qvar_builder: bool,
-    /// Cached last hidden state for MTP speculative decoding
-    pub last_hidden_for_mtp: std::sync::Mutex<Option<Tensor>>,
+    /// Pre-allocated hidden state buffer for MTP speculative decoding.
+    /// Allocated outside the CUDA graph pool so copy_ into it is graph-safe.
+    /// Shape: (max_graph_bs, hidden_size), allocated on first decode forward.
+    pub mtp_hidden_buffer: std::sync::Mutex<Option<Tensor>>,
 }
 
 impl Qwen3_5ForCausalLM {
@@ -482,7 +484,7 @@ impl Qwen3_5ForCausalLM {
             dtype,
             vocab_size,
             is_qvar_builder,
-            last_hidden_for_mtp: std::sync::Mutex::new(None),
+            mtp_hidden_buffer: std::sync::Mutex::new(None),
         })
     }
 
@@ -495,9 +497,12 @@ impl Qwen3_5ForCausalLM {
         }
     }
 
-    /// Take the last cached hidden state for MTP (consumes it)
+    /// Get the last hidden state for MTP from the pre-allocated buffer.
+    /// Returns row 0 of the buffer (MTP decode always uses batch_size=1).
     pub fn take_last_hidden_for_mtp(&self) -> Option<Tensor> {
-        self.last_hidden_for_mtp.lock().ok()?.take()
+        let guard = self.mtp_hidden_buffer.lock().ok()?;
+        let buf = guard.as_ref()?;
+        buf.get(0).ok()
     }
 
     fn forward_inner(
@@ -574,9 +579,15 @@ impl Qwen3_5ForCausalLM {
         if return_hidden {
             xs.to_dtype(DType::F32)
         } else {
-            // Cache hidden state for MTP speculative decoding
-            if let Ok(mut cache) = self.last_hidden_for_mtp.lock() {
-                *cache = Some(xs.clone());
+            // Copy hidden state into the pre-allocated MTP buffer (graph-safe).
+            // copy_ is a CUDA memcpy kernel that gets captured into the graph,
+            // so the buffer is updated in-place on every graph replay.
+            if let Ok(guard) = self.mtp_hidden_buffer.lock() {
+                if let Some(buf) = guard.as_ref() {
+                    if xs.elem_count() <= buf.elem_count() {
+                        let _ = buf.copy_(&xs, 0);
+                    }
+                }
             }
             if self.is_qvar_builder {
                 self.lm_head.forward(&xs)
@@ -680,6 +691,23 @@ impl Qwen3_5ForCausalLM {
         )
     }
 
+    /// Re-run forward on accepted tokens to fix mamba/GDN recurrent state.
+    /// KV cache entries are re-written with identical values (same tokens + positions).
+    /// Uses native flash attention (flashinfer_metadata=None in input_metadata).
+    /// Replay accepted tokens through all layers to fix GDN recurrent state
+    /// after a partial MTP rejection. Runs the full forward (attention layers
+    /// must execute to produce correct hidden states for subsequent GDN layers).
+    pub fn forward_mamba_only(
+        &self,
+        input_ids: &Tensor,
+        positions: &Tensor,
+        kv_caches: Option<&Vec<(Tensor, Tensor)>>,
+        input_metadata: &InputMetadata,
+    ) -> Result<()> {
+        let _ = self.forward(input_ids, positions, kv_caches, input_metadata, false)?;
+        Ok(())
+    }
+
     /// Apply lm_head to hidden states to get logits. Used by MTP drafting.
     pub fn forward_lm_head(&self, hidden: &Tensor) -> Result<Tensor> {
         if self.is_qvar_builder {
@@ -717,6 +745,20 @@ impl Qwen3_5ForCausalLM {
 
     pub fn preallocate_mamba_cache(&self, max_num_seqs: usize) -> Result<()> {
         self.mamba_cache.write().reserve_capacity(max_num_seqs)
+    }
+
+    /// Pre-allocate the MTP hidden state buffer outside of CUDA graph capture.
+    /// Must be called before warmup_capture so the buffer lives in regular GPU memory.
+    pub fn preallocate_mtp_hidden_buffer(&self, max_batch_size: usize) -> Result<()> {
+        let buf = Tensor::zeros(
+            (max_batch_size, self.config.hidden_size),
+            self.dtype,
+            &self.device,
+        )?;
+        if let Ok(mut guard) = self.mtp_hidden_buffer.lock() {
+            *guard = Some(buf);
+        }
+        Ok(())
     }
 
     pub fn set_mamba_prefix_cache_capacity(&self, capacity: usize) {

--- a/src/models/qwen3_5.rs
+++ b/src/models/qwen3_5.rs
@@ -497,6 +497,10 @@ impl Qwen3_5ForCausalLM {
         }
     }
 
+    pub fn embed_weight(&self) -> &Tensor {
+        self.embed_tokens.embeddings()
+    }
+
     /// Get the last hidden state for MTP from the pre-allocated buffer.
     /// Returns row 0 of the buffer (MTP decode always uses batch_size=1).
     pub fn take_last_hidden_for_mtp(&self) -> Option<Tensor> {
@@ -691,23 +695,6 @@ impl Qwen3_5ForCausalLM {
         )
     }
 
-    /// Re-run forward on accepted tokens to fix mamba/GDN recurrent state.
-    /// KV cache entries are re-written with identical values (same tokens + positions).
-    /// Uses native flash attention (flashinfer_metadata=None in input_metadata).
-    /// Replay accepted tokens through all layers to fix GDN recurrent state
-    /// after a partial MTP rejection. Runs the full forward (attention layers
-    /// must execute to produce correct hidden states for subsequent GDN layers).
-    pub fn forward_mamba_only(
-        &self,
-        input_ids: &Tensor,
-        positions: &Tensor,
-        kv_caches: Option<&Vec<(Tensor, Tensor)>>,
-        input_metadata: &InputMetadata,
-    ) -> Result<()> {
-        let _ = self.forward(input_ids, positions, kv_caches, input_metadata, false)?;
-        Ok(())
-    }
-
     /// Apply lm_head to hidden states to get logits. Used by MTP drafting.
     pub fn forward_lm_head(&self, hidden: &Tensor) -> Result<Tensor> {
         if self.is_qvar_builder {
@@ -789,6 +776,22 @@ impl Qwen3_5ForCausalLM {
 
     pub fn restore_mamba_prefix_state(&self, seq_id: usize, hash: u64) -> Result<bool> {
         self.mamba_cache.write().restore_prefix_state(seq_id, hash)
+    }
+
+    pub fn mtp_rollback_mamba(&self, seq_id: usize, keep_tokens: usize) -> Result<bool> {
+        let mut mamba_cache = self.mamba_cache.write();
+        let slots = mamba_cache
+            .get_slots_for_sequences(&[seq_id])?
+            .into_iter()
+            .map(|s| s as i64)
+            .collect::<Vec<_>>();
+        let seq_slots = Tensor::from_vec(slots, (1,), &self.device)?;
+        for layer in &self.layers {
+            if let Qwen3_5AttnType::LinearAttention(gdn) = &layer.attn {
+                gdn.rollback_mtp_verify(&mut mamba_cache, &seq_slots, keep_tokens)?;
+            }
+        }
+        Ok(true)
     }
 
     pub fn reset_mamba_cache(&self) -> Result<()> {

--- a/src/models/qwen3_5.rs
+++ b/src/models/qwen3_5.rs
@@ -194,6 +194,8 @@ pub struct Qwen3_5ForCausalLM {
     dtype: DType,
     vocab_size: usize,
     is_qvar_builder: bool,
+    /// Cached last hidden state for MTP speculative decoding
+    pub last_hidden_for_mtp: std::sync::Mutex<Option<Tensor>>,
 }
 
 impl Qwen3_5ForCausalLM {
@@ -480,6 +482,7 @@ impl Qwen3_5ForCausalLM {
             dtype,
             vocab_size,
             is_qvar_builder,
+            last_hidden_for_mtp: std::sync::Mutex::new(None),
         })
     }
 
@@ -490,6 +493,11 @@ impl Qwen3_5ForCausalLM {
         } else {
             Ok(xs)
         }
+    }
+
+    /// Take the last cached hidden state for MTP (consumes it)
+    pub fn take_last_hidden_for_mtp(&self) -> Option<Tensor> {
+        self.last_hidden_for_mtp.lock().ok()?.take()
     }
 
     fn forward_inner(
@@ -565,12 +573,18 @@ impl Qwen3_5ForCausalLM {
         let xs = self.norm.forward(&xs)?;
         if return_hidden {
             xs.to_dtype(DType::F32)
-        } else if self.is_qvar_builder {
-            self.lm_head.forward(&xs)
         } else {
-            self.lm_head
-                .forward(&xs.to_dtype(self.dtype)?)?
-                .to_dtype(DType::F32)
+            // Cache hidden state for MTP speculative decoding
+            if let Ok(mut cache) = self.last_hidden_for_mtp.lock() {
+                *cache = Some(xs.clone());
+            }
+            if self.is_qvar_builder {
+                self.lm_head.forward(&xs)
+            } else {
+                self.lm_head
+                    .forward(&xs.to_dtype(self.dtype)?)?
+                    .to_dtype(DType::F32)
+            }
         }
     }
 
@@ -614,6 +628,36 @@ impl Qwen3_5ForCausalLM {
         )
     }
 
+    /// Forward pass that returns both logits and hidden states.
+    /// Used by MTP speculative decoding to get backbone hidden states for the draft head.
+    pub fn forward_with_hidden(
+        &self,
+        input_ids: &Tensor,
+        positions: &Tensor,
+        kv_caches: Option<&Vec<(Tensor, Tensor)>>,
+        input_metadata: &InputMetadata,
+        embeded_inputs: bool,
+    ) -> Result<(Tensor, Tensor)> {
+        let hidden = self.forward_inner(
+            input_ids,
+            positions,
+            kv_caches,
+            input_metadata,
+            embeded_inputs,
+            &None,
+            &None,
+            true,
+        )?;
+        let logits = if self.is_qvar_builder {
+            self.lm_head.forward(&hidden)?
+        } else {
+            self.lm_head
+                .forward(&hidden.to_dtype(self.dtype)?)?
+                .to_dtype(DType::F32)?
+        };
+        Ok((logits, hidden))
+    }
+
     pub fn forward_with_deepstack(
         &self,
         input_ids: &Tensor,
@@ -634,6 +678,17 @@ impl Qwen3_5ForCausalLM {
             deepstack_visual_embeds,
             false,
         )
+    }
+
+    /// Apply lm_head to hidden states to get logits. Used by MTP drafting.
+    pub fn forward_lm_head(&self, hidden: &Tensor) -> Result<Tensor> {
+        if self.is_qvar_builder {
+            self.lm_head.forward(hidden)
+        } else {
+            self.lm_head
+                .forward(&hidden.to_dtype(self.dtype)?)?
+                .to_dtype(DType::F32)
+        }
     }
 
     pub fn get_vocab_size(&self) -> usize {

--- a/src/models/qwen3_5_moe.rs
+++ b/src/models/qwen3_5_moe.rs
@@ -621,6 +621,10 @@ impl Qwen3_5MoEForCausalLM {
         }
     }
 
+    pub fn embed_weight(&self) -> &Tensor {
+        self.embed_tokens.embeddings()
+    }
+
     pub fn take_last_hidden_for_mtp(&self) -> Option<Tensor> {
         let guard = self.mtp_hidden_buffer.lock().ok()?;
         let buf = guard.as_ref()?;
@@ -675,17 +679,6 @@ impl Qwen3_5MoEForCausalLM {
                 .forward(&hidden.to_dtype(self.dtype)?)?
                 .to_dtype(DType::F32)
         }
-    }
-
-    pub fn forward_mamba_only(
-        &self,
-        input_ids: &Tensor,
-        positions: &Tensor,
-        kv_caches: Option<&Vec<(Tensor, Tensor)>>,
-        input_metadata: &InputMetadata,
-    ) -> Result<()> {
-        let _ = self.forward(input_ids, positions, kv_caches, input_metadata, false)?;
-        Ok(())
     }
 
     fn forward_inner(
@@ -895,6 +888,23 @@ impl Qwen3_5MoEForCausalLM {
 
     pub fn restore_mamba_prefix_state(&self, seq_id: usize, hash: u64) -> Result<bool> {
         self.mamba_cache.write().restore_prefix_state(seq_id, hash)
+    }
+
+    pub fn mtp_rollback_mamba(&self, seq_id: usize, keep_tokens: usize) -> Result<bool> {
+        let mut mamba_cache = self.mamba_cache.write();
+
+        let slots = mamba_cache
+            .get_slots_for_sequences(&[seq_id])?
+            .into_iter()
+            .map(|s| s as i64)
+            .collect::<Vec<_>>();
+        let seq_slots = Tensor::from_vec(slots, (1,), &self.device)?;
+        for layer in &self.layers {
+            if let Qwen3_5MoEAttnType::LinearAttention(gdn) = &layer.attn {
+                gdn.rollback_mtp_verify(&mut mamba_cache, &seq_slots, keep_tokens)?;
+            }
+        }
+        Ok(true)
     }
 
     pub fn reset_mamba_cache(&self) -> Result<()> {

--- a/src/models/qwen3_5_moe.rs
+++ b/src/models/qwen3_5_moe.rs
@@ -333,6 +333,8 @@ pub struct Qwen3_5MoEForCausalLM {
     dtype: DType,
     vocab_size: usize,
     is_qvar_builder: bool,
+    /// Pre-allocated hidden state buffer for MTP speculative decoding (graph-safe).
+    pub mtp_hidden_buffer: std::sync::Mutex<Option<Tensor>>,
 }
 
 impl Qwen3_5MoEForCausalLM {
@@ -606,6 +608,7 @@ impl Qwen3_5MoEForCausalLM {
             dtype,
             vocab_size,
             is_qvar_builder,
+            mtp_hidden_buffer: std::sync::Mutex::new(None),
         })
     }
 
@@ -616,6 +619,73 @@ impl Qwen3_5MoEForCausalLM {
         } else {
             Ok(xs)
         }
+    }
+
+    pub fn take_last_hidden_for_mtp(&self) -> Option<Tensor> {
+        let guard = self.mtp_hidden_buffer.lock().ok()?;
+        let buf = guard.as_ref()?;
+        buf.get(0).ok()
+    }
+
+    pub fn preallocate_mtp_hidden_buffer(&self, max_batch_size: usize) -> Result<()> {
+        let buf = Tensor::zeros(
+            (max_batch_size, self.config.hidden_size),
+            self.dtype,
+            &self.device,
+        )?;
+        if let Ok(mut guard) = self.mtp_hidden_buffer.lock() {
+            *guard = Some(buf);
+        }
+        Ok(())
+    }
+
+    pub fn forward_with_hidden(
+        &self,
+        input_ids: &Tensor,
+        positions: &Tensor,
+        kv_caches: Option<&Vec<(Tensor, Tensor)>>,
+        input_metadata: &InputMetadata,
+        embeded_inputs: bool,
+    ) -> Result<(Tensor, Tensor)> {
+        let hidden = self.forward_inner(
+            input_ids,
+            positions,
+            kv_caches,
+            input_metadata,
+            embeded_inputs,
+            &None,
+            &None,
+            true,
+        )?;
+        let logits = if self.is_qvar_builder {
+            self.lm_head.forward(&hidden)?
+        } else {
+            self.lm_head
+                .forward(&hidden.to_dtype(self.dtype)?)?
+                .to_dtype(DType::F32)?
+        };
+        Ok((logits, hidden))
+    }
+
+    pub fn forward_lm_head(&self, hidden: &Tensor) -> Result<Tensor> {
+        if self.is_qvar_builder {
+            self.lm_head.forward(hidden)
+        } else {
+            self.lm_head
+                .forward(&hidden.to_dtype(self.dtype)?)?
+                .to_dtype(DType::F32)
+        }
+    }
+
+    pub fn forward_mamba_only(
+        &self,
+        input_ids: &Tensor,
+        positions: &Tensor,
+        kv_caches: Option<&Vec<(Tensor, Tensor)>>,
+        input_metadata: &InputMetadata,
+    ) -> Result<()> {
+        let _ = self.forward(input_ids, positions, kv_caches, input_metadata, false)?;
+        Ok(())
     }
 
     fn forward_inner(
@@ -689,12 +759,21 @@ impl Qwen3_5MoEForCausalLM {
         let xs = self.norm.forward(&xs)?;
         if return_hidden {
             xs.to_dtype(DType::F32)
-        } else if self.is_qvar_builder {
-            self.lm_head.forward(&xs)
         } else {
-            self.lm_head
-                .forward(&xs.to_dtype(self.dtype)?)?
-                .to_dtype(DType::F32)
+            if let Ok(guard) = self.mtp_hidden_buffer.lock() {
+                if let Some(buf) = guard.as_ref() {
+                    if xs.elem_count() <= buf.elem_count() {
+                        let _ = buf.copy_(&xs, 0);
+                    }
+                }
+            }
+            if self.is_qvar_builder {
+                self.lm_head.forward(&xs)
+            } else {
+                self.lm_head
+                    .forward(&xs.to_dtype(self.dtype)?)?
+                    .to_dtype(DType::F32)
+            }
         }
     }
 

--- a/src/models/qwen3_5_mtp.rs
+++ b/src/models/qwen3_5_mtp.rs
@@ -4,24 +4,77 @@
 // The MTP head is a lightweight transformer layer that predicts future tokens
 // using the backbone model's hidden states and KV cache.
 //
-// Weight prefix: "mtp."
-// Structure:
-//   - pre_fc_norm_hidden: RMS norm on backbone hidden states
-//   - pre_fc_norm_embedding: RMS norm on token embeddings
-//   - fc: Linear projection [2*hidden_size -> hidden_size]
-//   - layers.0: Single full-attention decoder layer (same arch as backbone)
-//   - norm: Final RMS norm before lm_head
+// Supports both dense and MoE variants:
+//   Dense: mtp.layers.0.mlp.{gate_proj,up_proj,down_proj}
+//   MoE:   mtp.layers.0.mlp.{gate,experts.N.{gate_proj,up_proj,down_proj},shared_expert.*,shared_expert_gate}
 
 use crate::models::layers::attention::Attention;
 use crate::models::layers::distributed::{Comm, ReplicatedLinear};
+use crate::models::layers::linear::LinearX as Linear;
 use crate::models::layers::mlp::MLP;
+use crate::models::layers::moe::{FusedMoe, FusedMoeFp8, FusedMoeGGUF, FusedMoeISQ};
 use crate::models::layers::others::{rms_norm, NormX};
 use crate::models::layers::rotary_emb::{ApplyRotaryEmbedding, ScalingRotaryEmbedding};
 use crate::models::layers::VarBuilderX;
 use crate::utils::config::Config;
-use candle_core::{DType, Device, Result, Tensor, D};
+use candle_core::{DType, Device, Module, Result, Tensor, D};
 use std::rc::Rc;
 use std::sync::Arc;
+
+enum MtpMlp {
+    Dense(MLP),
+    Moe {
+        fused_moe: MtpFusedMoe,
+        shared_gate: Option<Linear>,
+        shared_expert: Option<MLP>,
+    },
+}
+
+enum MtpFusedMoe {
+    BF16(FusedMoe),
+    FP8(FusedMoeFp8),
+    GGUF(FusedMoeGGUF),
+    ISQ(FusedMoeISQ),
+}
+
+impl MtpFusedMoe {
+    fn forward(&self, xs: &Tensor, is_prefill: bool) -> Result<Tensor> {
+        match self {
+            Self::BF16(m) => m.forward(xs, is_prefill),
+            Self::FP8(m) => m.forward(xs, is_prefill),
+            Self::GGUF(m) => m.forward(xs, is_prefill),
+            Self::ISQ(m) => m.forward(xs, is_prefill),
+        }
+    }
+}
+
+impl MtpMlp {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        match self {
+            Self::Dense(mlp) => mlp.forward(xs),
+            Self::Moe {
+                fused_moe,
+                shared_gate,
+                shared_expert,
+            } => {
+                let shared_output = match (shared_gate, shared_expert) {
+                    (Some(sg), Some(se)) => {
+                        let gate = candle_nn::ops::sigmoid(&sg.forward(xs)?)?;
+                        let shared_out = se.forward(xs)?;
+                        Some(gate.broadcast_mul(&shared_out)?)
+                    }
+                    _ => None,
+                };
+                let moe_output = fused_moe.forward(xs, false)?;
+                if let Some(shared_output) = shared_output {
+                    (moe_output + shared_output).map_err(Into::into)
+                } else {
+                    Ok(moe_output)
+                }
+            }
+        }
+    }
+}
 
 pub struct Qwen3_5MtpHead {
     pre_fc_norm_hidden: NormX,
@@ -36,7 +89,7 @@ pub struct Qwen3_5MtpHead {
 
 struct Qwen3_5MtpDecoderLayer {
     attn: Attention,
-    mlp: MLP,
+    mlp: MtpMlp,
     input_layernorm: NormX,
     post_attention_layernorm: NormX,
 }
@@ -138,22 +191,110 @@ impl Qwen3_5MtpHead {
             dtype,
         )?;
 
-        let mlp = MLP::new(
-            if is_qvar_builder {
-                vb.pp(&layer_prefix)
+        let mlp_vb = if is_qvar_builder {
+            vb.pp(&layer_prefix)
+        } else {
+            vb.pp(&format!("{}.mlp", layer_prefix))
+        };
+
+        let is_moe = config.moe_cfg.is_some() && mlp_vb.has_key("gate.weight");
+
+        let mlp = if is_moe {
+            let moe_cfg = config.moe_cfg.as_ref().unwrap();
+            let fused_moe = if is_qvar_builder {
+                MtpFusedMoe::GGUF(FusedMoeGGUF::new(
+                    config,
+                    mlp_vb.clone(),
+                    comm.clone(),
+                    dtype,
+                )?)
+            } else if let Some(quant_config) = &config.quantization_config {
+                if quant_config.quant_method == "fp8" {
+                    MtpFusedMoe::FP8(FusedMoeFp8::new(
+                        config,
+                        mlp_vb.clone(),
+                        comm.clone(),
+                        dtype,
+                        quant_config,
+                    )?)
+                } else {
+                    MtpFusedMoe::BF16(FusedMoe::new(config, mlp_vb.clone(), comm.clone(), dtype)?)
+                }
+            } else if config.quant.is_some() {
+                MtpFusedMoe::ISQ(FusedMoeISQ::new(
+                    config,
+                    mlp_vb.clone(),
+                    comm.clone(),
+                    dtype,
+                )?)
             } else {
-                vb.pp(&format!("{}.mlp", layer_prefix))
-            },
-            comm.clone(),
-            hidden_size,
-            config.intermediate_size,
-            &config.hidden_act,
-            &config.quantization_config,
-            &config.quant,
-            false,
-            dtype,
-            "",
-        )?;
+                MtpFusedMoe::BF16(FusedMoe::new(config, mlp_vb.clone(), comm.clone(), dtype)?)
+            };
+
+            let (shared_gate, shared_expert) = if let Some(intermediate_size) =
+                moe_cfg.shared_expert_intermediate_size
+            {
+                if intermediate_size > 0 {
+                    let ws = match &mlp_vb.0 {
+                        either::Either::Left(vb) => vb
+                            .pp("shared_expert_gate")
+                            .get((1, hidden_size), "weight")?,
+                        either::Either::Right(vb) => {
+                            let ws = vb.pp("ffn_gate_inp_shexp").get((hidden_size,), "weight")?;
+                            ws.dequantize(&vb.device())?.reshape((1, hidden_size))?
+                        }
+                    }
+                    .to_dtype(
+                        if is_qvar_builder || config.quant.is_some() {
+                            DType::F32
+                        } else {
+                            dtype
+                        },
+                    )?;
+                    let shared_gate = Linear::new(ws, None, &None)?;
+                    let shared_mlp = MLP::new(
+                        if is_qvar_builder {
+                            mlp_vb.clone()
+                        } else {
+                            mlp_vb.pp("shared_expert").clone()
+                        },
+                        comm.clone(),
+                        hidden_size,
+                        intermediate_size,
+                        &config.hidden_act,
+                        &config.quantization_config,
+                        &config.quant,
+                        false,
+                        dtype,
+                        if is_qvar_builder { "_shexp" } else { "" },
+                    )?;
+                    (Some(shared_gate), Some(shared_mlp))
+                } else {
+                    (None, None)
+                }
+            } else {
+                (None, None)
+            };
+
+            MtpMlp::Moe {
+                fused_moe,
+                shared_gate,
+                shared_expert,
+            }
+        } else {
+            MtpMlp::Dense(MLP::new(
+                mlp_vb,
+                comm.clone(),
+                hidden_size,
+                config.intermediate_size,
+                &config.hidden_act,
+                &config.quantization_config,
+                &config.quant,
+                false,
+                dtype,
+                "",
+            )?)
+        };
 
         let input_layernorm = rms_norm(
             hidden_size,
@@ -225,12 +366,66 @@ impl Qwen3_5MtpHead {
         self.norm.forward(&xs)
     }
 
-    /// Draft K tokens given the initial backbone hidden state and the anchor token.
+    /// Draft K tokens with all operations on GPU (no per-step CPU round-trips).
     ///
-    /// Uses the backbone's shared lm_head (passed as a closure) and embed_tokens
-    /// to autoregressively predict K tokens.
+    /// Uses GPU-resident argmax + gather-based embedding lookup to keep draft
+    /// tokens on device. Only transfers the final token list to CPU once.
     ///
-    /// Returns (draft_token_ids, last_hidden_state_for_each_step).
+    /// Returns (draft_token_ids, last_hidden_state).
+    pub fn draft_tokens_gpu(
+        &self,
+        initial_hidden: &Tensor,
+        anchor_token_tensor: &Tensor,
+        num_tokens: usize,
+        embed_weight: &Tensor,
+        lm_head_fn: impl Fn(&Tensor) -> Result<Tensor>,
+        positions_base: usize,
+    ) -> Result<(Vec<u32>, Tensor)> {
+        let mut gpu_draft_tokens: Vec<Tensor> = Vec::with_capacity(num_tokens);
+        let mut current_hidden = if initial_hidden.dims().len() == 1 {
+            initial_hidden.unsqueeze(0)?
+        } else {
+            initial_hidden.clone()
+        };
+        let mut current_token_t = anchor_token_tensor.reshape((1,))?;
+
+        for step in 0..num_tokens {
+            let token_embed = embed_weight.index_select(&current_token_t, 0)?;
+
+            let pos = (positions_base + step) as i64;
+            let positions = Tensor::from_vec(vec![pos], (1,), &self.device)?;
+
+            let hidden_out = self.forward_step(&current_hidden, &token_embed, &positions)?;
+
+            let logits = lm_head_fn(&hidden_out.to_dtype(self.dtype)?)?;
+            let logits_last = if logits.dims().len() == 2 {
+                logits.get(logits.dim(0)? - 1)?
+            } else {
+                logits
+            };
+            let next_token_t = logits_last.to_dtype(DType::F32)?.argmax(D::Minus1)?;
+
+            gpu_draft_tokens.push(next_token_t.clone());
+            current_hidden = if hidden_out.dims().len() == 2 {
+                hidden_out.get(hidden_out.dim(0)? - 1)?.unsqueeze(0)?
+            } else {
+                hidden_out
+            };
+            current_token_t = next_token_t.reshape((1,))?;
+        }
+
+        let draft_tokens: Vec<u32> = if gpu_draft_tokens.is_empty() {
+            vec![]
+        } else {
+            let stacked = Tensor::stack(&gpu_draft_tokens, 0)?;
+            stacked.to_vec1::<u32>()?
+        };
+
+        let final_hidden = current_hidden.squeeze(0)?;
+        Ok((draft_tokens, final_hidden))
+    }
+
+    /// Legacy draft method with CPU round-trips (kept for compatibility).
     pub fn draft_tokens(
         &self,
         initial_hidden: &Tensor,

--- a/src/models/qwen3_5_mtp.rs
+++ b/src/models/qwen3_5_mtp.rs
@@ -1,0 +1,292 @@
+// src/models/qwen3_5_mtp.rs
+// Qwen3.5 MTP (Multi-Token Prediction) Head
+//
+// The MTP head is a lightweight transformer layer that predicts future tokens
+// using the backbone model's hidden states and KV cache.
+//
+// Weight prefix: "mtp."
+// Structure:
+//   - pre_fc_norm_hidden: RMS norm on backbone hidden states
+//   - pre_fc_norm_embedding: RMS norm on token embeddings
+//   - fc: Linear projection [2*hidden_size -> hidden_size]
+//   - layers.0: Single full-attention decoder layer (same arch as backbone)
+//   - norm: Final RMS norm before lm_head
+
+use crate::models::layers::attention::Attention;
+use crate::models::layers::distributed::{Comm, ReplicatedLinear};
+use crate::models::layers::mlp::MLP;
+use crate::models::layers::others::{rms_norm, NormX};
+use crate::models::layers::rotary_emb::{ApplyRotaryEmbedding, ScalingRotaryEmbedding};
+use crate::models::layers::VarBuilderX;
+use crate::utils::config::Config;
+use candle_core::{DType, Device, Result, Tensor, D};
+use std::rc::Rc;
+use std::sync::Arc;
+
+pub struct Qwen3_5MtpHead {
+    pre_fc_norm_hidden: NormX,
+    pre_fc_norm_embedding: NormX,
+    fc: ReplicatedLinear,
+    layer: Qwen3_5MtpDecoderLayer,
+    norm: NormX,
+    rotary_emb: Arc<ScalingRotaryEmbedding>,
+    device: Device,
+    dtype: DType,
+}
+
+struct Qwen3_5MtpDecoderLayer {
+    attn: Attention,
+    mlp: MLP,
+    input_layernorm: NormX,
+    post_attention_layernorm: NormX,
+}
+
+impl Qwen3_5MtpDecoderLayer {
+    /// Forward for MTP head - single token, no KV cache needed.
+    /// For seq_len=1, self-attention is trivially identity on the value,
+    /// so we compute: output = O_proj(V_proj(norm(x))) after RoPE on Q/K.
+    /// This avoids going through PagedAttention/FlashInfer backends entirely.
+    fn forward_single_token(
+        &self,
+        xs: &Tensor,
+        positions: &Tensor,
+        rotary_emb: &Arc<ScalingRotaryEmbedding>,
+    ) -> Result<Tensor> {
+        let residual = xs;
+        let xs = self.input_layernorm.forward(xs)?;
+        let rope: Arc<dyn ApplyRotaryEmbedding> = rotary_emb.clone();
+        let attn_output = self
+            .attn
+            .forward_single_token_no_cache(&xs, &rope, positions)?;
+        let xs = (attn_output + residual)?;
+        let residual = &xs;
+        let xs = self.post_attention_layernorm.forward(&xs)?;
+        let mlp_output = self.mlp.forward(&xs)?;
+        residual + mlp_output
+    }
+}
+
+impl Qwen3_5MtpHead {
+    pub fn new(
+        vb: &VarBuilderX,
+        comm: Rc<Comm>,
+        config: &Config,
+        dtype: DType,
+        is_rope_i: bool,
+        device: &Device,
+    ) -> Result<Self> {
+        let hidden_size = config.hidden_size;
+        let is_qvar_builder = vb.is_qvar_builder();
+        let prefix = "mtp.";
+
+        let pre_fc_norm_hidden = rms_norm(
+            hidden_size,
+            config.rms_norm_eps,
+            vb.pp(&format!("{}pre_fc_norm_hidden", prefix)),
+            DType::F32,
+            !is_qvar_builder,
+        )?;
+
+        let pre_fc_norm_embedding = rms_norm(
+            hidden_size,
+            config.rms_norm_eps,
+            vb.pp(&format!("{}pre_fc_norm_embedding", prefix)),
+            DType::F32,
+            !is_qvar_builder,
+        )?;
+
+        let fc = ReplicatedLinear::load_no_bias(
+            hidden_size * 2,
+            hidden_size,
+            vb.pp(&format!("{}fc", prefix)),
+            &None,
+            &None,
+            dtype,
+        )?;
+
+        let norm = rms_norm(
+            hidden_size,
+            config.rms_norm_eps,
+            vb.pp(&format!("{}norm", prefix)),
+            DType::F32,
+            !is_qvar_builder,
+        )?;
+
+        let rotary_emb = Arc::new(ScalingRotaryEmbedding::new(
+            if is_qvar_builder || config.higher_precision_required() {
+                DType::F32
+            } else {
+                dtype
+            },
+            config,
+            device,
+            is_rope_i,
+            config.rope_theta,
+        )?);
+
+        let layer_prefix = format!("{}layers.0", prefix);
+        let attn = Attention::new(
+            if is_qvar_builder {
+                vb.pp(&layer_prefix)
+            } else {
+                vb.pp(&format!("{}.self_attn", layer_prefix))
+            },
+            comm.clone(),
+            config,
+            None,
+            config.sliding_window,
+            dtype,
+        )?;
+
+        let mlp = MLP::new(
+            if is_qvar_builder {
+                vb.pp(&layer_prefix)
+            } else {
+                vb.pp(&format!("{}.mlp", layer_prefix))
+            },
+            comm.clone(),
+            hidden_size,
+            config.intermediate_size,
+            &config.hidden_act,
+            &config.quantization_config,
+            &config.quant,
+            false,
+            dtype,
+            "",
+        )?;
+
+        let input_layernorm = rms_norm(
+            hidden_size,
+            config.rms_norm_eps,
+            vb.pp(&format!("{}.input_layernorm", layer_prefix)),
+            DType::F32,
+            !is_qvar_builder,
+        )?;
+
+        let post_attention_layernorm = rms_norm(
+            hidden_size,
+            config.rms_norm_eps,
+            vb.pp(&format!("{}.post_attention_layernorm", layer_prefix)),
+            DType::F32,
+            !is_qvar_builder,
+        )?;
+
+        let layer = Qwen3_5MtpDecoderLayer {
+            attn,
+            mlp,
+            input_layernorm,
+            post_attention_layernorm,
+        };
+
+        Ok(Self {
+            pre_fc_norm_hidden,
+            pre_fc_norm_embedding,
+            fc,
+            layer,
+            norm,
+            rotary_emb,
+            device: device.clone(),
+            dtype,
+        })
+    }
+
+    /// Single MTP draft step.
+    ///
+    /// Given the backbone's last hidden states and the embedding of the current token,
+    /// produces the next hidden state for the MTP head.
+    /// The caller should apply lm_head to get logits.
+    ///
+    /// `backbone_hidden`: [batch, hidden_size] - last hidden from the backbone
+    /// `token_embedding`: [batch, hidden_size] - embedding of the last sampled/draft token
+    /// `positions`: position IDs for this step
+    /// `kv_cache`: MTP head's own KV cache (separate from backbone)
+    /// `input_metadata`: attention metadata for this step
+    pub fn forward_step(
+        &self,
+        backbone_hidden: &Tensor,
+        token_embedding: &Tensor,
+        positions: &Tensor,
+    ) -> Result<Tensor> {
+        let norm_hidden = self.pre_fc_norm_hidden.forward(backbone_hidden)?;
+        let norm_embed = self.pre_fc_norm_embedding.forward(token_embedding)?;
+
+        // Concat order: [embedding, hidden] — matches vLLM/HuggingFace weight layout
+        // The FC weight's first half corresponds to embedding columns
+        let norm_embed = norm_embed.to_dtype(norm_hidden.dtype())?;
+        let fused = Tensor::cat(&[norm_embed, norm_hidden], D::Minus1)?;
+        let fused = fused.to_dtype(self.dtype)?;
+        let xs = self.fc.forward(&fused)?;
+
+        // MTP head uses single-token attention without KV cache
+        let xs = self
+            .layer
+            .forward_single_token(&xs, positions, &self.rotary_emb)?;
+
+        self.norm.forward(&xs)
+    }
+
+    /// Draft K tokens given the initial backbone hidden state and the anchor token.
+    ///
+    /// Uses the backbone's shared lm_head (passed as a closure) and embed_tokens
+    /// to autoregressively predict K tokens.
+    ///
+    /// Returns (draft_token_ids, last_hidden_state_for_each_step).
+    pub fn draft_tokens(
+        &self,
+        initial_hidden: &Tensor,
+        anchor_token: u32,
+        num_tokens: usize,
+        embed_fn: impl Fn(u32) -> Result<Tensor>,
+        lm_head_fn: impl Fn(&Tensor) -> Result<Tensor>,
+        positions_base: usize,
+    ) -> Result<(Vec<u32>, Tensor)> {
+        let mut draft_tokens = Vec::with_capacity(num_tokens);
+        let mut current_hidden = initial_hidden.clone();
+        let mut current_token = anchor_token;
+
+        for step in 0..num_tokens {
+            let token_embed = embed_fn(current_token)?;
+            let token_embed = match token_embed.dims().len() {
+                1 => token_embed.unsqueeze(0)?,
+                _ => token_embed,
+            };
+
+            let current_hidden_2d = match current_hidden.dims().len() {
+                1 => current_hidden.unsqueeze(0)?,
+                _ => current_hidden.clone(),
+            };
+
+            let pos = (positions_base + step) as i64;
+            let positions = Tensor::from_vec(vec![pos], (1,), &self.device)?;
+
+            let hidden_out = self.forward_step(&current_hidden_2d, &token_embed, &positions)?;
+
+            let logits = lm_head_fn(&hidden_out.to_dtype(self.dtype)?)?;
+            let logits = logits.to_dtype(DType::F32)?;
+            let logits_last = if logits.dims().len() == 2 {
+                logits.get(logits.dim(0)? - 1)?
+            } else {
+                logits
+            };
+            let next_token = logits_last.argmax(D::Minus1)?.to_scalar::<u32>()?;
+
+            draft_tokens.push(next_token);
+            current_hidden = if hidden_out.dims().len() == 2 {
+                hidden_out.get(hidden_out.dim(0)? - 1)?
+            } else {
+                hidden_out
+            };
+            current_token = next_token;
+        }
+
+        Ok((draft_tokens, current_hidden))
+    }
+
+    pub fn device(&self) -> &Device {
+        &self.device
+    }
+
+    pub fn dtype(&self) -> DType {
+        self.dtype
+    }
+}

--- a/src/models/qwen3_vl/mod.rs
+++ b/src/models/qwen3_vl/mod.rs
@@ -721,6 +721,14 @@ impl Qwen3VLForConditionalGeneration {
         }
     }
 
+    pub fn mtp_rollback_mamba(&self, seq_id: usize, keep_tokens: usize) -> Result<bool> {
+        match &self.text_model {
+            Qwen3TextModel::Dense35(m) => m.mtp_rollback_mamba(seq_id, keep_tokens),
+            Qwen3TextModel::MoE35(m) => m.mtp_rollback_mamba(seq_id, keep_tokens),
+            _ => Ok(false),
+        }
+    }
+
     pub fn reset_mamba_cache(&self) -> Result<()> {
         match &self.text_model {
             Qwen3TextModel::Dense35(m) => m.reset_mamba_cache(),
@@ -778,6 +786,14 @@ impl Qwen3VLForConditionalGeneration {
         }
     }
 
+    pub fn embed_weight(&self) -> Option<&candle_core::Tensor> {
+        match &self.text_model {
+            Qwen3TextModel::Dense35(m) => Some(m.embed_weight()),
+            Qwen3TextModel::MoE35(m) => Some(m.embed_weight()),
+            _ => None,
+        }
+    }
+
     /// Take the cached last hidden state for MTP
     pub fn take_last_hidden_for_mtp(&self) -> Option<candle_core::Tensor> {
         match &self.text_model {
@@ -792,25 +808,6 @@ impl Qwen3VLForConditionalGeneration {
         match &self.text_model {
             Qwen3TextModel::Dense35(m) => m.preallocate_mtp_hidden_buffer(max_batch_size),
             Qwen3TextModel::MoE35(m) => m.preallocate_mtp_hidden_buffer(max_batch_size),
-            _ => Ok(()),
-        }
-    }
-
-    /// Replay tokens through all layers to fix GDN recurrent state.
-    pub fn forward_mamba_only(
-        &self,
-        input_ids: &Tensor,
-        positions: &Tensor,
-        kv_caches: Option<&Vec<(Tensor, Tensor)>>,
-        input_metadata: &InputMetadata,
-    ) -> Result<()> {
-        match &self.text_model {
-            Qwen3TextModel::Dense35(m) => {
-                m.forward_mamba_only(input_ids, positions, kv_caches, input_metadata)
-            }
-            Qwen3TextModel::MoE35(m) => {
-                m.forward_mamba_only(input_ids, positions, kv_caches, input_metadata)
-            }
             _ => Ok(()),
         }
     }

--- a/src/models/qwen3_vl/mod.rs
+++ b/src/models/qwen3_vl/mod.rs
@@ -728,4 +728,53 @@ impl Qwen3VLForConditionalGeneration {
             _ => Ok(()),
         }
     }
+
+    /// Forward pass that returns both logits and hidden states (for MTP drafting).
+    pub fn forward_with_hidden(
+        &self,
+        input_ids: &Tensor,
+        positions: &Tensor,
+        kv_caches: Option<&Vec<(Tensor, Tensor)>>,
+        input_metadata: &InputMetadata,
+        embeded_inputs: bool,
+    ) -> Result<(Tensor, Tensor)> {
+        match &self.text_model {
+            Qwen3TextModel::Dense35(m) => m.forward_with_hidden(
+                input_ids,
+                positions,
+                kv_caches,
+                input_metadata,
+                embeded_inputs,
+            ),
+            _ => {
+                candle_core::bail!("forward_with_hidden only supported for Qwen3.5 text models")
+            }
+        }
+    }
+
+    /// Apply lm_head to hidden states (for MTP drafting).
+    pub fn forward_lm_head(&self, hidden: &Tensor) -> Result<Tensor> {
+        match &self.text_model {
+            Qwen3TextModel::Dense35(m) => m.forward_lm_head(hidden),
+            _ => candle_core::bail!("forward_lm_head only supported for Qwen3.5 text models"),
+        }
+    }
+
+    /// Get token embedding for a single token (for MTP drafting).
+    pub fn embed_forward(&self, input_ids: &Tensor) -> Result<Tensor> {
+        match &self.text_model {
+            Qwen3TextModel::Dense35(m) => m.embed_forward(input_ids),
+            Qwen3TextModel::MoE35(m) => m.embed_forward(input_ids),
+            Qwen3TextModel::Dense(m) => m.embed_forward(input_ids),
+            Qwen3TextModel::MoE(m) => m.embed_forward(input_ids),
+        }
+    }
+
+    /// Take the cached last hidden state for MTP
+    pub fn take_last_hidden_for_mtp(&self) -> Option<candle_core::Tensor> {
+        match &self.text_model {
+            Qwen3TextModel::Dense35(m) => m.take_last_hidden_for_mtp(),
+            _ => None,
+        }
+    }
 }

--- a/src/models/qwen3_vl/mod.rs
+++ b/src/models/qwen3_vl/mod.rs
@@ -746,6 +746,13 @@ impl Qwen3VLForConditionalGeneration {
                 input_metadata,
                 embeded_inputs,
             ),
+            Qwen3TextModel::MoE35(m) => m.forward_with_hidden(
+                input_ids,
+                positions,
+                kv_caches,
+                input_metadata,
+                embeded_inputs,
+            ),
             _ => {
                 candle_core::bail!("forward_with_hidden only supported for Qwen3.5 text models")
             }
@@ -756,6 +763,7 @@ impl Qwen3VLForConditionalGeneration {
     pub fn forward_lm_head(&self, hidden: &Tensor) -> Result<Tensor> {
         match &self.text_model {
             Qwen3TextModel::Dense35(m) => m.forward_lm_head(hidden),
+            Qwen3TextModel::MoE35(m) => m.forward_lm_head(hidden),
             _ => candle_core::bail!("forward_lm_head only supported for Qwen3.5 text models"),
         }
     }
@@ -774,7 +782,36 @@ impl Qwen3VLForConditionalGeneration {
     pub fn take_last_hidden_for_mtp(&self) -> Option<candle_core::Tensor> {
         match &self.text_model {
             Qwen3TextModel::Dense35(m) => m.take_last_hidden_for_mtp(),
+            Qwen3TextModel::MoE35(m) => m.take_last_hidden_for_mtp(),
             _ => None,
+        }
+    }
+
+    /// Pre-allocate the MTP hidden state buffer
+    pub fn preallocate_mtp_hidden_buffer(&self, max_batch_size: usize) -> Result<()> {
+        match &self.text_model {
+            Qwen3TextModel::Dense35(m) => m.preallocate_mtp_hidden_buffer(max_batch_size),
+            Qwen3TextModel::MoE35(m) => m.preallocate_mtp_hidden_buffer(max_batch_size),
+            _ => Ok(()),
+        }
+    }
+
+    /// Replay tokens through all layers to fix GDN recurrent state.
+    pub fn forward_mamba_only(
+        &self,
+        input_ids: &Tensor,
+        positions: &Tensor,
+        kv_caches: Option<&Vec<(Tensor, Tensor)>>,
+        input_metadata: &InputMetadata,
+    ) -> Result<()> {
+        match &self.text_model {
+            Qwen3TextModel::Dense35(m) => {
+                m.forward_mamba_only(input_ids, positions, kv_caches, input_metadata)
+            }
+            Qwen3TextModel::MoE35(m) => {
+                m.forward_mamba_only(input_ids, positions, kv_caches, input_metadata)
+            }
+            _ => Ok(()),
         }
     }
 }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -181,8 +181,14 @@ pub enum MessageType {
     /// Sent by main process to request inference on sequences.
     RunDecode((Vec<DecodeSequence>, bool)),
 
+    /// Sent by main process to request MTP speculative decode on sequences.
+    RunDecodeMTP(Vec<DecodeSequence>),
+
     /// Sent by runner in response to `Run` with generated token IDs.
     RunResponse(Vec<u32>),
+
+    /// Sent by runner in response to `RunDecodeMTP` with multiple tokens per sequence.
+    RunResponseMTP(Vec<Vec<u32>>),
 
     /// Sent by main process to request embedding on sequences.
     RunEmbed((Vec<Sequence>, EmbeddingStrategy)),
@@ -868,6 +874,26 @@ pub fn run_runner_process(args: Vec<String>) -> anyhow::Result<()> {
                     ),
                     false,
                 )?;
+            }
+            Ok(MessageType::RunDecodeMTP(sequences)) => {
+                let outputs = runner.run_mtp_decode(Seqs::DecodeVec(&sequences));
+                match outputs {
+                    Ok(multi_tokens) => {
+                        send_local(
+                            &mut vec![stream.try_clone()?],
+                            &MessageType::RunResponseMTP(multi_tokens),
+                            false,
+                        )?;
+                    }
+                    Err(e) => {
+                        crate::log_error!("Runner MTP decode error: {:?}", e);
+                        send_local(
+                            &mut vec![stream.try_clone()?],
+                            &MessageType::RunResponseMTP(vec![]),
+                            false,
+                        )?;
+                    }
+                }
             }
             Ok(MessageType::ClearBlocks(block_ids)) => {
                 let ret = runner.clear_blocks(block_ids);

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -142,7 +142,6 @@ impl From<DType> for SerializableDType {
             DType::F16 => Self::F16,
             DType::F32 => Self::F32,
             DType::F64 => Self::F64,
-            DType::F8E8M0 | DType::F8E4M3 => Self::U8,
         }
     }
 }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -142,6 +142,7 @@ impl From<DType> for SerializableDType {
             DType::F16 => Self::F16,
             DType::F32 => Self::F32,
             DType::F64 => Self::F64,
+            DType::F8E8M0 | DType::F8E4M3 => Self::U8,
         }
     }
 }

--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -281,6 +281,26 @@ pub fn run_runner() -> anyhow::Result<()> {
                     false,
                 )?;
             }
+            Ok(MessageType::RunDecodeMTP(sequences)) => {
+                let outputs = runner.run_mtp_decode(Seqs::DecodeVec(&sequences));
+                match outputs {
+                    Ok(multi_tokens) => {
+                        send_local(
+                            &mut vec![stream.try_clone()?],
+                            &MessageType::RunResponseMTP(multi_tokens),
+                            false,
+                        )?;
+                    }
+                    Err(e) => {
+                        xinfer::log_error!("Runner MTP decode error: {:?}", e);
+                        send_local(
+                            &mut vec![stream.try_clone()?],
+                            &MessageType::RunResponseMTP(vec![]),
+                            false,
+                        )?;
+                    }
+                }
+            }
             Ok(MessageType::RunEmbed((sequences, strategy))) => {
                 use xinfer::core::sequence::Sequence;
                 let refs: Vec<&Sequence> = sequences.iter().collect();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1039,6 +1039,12 @@ pub struct Args {
     /// Master node port for multi-node NCCL bootstrap and forward-pass coordination.
     #[arg(long, default_value_t = 29500)]
     pub master_port: u16,
+
+    /// Enable MTP (Multi-Token Prediction) speculative decoding.
+    /// Specifies the number of speculative draft tokens per step (e.g. 3-7).
+    /// The model must have MTP heads (e.g. Qwen3.5, DeepSeek-V3).
+    #[arg(long, default_value = None)]
+    pub mtp: Option<usize>,
 }
 
 impl Args {

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -303,6 +303,10 @@ pub struct Config {
     pub extra_config_json: Option<String>,
     #[serde(default)]
     pub is_f16_mode: bool,
+    #[serde(default)]
+    pub mtp_num_hidden_layers: Option<usize>,
+    #[serde(default)]
+    pub mtp_use_dedicated_embeddings: Option<bool>,
 }
 
 impl fmt::Debug for Config {
@@ -429,6 +433,10 @@ pub struct EngineConfig {
     pub master_addr: Option<String>,
     #[serde(default = "default_master_port")]
     pub master_port: u16,
+    /// MTP (Multi-Token Prediction) speculative decoding: number of draft tokens per step.
+    /// None means MTP is disabled.
+    #[serde(default)]
+    pub mtp_num_speculative_tokens: Option<usize>,
 }
 
 fn default_num_nodes() -> usize {
@@ -533,6 +541,8 @@ pub struct EngineConfig {
     #[pyo3(get, set)]
     #[serde(default = "default_master_port")]
     pub master_port: u16,
+    #[serde(default)]
+    pub mtp_num_speculative_tokens: Option<usize>,
 }
 
 impl EngineConfig {
@@ -645,7 +655,13 @@ impl EngineConfig {
             node_rank,
             master_addr,
             master_port,
+            mtp_num_speculative_tokens: None,
         }
+    }
+
+    pub fn with_mtp(mut self, mtp_tokens: Option<usize>) -> Self {
+        self.mtp_num_speculative_tokens = mtp_tokens;
+        self
     }
 }
 

--- a/src/utils/graph.rs
+++ b/src/utils/graph.rs
@@ -915,6 +915,7 @@ impl<M: CudaGraphModule> GraphCapturer<M> {
         };
 
         let mut outputs = BTreeMap::<usize, Tensor>::new();
+        let _guard = candle_core::cuda_backend::cuda_param_cache_scope(true);
 
         for is_warmup in [true, false] {
             if !is_warmup || capture_in_warmup {

--- a/src/utils/graph.rs
+++ b/src/utils/graph.rs
@@ -389,6 +389,10 @@ pub struct MtpGraphCaptureVars {
     pub flashinfer_indices: Tensor,
     #[cfg(feature = "flashinfer")]
     pub flashinfer_last_len: Tensor,
+    #[cfg(feature = "flashinfer")]
+    pub flashinfer_batch_indices: Tensor,
+    #[cfg(feature = "flashinfer")]
+    pub flashinfer_positions: Tensor,
     pub outputs: BTreeMap<usize, Tensor>,
 }
 
@@ -844,6 +848,10 @@ impl<M: CudaGraphModule> GraphCapturer<M> {
         let flashinfer_indices = Tensor::zeros((max_num_blocks,), DType::U32, device)?;
         #[cfg(feature = "flashinfer")]
         let flashinfer_last_len = Tensor::zeros((1,), DType::U32, device)?;
+        #[cfg(feature = "flashinfer")]
+        let flashinfer_batch_indices = Tensor::zeros((verify_len,), DType::U32, device)?;
+        #[cfg(feature = "flashinfer")]
+        let flashinfer_positions = Tensor::zeros((verify_len,), DType::U32, device)?;
 
         #[cfg(feature = "flashinfer")]
         let use_flashinfer = self.flashinfer_kv_params.is_some();
@@ -882,8 +890,8 @@ impl<M: CudaGraphModule> GraphCapturer<M> {
                 last_len_host: Some(vec![self.max_model_len as u32]),
                 kv_len_arr_host: Some(kv_len_arr_host),
                 total_num_rows: Some(verify_len as u32),
-                batch_indices: None,
-                positions: None,
+                batch_indices: Some(flashinfer_batch_indices.clone()),
+                positions: Some(flashinfer_positions.clone()),
                 use_cuda_graph: true,
                 decode_plan_info: None,
                 prefill_plan_info: Some(prefill_plan_info),
@@ -965,6 +973,10 @@ impl<M: CudaGraphModule> GraphCapturer<M> {
             flashinfer_indices,
             #[cfg(feature = "flashinfer")]
             flashinfer_last_len,
+            #[cfg(feature = "flashinfer")]
+            flashinfer_batch_indices,
+            #[cfg(feature = "flashinfer")]
+            flashinfer_positions,
             outputs,
         });
         Ok(())
@@ -1037,6 +1049,16 @@ impl<M: CudaGraphModule> GraphCapturer<M> {
             mtp_vars.flashinfer_indices.copy_(&fm.indices, 0)?;
             mtp_vars.flashinfer_last_len.zero_()?;
             mtp_vars.flashinfer_last_len.copy_(&fm.last_len, 0)?;
+            let batch_indices = fm.batch_indices.as_ref().ok_or_else(|| {
+                candle_core::Error::msg("mtp replay requires flashinfer batch_indices")
+            })?;
+            let positions = fm.positions.as_ref().ok_or_else(|| {
+                candle_core::Error::msg("mtp replay requires flashinfer positions")
+            })?;
+            mtp_vars.flashinfer_batch_indices.zero_()?;
+            mtp_vars.flashinfer_batch_indices.copy_(batch_indices, 0)?;
+            mtp_vars.flashinfer_positions.zero_()?;
+            mtp_vars.flashinfer_positions.copy_(positions, 0)?;
 
             if let Some(params) = self.flashinfer_kv_params {
                 let dev = self

--- a/src/utils/graph.rs
+++ b/src/utils/graph.rs
@@ -100,9 +100,6 @@ pub trait CudaGraphModule {
         embeded_inputs: bool,
     ) -> Result<Tensor>;
     fn report_graph_pool_usage(&self) -> Result<()>;
-    fn start_capture_mtp(&mut self, verify_len: usize) -> Result<()>;
-    fn end_capture_mtp(&mut self, verify_len: usize, save: bool) -> Result<()>;
-    fn replay_mtp(&self, verify_len: usize) -> Result<()>;
 }
 
 pub struct CudaGraphHandle {
@@ -139,7 +136,6 @@ where
     device: Arc<CudaDevice>,
     pub pool_handle: RwLock<Option<i64>>,
     captured_bs: Vec<usize>,
-    mtp_captured_graphs: BTreeMap<usize, CudaGraphHandle>,
 }
 
 impl<M> CudaGraphWrapper<M>
@@ -161,7 +157,6 @@ where
             device,
             pool_handle: RwLock::new(None),
             captured_bs: Vec::new(),
-            mtp_captured_graphs: BTreeMap::new(),
         }
     }
 
@@ -342,44 +337,6 @@ where
         );
         Ok(())
     }
-
-    fn start_capture_mtp(&mut self, verify_len: usize) -> Result<()> {
-        self.capturing = true;
-        self.current_bs = Some(verify_len);
-        self.sync_stream()?;
-        self.set_capture_mem_pool()?;
-        CudaGraph::begin_capture(
-            self.device.cu_stream().clone(),
-            CUstreamCaptureMode::CU_STREAM_CAPTURE_MODE_RELAXED,
-        )?;
-        Ok(())
-    }
-
-    fn end_capture_mtp(&mut self, verify_len: usize, save: bool) -> Result<()> {
-        self.capturing = false;
-        self.current_bs = None;
-
-        let graph = CudaGraph::end_capture(
-            self.device.cu_stream().clone(),
-            CUgraphInstantiate_flags::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
-        )?;
-        if save {
-            self.mtp_captured_graphs
-                .insert(verify_len, CudaGraphHandle::new(Arc::new(graph)));
-        }
-        self.sync_stream()?;
-        Ok(())
-    }
-
-    fn replay_mtp(&self, verify_len: usize) -> Result<()> {
-        if let Some(graph) = self.mtp_captured_graphs.get(&verify_len) {
-            self.sync_stream()?;
-            graph.replay()?;
-            self.sync_stream()
-        } else {
-            candle_core::bail!("MTP verify graph for len {} is not captured!", verify_len)
-        }
-    }
 }
 
 #[derive(Clone, Copy)]
@@ -426,6 +383,12 @@ pub struct MtpGraphCaptureVars {
     pub block_tables: Tensor,
     pub cu_seqlens_q: Tensor,
     pub cu_seqlens_k: Tensor,
+    #[cfg(feature = "flashinfer")]
+    pub flashinfer_indptr: Tensor,
+    #[cfg(feature = "flashinfer")]
+    pub flashinfer_indices: Tensor,
+    #[cfg(feature = "flashinfer")]
+    pub flashinfer_last_len: Tensor,
     pub outputs: BTreeMap<usize, Tensor>,
 }
 
@@ -441,7 +404,6 @@ pub struct GraphCapturer<M: CudaGraphModule> {
     #[cfg(feature = "flashinfer")]
     pub flashinfer_kv_params: Option<FlashInferKvParams>,
     pub is_mla: bool,
-    pub mtp_num_speculative: usize,
     pub mtp_graph_vars: Option<MtpGraphCaptureVars>,
 }
 
@@ -520,7 +482,6 @@ impl<M: CudaGraphModule> GraphCapturer<M> {
             #[cfg(feature = "flashinfer")]
             flashinfer_kv_params: flashinfer_kv_params.clone(),
             is_mla,
-            mtp_num_speculative: 0,
             mtp_graph_vars: None,
         }
     }
@@ -863,64 +824,130 @@ impl<M: CudaGraphModule> GraphCapturer<M> {
         if mtp_num_speculative == 0 {
             return Ok(());
         }
-        self.mtp_num_speculative = mtp_num_speculative;
 
-        let max_verify_len = mtp_num_speculative + 1;
+        self.device = Some(device.clone());
+        let verify_len = mtp_num_speculative + 1;
         let max_num_blocks = (self.max_model_len + self.block_size - 1) / self.block_size;
 
-        let input_ids = Tensor::zeros((max_verify_len,), DType::U32, device)?;
-        let positions = Tensor::zeros((max_verify_len,), DType::I64, device)?;
+        let input_ids = Tensor::zeros((verify_len,), DType::U32, device)?;
+        let positions = Tensor::zeros((verify_len,), DType::I64, device)?;
         let mamba_slot_mapping = Tensor::zeros((1,), DType::I64, device)?;
-        let slot_mapping = Tensor::zeros((max_verify_len,), DType::I64, device)?;
+        let slot_mapping = Tensor::zeros((verify_len,), DType::I64, device)?;
         let context_lens = Tensor::zeros((1,), DType::U32, device)?;
         let block_tables = Tensor::zeros((1, max_num_blocks), DType::U32, device)?;
         let cu_seqlens_q = Tensor::zeros((2,), DType::U32, device)?;
         let cu_seqlens_k = Tensor::zeros((2,), DType::U32, device)?;
 
+        #[cfg(feature = "flashinfer")]
+        let flashinfer_indptr = Tensor::zeros((2,), DType::U32, device)?;
+        #[cfg(feature = "flashinfer")]
+        let flashinfer_indices = Tensor::zeros((max_num_blocks,), DType::U32, device)?;
+        #[cfg(feature = "flashinfer")]
+        let flashinfer_last_len = Tensor::zeros((1,), DType::U32, device)?;
+
+        #[cfg(feature = "flashinfer")]
+        let use_flashinfer = self.flashinfer_kv_params.is_some();
+        #[cfg(not(feature = "flashinfer"))]
+        let use_flashinfer = false;
+
+        let capture_in_warmup = use_flashinfer;
+
+        #[cfg(feature = "flashinfer")]
+        let flashinfer_metadata = if let Some(params) = self.flashinfer_kv_params {
+            let indptr_host = vec![0u32, max_num_blocks as u32];
+            let kv_len_arr_host = vec![self.max_model_len as u32];
+            let q_cu_seqlens_host = vec![0u32, verify_len as u32];
+
+            let prefill_plan_info = attention_rs::flashinfer::graph_prefill_plan(
+                device,
+                &q_cu_seqlens_host,
+                &indptr_host,
+                &kv_len_arr_host,
+                verify_len as u32,
+                1,
+                params.num_qo_heads,
+                params.num_kv_heads,
+                params.head_dim,
+                params.page_size,
+                params.out_dtype,
+                None,
+                Some(params.kv_dtype),
+            )?;
+
+            Some(attention_rs::FlashInferMetadata {
+                indptr: flashinfer_indptr.clone(),
+                indptr_host,
+                indices: flashinfer_indices.clone(),
+                last_len: flashinfer_last_len.clone(),
+                last_len_host: Some(vec![self.max_model_len as u32]),
+                kv_len_arr_host: Some(kv_len_arr_host),
+                total_num_rows: Some(verify_len as u32),
+                batch_indices: None,
+                positions: None,
+                use_cuda_graph: true,
+                decode_plan_info: None,
+                prefill_plan_info: Some(prefill_plan_info),
+                mla_decode_plan_info: None,
+                mla_prefill_plan_info: None,
+            })
+        } else {
+            None
+        };
+        #[cfg(not(feature = "flashinfer"))]
+        let flashinfer_metadata = None;
+
+        let input_metadata = InputMetadata {
+            is_prefill: true,
+            is_mla: self.is_mla,
+            sequence_ids: Some(vec![0]),
+            mamba_slot_mapping: Some(mamba_slot_mapping.clone()),
+            slot_mapping: slot_mapping.clone(),
+            block_tables: Some(block_tables.clone()),
+            context_lens: Some(context_lens.clone()),
+            cu_seqlens_q: Some(cu_seqlens_q.clone()),
+            cu_seqlens_k: Some(cu_seqlens_k.clone()),
+            max_seqlen_q: verify_len,
+            max_seqlen_k: self.max_model_len,
+            max_context_len: self.max_model_len,
+            seqlens: None,
+            flashinfer_metadata,
+            is_mtp_verify: true,
+        };
+
         let mut outputs = BTreeMap::<usize, Tensor>::new();
 
-        for verify_len in 2..=max_verify_len {
-            let input_ids_vl = input_ids.narrow(0, 0, verify_len)?;
-            let positions_vl = positions.narrow(0, 0, verify_len)?;
-            let slot_mapping_vl = slot_mapping.narrow(0, 0, verify_len)?;
-
-            let input_metadata = InputMetadata {
-                is_prefill: true,
-                is_mla: self.is_mla,
-                sequence_ids: Some(vec![0]),
-                mamba_slot_mapping: Some(mamba_slot_mapping.clone()),
-                slot_mapping: slot_mapping_vl,
-                block_tables: Some(block_tables.clone()),
-                context_lens: Some(context_lens.clone()),
-                cu_seqlens_q: Some(cu_seqlens_q.clone()),
-                cu_seqlens_k: Some(cu_seqlens_k.clone()),
-                max_seqlen_q: verify_len,
-                max_seqlen_k: self.max_model_len,
-                max_context_len: self.max_model_len,
-                seqlens: None,
-                flashinfer_metadata: None,
-                is_mtp_verify: true,
-            };
-
-            for is_warmup in [true, false] {
-                if !is_warmup {
-                    self.model.start_capture_mtp(verify_len)?;
-                }
-                let out = self.model.forward(
-                    &input_ids_vl,
-                    &positions_vl,
+        for is_warmup in [true, false] {
+            if !is_warmup || capture_in_warmup {
+                self.model.start_capture(verify_len)?;
+            }
+            if is_warmup {
+                let _ = self.model.forward(
+                    &input_ids,
+                    &positions,
                     kv_caches,
                     &input_metadata,
                     false,
                 )?;
-                if !is_warmup {
-                    self.model.end_capture_mtp(verify_len, true)?;
-                    outputs.insert(verify_len, out);
-                }
+            } else {
+                let out = self.model.forward(
+                    &input_ids,
+                    &positions,
+                    kv_caches,
+                    &input_metadata,
+                    false,
+                )?;
+                outputs.insert(verify_len, out);
+            }
+            if !is_warmup || capture_in_warmup {
+                self.model.end_capture(!is_warmup)?;
             }
         }
 
-        crate::log_warn!("Captured MTP verify graphs {:?}", outputs.keys());
+        crate::log_warn!(
+            "Captured MTP verify graph len={} (flashinfer={})",
+            verify_len,
+            use_flashinfer
+        );
 
         self.mtp_graph_vars = Some(MtpGraphCaptureVars {
             input_ids,
@@ -931,6 +958,12 @@ impl<M: CudaGraphModule> GraphCapturer<M> {
             block_tables,
             cu_seqlens_q,
             cu_seqlens_k,
+            #[cfg(feature = "flashinfer")]
+            flashinfer_indptr,
+            #[cfg(feature = "flashinfer")]
+            flashinfer_indices,
+            #[cfg(feature = "flashinfer")]
+            flashinfer_last_len,
             outputs,
         });
         Ok(())
@@ -957,10 +990,7 @@ impl<M: CudaGraphModule> GraphCapturer<M> {
             .ok_or_else(|| candle_core::Error::msg("MTP graphs not captured"))?;
 
         if !mtp_vars.outputs.contains_key(&verify_len) {
-            candle_core::bail!(
-                "MTP verify graph for len {} is not captured!",
-                verify_len
-            );
+            candle_core::bail!("MTP verify graph for len {} is not captured!", verify_len);
         }
 
         mtp_vars.input_ids.zero_()?;
@@ -998,7 +1028,43 @@ impl<M: CudaGraphModule> GraphCapturer<M> {
             mtp_vars.cu_seqlens_k.copy_(cu_k, 0)?;
         }
 
-        self.model.replay_mtp(verify_len)?;
+        #[cfg(feature = "flashinfer")]
+        if let Some(fm) = input_metadata.flashinfer_metadata.as_ref() {
+            mtp_vars.flashinfer_indptr.zero_()?;
+            mtp_vars.flashinfer_indptr.copy_(&fm.indptr, 0)?;
+            mtp_vars.flashinfer_indices.zero_()?;
+            mtp_vars.flashinfer_indices.copy_(&fm.indices, 0)?;
+            mtp_vars.flashinfer_last_len.zero_()?;
+            mtp_vars.flashinfer_last_len.copy_(&fm.last_len, 0)?;
+
+            if let Some(params) = self.flashinfer_kv_params {
+                let dev = self
+                    .device
+                    .as_ref()
+                    .ok_or_else(|| candle_core::Error::msg("graph device is missing"))?;
+                let kv_len_arr_host = fm.kv_len_arr_host.as_deref().ok_or_else(|| {
+                    candle_core::Error::msg("mtp replay requires kv_len_arr_host")
+                })?;
+                let q_cu_seqlens_host = vec![0u32, verify_len as u32];
+                let _ = attention_rs::flashinfer::graph_prefill_plan(
+                    dev,
+                    &q_cu_seqlens_host,
+                    &fm.indptr_host,
+                    kv_len_arr_host,
+                    verify_len as u32,
+                    1,
+                    params.num_qo_heads,
+                    params.num_kv_heads,
+                    params.head_dim,
+                    params.page_size,
+                    params.out_dtype,
+                    None,
+                    Some(params.kv_dtype),
+                )?;
+            }
+        }
+
+        self.model.replay(verify_len)?;
 
         mtp_vars.outputs[&verify_len].contiguous()
     }

--- a/src/utils/graph.rs
+++ b/src/utils/graph.rs
@@ -100,6 +100,9 @@ pub trait CudaGraphModule {
         embeded_inputs: bool,
     ) -> Result<Tensor>;
     fn report_graph_pool_usage(&self) -> Result<()>;
+    fn start_capture_mtp(&mut self, verify_len: usize) -> Result<()>;
+    fn end_capture_mtp(&mut self, verify_len: usize, save: bool) -> Result<()>;
+    fn replay_mtp(&self, verify_len: usize) -> Result<()>;
 }
 
 pub struct CudaGraphHandle {
@@ -136,6 +139,7 @@ where
     device: Arc<CudaDevice>,
     pub pool_handle: RwLock<Option<i64>>,
     captured_bs: Vec<usize>,
+    mtp_captured_graphs: BTreeMap<usize, CudaGraphHandle>,
 }
 
 impl<M> CudaGraphWrapper<M>
@@ -157,6 +161,7 @@ where
             device,
             pool_handle: RwLock::new(None),
             captured_bs: Vec::new(),
+            mtp_captured_graphs: BTreeMap::new(),
         }
     }
 
@@ -337,6 +342,44 @@ where
         );
         Ok(())
     }
+
+    fn start_capture_mtp(&mut self, verify_len: usize) -> Result<()> {
+        self.capturing = true;
+        self.current_bs = Some(verify_len);
+        self.sync_stream()?;
+        self.set_capture_mem_pool()?;
+        CudaGraph::begin_capture(
+            self.device.cu_stream().clone(),
+            CUstreamCaptureMode::CU_STREAM_CAPTURE_MODE_RELAXED,
+        )?;
+        Ok(())
+    }
+
+    fn end_capture_mtp(&mut self, verify_len: usize, save: bool) -> Result<()> {
+        self.capturing = false;
+        self.current_bs = None;
+
+        let graph = CudaGraph::end_capture(
+            self.device.cu_stream().clone(),
+            CUgraphInstantiate_flags::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
+        )?;
+        if save {
+            self.mtp_captured_graphs
+                .insert(verify_len, CudaGraphHandle::new(Arc::new(graph)));
+        }
+        self.sync_stream()?;
+        Ok(())
+    }
+
+    fn replay_mtp(&self, verify_len: usize) -> Result<()> {
+        if let Some(graph) = self.mtp_captured_graphs.get(&verify_len) {
+            self.sync_stream()?;
+            graph.replay()?;
+            self.sync_stream()
+        } else {
+            candle_core::bail!("MTP verify graph for len {} is not captured!", verify_len)
+        }
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -374,6 +417,18 @@ pub struct GraphCaptureVars {
     pub outputs: BTreeMap<usize, Tensor>,
 }
 
+pub struct MtpGraphCaptureVars {
+    pub input_ids: Tensor,
+    pub positions: Tensor,
+    pub mamba_slot_mapping: Tensor,
+    pub slot_mapping: Tensor,
+    pub context_lens: Tensor,
+    pub block_tables: Tensor,
+    pub cu_seqlens_q: Tensor,
+    pub cu_seqlens_k: Tensor,
+    pub outputs: BTreeMap<usize, Tensor>,
+}
+
 pub struct GraphCapturer<M: CudaGraphModule> {
     pub model: M,
     pub graph_bs: Vec<usize>,
@@ -386,6 +441,8 @@ pub struct GraphCapturer<M: CudaGraphModule> {
     #[cfg(feature = "flashinfer")]
     pub flashinfer_kv_params: Option<FlashInferKvParams>,
     pub is_mla: bool,
+    pub mtp_num_speculative: usize,
+    pub mtp_graph_vars: Option<MtpGraphCaptureVars>,
 }
 
 pub fn planned_graph_capture_batches(max_num_seqs: usize) -> Vec<usize> {
@@ -463,6 +520,8 @@ impl<M: CudaGraphModule> GraphCapturer<M> {
             #[cfg(feature = "flashinfer")]
             flashinfer_kv_params: flashinfer_kv_params.clone(),
             is_mla,
+            mtp_num_speculative: 0,
+            mtp_graph_vars: None,
         }
     }
 
@@ -599,6 +658,7 @@ impl<M: CudaGraphModule> GraphCapturer<M> {
                     max_context_len: self.max_model_len,
                     seqlens: None,
                     flashinfer_metadata,
+                    is_mtp_verify: false,
                 };
 
                 let should_capture =
@@ -792,6 +852,155 @@ impl<M: CudaGraphModule> GraphCapturer<M> {
         } else {
             candle_core::bail!("Graph is not captured!")
         }
+    }
+
+    pub fn capture_mtp(
+        &mut self,
+        device: &Device,
+        kv_caches: Option<&Vec<(Tensor, Tensor)>>,
+        mtp_num_speculative: usize,
+    ) -> Result<()> {
+        if mtp_num_speculative == 0 {
+            return Ok(());
+        }
+        self.mtp_num_speculative = mtp_num_speculative;
+
+        let max_verify_len = mtp_num_speculative + 1;
+        let max_num_blocks = (self.max_model_len + self.block_size - 1) / self.block_size;
+
+        let input_ids = Tensor::zeros((max_verify_len,), DType::U32, device)?;
+        let positions = Tensor::zeros((max_verify_len,), DType::I64, device)?;
+        let mamba_slot_mapping = Tensor::zeros((1,), DType::I64, device)?;
+        let slot_mapping = Tensor::zeros((max_verify_len,), DType::I64, device)?;
+        let context_lens = Tensor::zeros((1,), DType::U32, device)?;
+        let block_tables = Tensor::zeros((1, max_num_blocks), DType::U32, device)?;
+        let cu_seqlens_q = Tensor::zeros((2,), DType::U32, device)?;
+        let cu_seqlens_k = Tensor::zeros((2,), DType::U32, device)?;
+
+        let mut outputs = BTreeMap::<usize, Tensor>::new();
+
+        for verify_len in 2..=max_verify_len {
+            let input_ids_vl = input_ids.narrow(0, 0, verify_len)?;
+            let positions_vl = positions.narrow(0, 0, verify_len)?;
+            let slot_mapping_vl = slot_mapping.narrow(0, 0, verify_len)?;
+
+            let input_metadata = InputMetadata {
+                is_prefill: true,
+                is_mla: self.is_mla,
+                sequence_ids: Some(vec![0]),
+                mamba_slot_mapping: Some(mamba_slot_mapping.clone()),
+                slot_mapping: slot_mapping_vl,
+                block_tables: Some(block_tables.clone()),
+                context_lens: Some(context_lens.clone()),
+                cu_seqlens_q: Some(cu_seqlens_q.clone()),
+                cu_seqlens_k: Some(cu_seqlens_k.clone()),
+                max_seqlen_q: verify_len,
+                max_seqlen_k: self.max_model_len,
+                max_context_len: self.max_model_len,
+                seqlens: None,
+                flashinfer_metadata: None,
+                is_mtp_verify: true,
+            };
+
+            for is_warmup in [true, false] {
+                if !is_warmup {
+                    self.model.start_capture_mtp(verify_len)?;
+                }
+                let out = self.model.forward(
+                    &input_ids_vl,
+                    &positions_vl,
+                    kv_caches,
+                    &input_metadata,
+                    false,
+                )?;
+                if !is_warmup {
+                    self.model.end_capture_mtp(verify_len, true)?;
+                    outputs.insert(verify_len, out);
+                }
+            }
+        }
+
+        crate::log_warn!("Captured MTP verify graphs {:?}", outputs.keys());
+
+        self.mtp_graph_vars = Some(MtpGraphCaptureVars {
+            input_ids,
+            positions,
+            mamba_slot_mapping,
+            slot_mapping,
+            context_lens,
+            block_tables,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            outputs,
+        });
+        Ok(())
+    }
+
+    pub fn is_mtp_captured(&self, verify_len: usize) -> bool {
+        self.mtp_graph_vars
+            .as_ref()
+            .map_or(false, |v| v.outputs.contains_key(&verify_len))
+    }
+
+    pub fn replay_mtp(
+        &self,
+        input_ids: &Tensor,
+        positions: &Tensor,
+        input_metadata: &InputMetadata,
+    ) -> Result<Tensor> {
+        let verify_len = input_ids.dim(0)?;
+        let max_num_blocks = (self.max_model_len + self.block_size - 1) / self.block_size;
+
+        let mtp_vars = self
+            .mtp_graph_vars
+            .as_ref()
+            .ok_or_else(|| candle_core::Error::msg("MTP graphs not captured"))?;
+
+        if !mtp_vars.outputs.contains_key(&verify_len) {
+            candle_core::bail!(
+                "MTP verify graph for len {} is not captured!",
+                verify_len
+            );
+        }
+
+        mtp_vars.input_ids.zero_()?;
+        mtp_vars.input_ids.copy_(input_ids, 0)?;
+        mtp_vars.positions.zero_()?;
+        mtp_vars.positions.copy_(positions, 0)?;
+
+        if let Some(ms_mapping) = input_metadata.mamba_slot_mapping.as_ref() {
+            mtp_vars.mamba_slot_mapping.zero_()?;
+            mtp_vars.mamba_slot_mapping.copy_(ms_mapping, 0)?;
+        }
+
+        mtp_vars.slot_mapping.zero_()?;
+        mtp_vars
+            .slot_mapping
+            .copy_(&input_metadata.slot_mapping, 0)?;
+
+        if let Some(c_lens) = input_metadata.context_lens.as_ref() {
+            mtp_vars.context_lens.zero_()?;
+            mtp_vars.context_lens.copy_(c_lens, 0)?;
+        }
+
+        if let Some(b_tables) = input_metadata.block_tables.as_ref() {
+            let padded_table = b_tables
+                .pad_with_zeros(1, 0, max_num_blocks - b_tables.dim(1)?)?
+                .contiguous()?;
+            mtp_vars.block_tables.zero_()?;
+            mtp_vars.block_tables.copy_(&padded_table, 0)?;
+        }
+
+        if let Some(cu_q) = input_metadata.cu_seqlens_q.as_ref() {
+            mtp_vars.cu_seqlens_q.copy_(cu_q, 0)?;
+        }
+        if let Some(cu_k) = input_metadata.cu_seqlens_k.as_ref() {
+            mtp_vars.cu_seqlens_k.copy_(cu_k, 0)?;
+        }
+
+        self.model.replay_mtp(verify_len)?;
+
+        mtp_vars.outputs[&verify_len].contiguous()
     }
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -641,6 +641,8 @@ pub fn config_from_gguf<R: std::io::Seek + std::io::Read>(
         is_multi_model: None,
         extra_config_json,
         is_f16_mode: false,
+        mtp_num_hidden_layers: None,
+        mtp_use_dedicated_embeddings: None,
     };
 
     if arch == "gemma4" || arch == "gemma3" {


### PR DESCRIPTION
Tested case:

Supported Model Arch: Qwen3.5/Qwen3.6 (BF16, FP8; NVP4 - untested)

```
cargo run --release --features cuda,nccl,flashinfer,cutlass
xinfer --m Qwen/Qwen3.5-27B-FP8/ --mtp 2 --ui-server
```

Acceptance rate around 60% and speedup 10 - 30%, e.g., Qwen3.5 27B model from 42 tokens/s to 56.20 t/s under mtp=2.

Num of speculative tokens stable at 2 (--mtp 2).

<details>

```
2026-05-28T14:32:58.852530Z  WARN xinfer::server::server: Stream request has session_id c3a435a5-736e-4031-9984-d0f6c82e2f96
2026-05-28T14:32:58.930939Z  WARN xinfer::core::engine: [Stream] New request [Seq_id 0, 15 tokens] received! (session_id: Some("c3a435a5-736e-4031-9984-d0f6c82e2f96"))

2026-05-28T14:32:59.036833Z  INFO xinfer::core::runner: User's thinking preference for reasoning models: Some(true)
2026-05-28T14:32:59.036866Z  WARN xinfer::core::runner: Using user's sampling params: temp=Some(0.6), top_k=Some(20),top_p=Some(0.95), freq_penalty=None, pres_penalty=None
2026-05-28T14:32:59.047469Z  INFO xinfer::core::engine: Prefilling 1 seq(s) [0]: 16 total tokens in 0.19s (82.47 tokens/s)
2026-05-28T14:32:59.972350Z  INFO xinfer::core::runner: MTP Stats: proposed=32, accepted=21, acceptance_rate=65.62%, avg_tokens/step=3.31
2026-05-28T14:33:00.895722Z  INFO xinfer::core::runner: MTP Stats: proposed=64, accepted=39, acceptance_rate=60.94%, avg_tokens/step=3.22
2026-05-28T14:33:01.822555Z  INFO xinfer::core::runner: MTP Stats: proposed=96, accepted=61, acceptance_rate=63.54%, avg_tokens/step=3.27
2026-05-28T14:33:02.747718Z  INFO xinfer::core::runner: MTP Stats: proposed=128, accepted=79, acceptance_rate=61.72%,avg_tokens/step=3.23
2026-05-28T14:33:03.674480Z  INFO xinfer::core::runner: MTP Stats: proposed=160, accepted=96, acceptance_rate=60.00%,avg_tokens/step=3.20
2026-05-28T14:33:04.602557Z  INFO xinfer::core::runner: MTP Stats: proposed=192, accepted=118, acceptance_rate=61.46%, avg_tokens/step=3.23
2026-05-28T14:33:05.531340Z  INFO xinfer::core::runner: MTP Stats: proposed=224, accepted=140, acceptance_rate=62.50%, avg_tokens/step=3.25
2026-05-28T14:33:06.463584Z  INFO xinfer::core::runner: MTP Stats: proposed=256, accepted=159, acceptance_rate=62.11%, avg_tokens/step=3.24
2026-05-28T14:33:07.396372Z  INFO xinfer::core::runner: MTP Stats: proposed=288, accepted=180, acceptance_rate=62.50%, avg_tokens/step=3.25
2026-05-28T14:33:08.332577Z  INFO xinfer::core::runner: MTP Stats: proposed=320, accepted=205, acceptance_rate=64.06%, avg_tokens/step=3.28
2026-05-28T14:33:09.270424Z  INFO xinfer::core::runner: MTP Stats: proposed=352, accepted=224, acceptance_rate=63.64%, avg_tokens/step=3.27
2026-05-28T14:33:10.208793Z  INFO xinfer::core::runner: MTP Stats: proposed=384, accepted=245, acceptance_rate=63.80%, avg_tokens/step=3.28
2026-05-28T14:33:11.146838Z  INFO xinfer::core::runner: MTP Stats: proposed=416, accepted=269, acceptance_rate=64.66%, avg_tokens/step=3.29
2026-05-28T14:33:12.088962Z  INFO xinfer::core::runner: MTP Stats: proposed=448, accepted=286, acceptance_rate=63.84%, avg_tokens/step=3.28
2026-05-28T14:33:13.032053Z  INFO xinfer::core::runner: MTP Stats: proposed=480, accepted=302, acceptance_rate=62.92%, avg_tokens/step=3.26
2026-05-28T14:33:13.976385Z  INFO xinfer::core::runner: MTP Stats: proposed=512, accepted=322, acceptance_rate=62.89%, avg_tokens/step=3.26
2026-05-28T14:33:14.921817Z  INFO xinfer::core::runner: MTP Stats: proposed=544, accepted=348, acceptance_rate=63.97%, avg_tokens/step=3.28
2026-05-28T14:33:15.867525Z  INFO xinfer::core::runner: MTP Stats: proposed=576, accepted=371, acceptance_rate=64.41%, avg_tokens/step=3.29
2026-05-28T14:33:16.816091Z  INFO xinfer::core::runner: MTP Stats: proposed=608, accepted=392, acceptance_rate=64.47%, avg_tokens/step=3.29
2026-05-28T14:33:17.765741Z  INFO xinfer::core::runner: MTP Stats: proposed=640, accepted=415, acceptance_rate=64.84%, avg_tokens/step=3.30
2026-05-28T14:33:17.767200Z  INFO xinfer::core::block_manager: Prefix cache insert seq 0 (1067 tokens, 16 blocks)
2026-05-28T14:33:17.769180Z  WARN xinfer::server::server: --- Performance Metrics ---
2026-05-28T14:33:17.769192Z  INFO xinfer::server::server: [Seq 0] ⏱️ Prompt: 15 tokens in 0.19s (77.32 t/s)
2026-05-28T14:33:17.769198Z  INFO xinfer::server::server: [Seq 0] ⏱️ Decoded: 1052 tokens in 18.72s (56.20 t/s)
```

</details>