### PR TITLE
Optimize CUDA graph with kernel parameter caching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xinfer"
-version = "0.12.7"
+version = "0.12.8"
 edition = "2021"
 default-run = "xinfer"
 description = "xInfer — a minimal, high-performance large language model (LLM) inference engine in Rust."
@@ -12,8 +12,8 @@ categories = ["algorithms", "hardware-support", "science"]
 license = "MIT"
 
 [dependencies]
-candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "68b6d74" }
-candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "68b6d74" }
+candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "15b70c7" }
+candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "15b70c7" }
 serde = { version = "1.0.190", features = ["serde_derive"] }
 tokenizers = {version = "0.21.2", features = ["http"] }
 hf-hub = "0.4.1"
@@ -46,7 +46,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.5.8", rev = "52bec1f" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.5.8", rev = "8fdb7ab" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"

--- a/ReadMe-CN.md
+++ b/ReadMe-CN.md
@@ -11,7 +11,7 @@
 | | 特性 | 详情 |
 |---|---|---|
 | **0️⃣** | 零 Python 依赖 | 纯 Rust 后端 — 不需要 PyTorch 或 CUDA Python 绑定 |
-| **⚡** | 极致性能 | 原生 Flash Attention、FlashInfer、CUDA Graphs、持续批处理、前缀缓存、PD 分离。消费级 GPU 上 `30B+` 模型解码速度高达 **175 tok/s** |
+| **⚡** | 极致性能 | 原生 Flash Attention、FlashInfer、CUDA Graphs、持续批处理、前缀缓存、PD 分离。消费级 GPU 上 `30B+` 模型解码速度高达 **181 tok/s** |
 | **🪶** | 极简内核 | 核心调度 + 注意力逻辑仅 **< 5000 行** Rust 代码 |
 | **🌍** | 跨平台 | CUDA（Linux/Windows）、Metal（macOS），统一二进制，统一 API |
 | **🏭** | 生产就绪 | OpenAI/Anthropic 兼容 API、内置 ChatGPT 风格 Web UI、MCP 工具调用、结构化输出、Embedding + 分词器端点 |
@@ -79,21 +79,21 @@ python3 -m xinfer.server --m Qwen/Qwen3.6-27B-FP8 --kvcache-dtype turbo4 --ui-se
 
 | 模型 | 格式 | 大小 | 输出速度 |
 |---|---|---|---|
-| Ministral-3-3B (**多模态**) | ISQ (BF16→Q4K) | 3B | **171.92** tokens/s |
-| Qwen3-VL-8B-Instruct (**多模态**) | Q8_0 | 8B | **105.31** tokens/s |
-| Llama-3.1-8B | ISQ (BF16→Q4K) | 8B | **120.74** tokens/s |
-| DeepSeek-R1-0528-Qwen3-8B | Q4_K_M | 8B | **124.87** tokens/s |
-| GLM-4-9B-0414 | Q4_K_M | 9B | **70.38** tokens/s |
-| QwQ-32B | Q4_K_M | 32B | **41.36** tokens/s |
-| **Qwen3-30B-A3B** | NVFP4 | **30B (MoE)** | **175.30** tokens/s (**RTX 5090**) |
-| **Qwen3-30B-A3B** | NVFP4 | **30B (MoE)** | **67.10** tokens/s (**V100, Software FP4**) |
-| **Qwen3.5-27B** (**多模态**) | Q4_K_M | **27B (Dense)** | **45.20** tokens/s |
-| **Qwen3.5-27B/Qwen3.6-27B** | FP8 | **27B (Dense)** | **42** tokens/s (**Hopper**) |
-| **Qwen3.6-35B-A3B** (**多模态**) | FP8 | **35B (MoE)** | **102** tokens/s (**Hopper**) |
+| Ministral-3-3B (**多模态**) | ISQ (BF16→Q4K) | 3B | **193.67** tokens/s |
+| Qwen3-VL-8B-Instruct (**多模态**) | Q8_0 | 8B | **112.51** tokens/s |
+| Llama-3.1-8B | ISQ (BF16→Q4K) | 8B | **133.10** tokens/s |
+| DeepSeek-R1-0528-Qwen3-8B | Q4_K_M | 8B | **139.25** tokens/s |
+| GLM-4-9B-0414 | Q4_K_M | 9B | **77.48** tokens/s |
+| QwQ-32B | Q4_K_M | 32B | **46.02** tokens/s |
+| **Qwen3-30B-A3B** | NVFP4 | **30B (MoE)** | **181.59** tokens/s (**RTX 5090**) |
+| **Qwen3-30B-A3B** | NVFP4 | **30B (MoE)** | **72.86** tokens/s (**V100, Software FP4**) |
+| **Qwen3.5-27B** (**多模态**) | Q4_K_M | **27B (Dense)** | **49.33** tokens/s |
+| **Qwen3.5-27B/Qwen3.6-27B** | FP8 | **27B (Dense)** | **45** tokens/s (**Hopper**) |
+| **Qwen3.6-35B-A3B** (**多模态**) | FP8 | **35B (MoE)** | **110** tokens/s (**Hopper**) |
 | **GLM4.7 Flash** | NVFP4 | **30B (MoE)** | **79** tokens/s (**Hopper, Software FP4**) |
-| **Gemma4-31B** | ISQ (BF16→Q4K) | **31B (Dense)** | **41** tokens/s (**Hopper**) |
-| **Gemma4-26B-A4B** | NVFP4 | **26B (MoE)** | **131** tokens/s (**RTX 5090**) |
-| **MiniMax-M2.5** | NVFP4 | **229B (MoE)** | **62** tokens/s (**Hopper, Software FP4, TP=2**) |
+| **Gemma4-31B** | ISQ (BF16→Q4K) | **31B (Dense)** | **47** tokens/s (**Hopper**) |
+| **Gemma4-26B-A4B** | NVFP4 | **26B (MoE)** | **137.23** tokens/s (**RTX 5090**) |
+| **MiniMax-M2.5** | NVFP4 | **229B (MoE)** | **64.50** tokens/s (**Hopper, Software FP4, TP=2**) |
 
 <details>
 <summary><b>Apple Silicon (M4)</b></summary>

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -11,7 +11,7 @@
 | | Feature | Details |
 |---|---|---|
 | **0️⃣** | Zero Python dependencies | Pure Rust backend — no PyTorch, no CUDA Python bindings |
-| **⚡** | Fast | Native Flash Attention, FlashInfer, CUDA Graphs, continuous batching, prefix caching, PD disaggregation. Up to **175 tok/s** decode for `30B+` models on consumer GPUs |
+| **⚡** | Fast | Native Flash Attention, FlashInfer, CUDA Graphs, continuous batching, prefix caching, PD disaggregation. Up to **181 tok/s** decode for `30B+` models on consumer GPUs |
 | **🪶** | Tiny footprint | Core scheduling + attention logic in **< 5 000 lines** of Rust |
 | **🌍** | Cross-platform | CUDA (Linux/Windows), Metal (macOS). Same binary, same API |
 | **🏭** | Production-ready | OpenAI/Anthropic-compatible APIs, built-in ChatGPT-style Web UI, MCP tool calling, structured outputs, embedding + tokenizer endpoints |
@@ -79,21 +79,21 @@ Add `--kvcache-dtype` to compress KV cache and extend context length:
 
 | Model | Format | Size | Decoding Speed |
 |---|---|---|---|
-| Ministral-3-3B (**Multimodal**) | ISQ (BF16→Q4K) | 3B | **171.92** tokens/s |
-| Qwen3-VL-8B-Instruct (**Multimodal**) | Q8_0 | 8B | **105.31** tokens/s |
-| Llama-3.1-8B | ISQ (BF16→Q4K) | 8B | **120.74** tokens/s |
-| DeepSeek-R1-0528-Qwen3-8B | Q4_K_M | 8B | **124.87** tokens/s |
-| GLM-4-9B-0414 | Q4_K_M | 9B | **70.38** tokens/s |
-| QwQ-32B | Q4_K_M | 32B | **41.36** tokens/s |
-| **Qwen3-30B-A3B** | NVFP4 | **30B (MoE)** | **175.30** tokens/s (**RTX 5090**) |
-| **Qwen3-30B-A3B** | NVFP4 | **30B (MoE)** | **67.10** tokens/s (**V100, Software FP4**) |
-| **Qwen3.5-27B** (**Multimodal**) | Q4_K_M | **27B (Dense)** | **45.20** tokens/s |
-| **Qwen3.5-27B/Qwen3.6-27B** | FP8 | **27B (Dense)** | **42** tokens/s (**Hopper**) |
-| **Qwen3.6-35B-A3B** (**Multimodal**) | FP8 | **35B (MoE)** | **102** tokens/s (**Hopper**) |
+| Ministral-3-3B (**Multimodal**) | ISQ (BF16→Q4K) | 3B | **193.67** tokens/s |
+| Qwen3-VL-8B-Instruct (**Multimodal**) | Q8_0 | 8B | **112.51** tokens/s |
+| Llama-3.1-8B | ISQ (BF16→Q4K) | 8B | **133.10** tokens/s |
+| DeepSeek-R1-0528-Qwen3-8B | Q4_K_M | 8B | **139.25** tokens/s |
+| GLM-4-9B-0414 | Q4_K_M | 9B | **77.48** tokens/s |
+| QwQ-32B | Q4_K_M | 32B | **46.02** tokens/s |
+| **Qwen3-30B-A3B** | NVFP4 | **30B (MoE)** | **181.59** tokens/s (**RTX 5090**) |
+| **Qwen3-30B-A3B** | NVFP4 | **30B (MoE)** | **72.86** tokens/s (**V100, Software FP4**) |
+| **Qwen3.5-27B** (**Multimodal**) | Q4_K_M | **27B (Dense)** | **49.33** tokens/s |
+| **Qwen3.5-27B/Qwen3.6-27B** | FP8 | **27B (Dense)** | **45** tokens/s (**Hopper**) |
+| **Qwen3.6-35B-A3B** (**Multimodal**) | FP8 | **35B (MoE)** | **110** tokens/s (**Hopper**) |
 | **GLM4.7 Flash** | NVFP4 | **30B (MoE)** | **79** tokens/s (**Hopper, Software FP4**) |
-| **Gemma4-31B** | ISQ (BF16→Q4K) | **31B (Dense)** | **41** tokens/s (**Hopper**) |
-| **Gemma4-26B-A4B** | NVFP4 | **26B (MoE)** | **131** tokens/s (**RTX 5090**) |
-| **MiniMax-M2.5** | NVFP4 | **229B (MoE)** | **62** tokens/s (**Hopper, Software FP4, TP=2**) |
+| **Gemma4-31B** | ISQ (BF16→Q4K) | **31B (Dense)** | **47** tokens/s (**Hopper**) |
+| **Gemma4-26B-A4B** | NVFP4 | **26B (MoE)** | **137.23** tokens/s (**RTX 5090**) |
+| **MiniMax-M2.5** | NVFP4 | **229B (MoE)** | **64.50** tokens/s (**Hopper, Software FP4, TP=2**) |
 
 <details>
 <summary><b>Apple Silicon (M4)</b></summary>

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -10,21 +10,21 @@ This document contains detailed performance benchmarks for xInfer across differe
 
 | Model | Format | Size | Hardware | Decoding Speed |
 |-------|--------|------|----------|----------------|
-| Qwen3-30B-A3B | NVFP4 | 30B MoE | RTX 5090 (SM120) | **175.30** tokens/s |
-| Gemma4-26B-A4B | NVFP4 | 26B MoE | RTX 5090 (SM120) | **131** tokens/s |
-| Ministral-3-3B (Multimodal) | ISQ (BF16→Q4K) | 3B | A100 (SM80) | **171.92** tokens/s |
-| DeepSeek-R1-0528-Qwen3-8B | Q4_K_M | 8B | A100 (SM80) | **124.87** tokens/s |
-| Llama-3.1-8B | ISQ (BF16→Q4K) | 8B | A100 (SM80) | **120.74** tokens/s |
-| Qwen3-VL-8B-Instruct (Multimodal) | Q8_0 | 8B | A100 (SM80) | **105.31** tokens/s |
-| Qwen3.6-35B-A3B (Multimodal) | FP8 | 35B MoE | H800 (SM90) | **102** tokens/s |
-| GLM4.7 Flash | NVFP4 | 30B MoE | H800 (SM90) | **79** tokens/s |
-| Qwen3-30B-A3B | NVFP4 | 30B MoE | V100 (SM70) | **67.10** tokens/s |
-| GLM-4-9B-0414 | Q4_K_M | 9B | A100 (SM80) | **70.38** tokens/s |
-| MiniMax-M2.5 | NVFP4 | 229B MoE | H800 ×2 (SM90) | **62** tokens/s |
-| Qwen3.5-27B (Multimodal) | Q4_K_M | 27B Dense | A100 (SM80) | **45.20** tokens/s |
-| Qwen3.5-27B/Qwen3.6-27B | FP8 | 27B Dense | H800 (SM90) | **42** tokens/s |
-| QwQ-32B | Q4_K_M | 32B | A100 (SM80) | **41.36** tokens/s |
-| Gemma4-31B | ISQ (BF16→Q4K) | 31B Dense | H800 (SM90) | **41** tokens/s |
+| Ministral-3-3B (**Multimodal**) | ISQ (BF16→Q4K) | 3B | A100| **193.67** tokens/s |
+| Qwen3-VL-8B-Instruct (**Multimodal**) | Q8_0 | 8B | A100| **112.51** tokens/s |
+| Llama-3.1-8B | ISQ (BF16→Q4K) | 8B | A100| **133.10** tokens/s |
+| DeepSeek-R1-0528-Qwen3-8B | Q4_K_M | 8B | A100| **139.25** tokens/s |
+| GLM-4-9B-0414 | Q4_K_M | 9B | A100| **77.48** tokens/s |
+| QwQ-32B | Q4_K_M | 32B | A100| **46.02** tokens/s |
+| **Qwen3-30B-A3B** | NVFP4 | **30B (MoE)** | RTX 5090 | **181.59** tokens/s|
+| **Qwen3-30B-A3B** | NVFP4 | **30B (MoE)** | V100 | **72.86** tokens/s (**Software FP4**) |
+| **Qwen3.5-27B** (**Multimodal**) | Q4_K_M | **27B (Dense)** | Hopper | **49.33** tokens/s |
+| **Qwen3.5-27B/Qwen3.6-27B** | FP8 | **27B (Dense)** | Hopper | **45** tokens/s|
+| **Qwen3.6-35B-A3B** (**Multimodal**) | FP8 | **35B (MoE)** | Hopper | **110** tokens/s |
+| **GLM4.7 Flash** | NVFP4 | **30B (MoE)** | Hopper | **79** tokens/s (**Software FP4**) |
+| **Gemma4-31B** | ISQ (BF16→Q4K) | **31B (Dense)** | Hopper| **47** tokens/s |
+| **Gemma4-26B-A4B** | NVFP4 | **26B (MoE)** | RTX 5090 | **137.23** tokens/s|
+| **MiniMax-M2.5** | NVFP4 | **229B (MoE)** | Hopper | **64.50** tokens/s (**Software FP4, TP=2**) |
 
 ### V100 + NVFP4 + TurboQuant (First-Ever)
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xinfer-ai",
-  "version": "0.12.7",
-  "assetVersion": "0.12.7",
+  "version": "0.12.8",
+  "assetVersion": "0.12.8",
   "description": "xInfer — a high-performance LLM inference engine in Rust with CUDA/Metal acceleration",
   "license": "MIT",
   "homepage": "https://github.com/guoqingbao/xinfer#readme",

--- a/pages/index.html
+++ b/pages/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>xInfer — Blazing-fast LLM Inference in Pure Rust</title>
-<meta name="description" content="High-performance LLM inference engine in pure Rust. No PyTorch. CUDA &amp; Metal. 175+ tok/s.">
+<meta name="description" content="High-performance LLM inference engine in pure Rust. No PyTorch. CUDA &amp; Metal. 180+ tok/s.">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><text y='20' font-size='20'>⚡</text></svg>">
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
@@ -282,14 +282,14 @@ footer{padding:56px 0 28px;border-top:1px solid var(--c-border);position:relativ
       <table>
         <thead><tr><th data-i="p.m">Model</th><th data-i="p.fmt">Format</th><th data-i="p.sz">Size</th><th data-i="p.hw">Hardware</th><th data-i="p.sp">Speed</th><th data-i="p.note">Note</th></tr></thead>
         <tbody>
-          <tr><td>Qwen3-30B-A3B</td><td>NVFP4</td><td>30B MoE</td><td>RTX 5090 (SM120)</td><td><span class="sv" data-n="175.30">0</span> tok/s</td><td data-i="p.n1">HW NVFP4</td></tr>
-          <tr><td>Gemma4-26B-A4B</td><td>NVFP4</td><td>26B MoE</td><td>RTX 5090 (SM120)</td><td><span class="sv" data-n="131">0</span> tok/s</td><td data-i="p.n1">HW NVFP4</td></tr>
-          <tr><td>Qwen3.6-35B-A3B</td><td>FP8</td><td>35B MoE</td><td>H800 (SM90)</td><td><span class="sv" data-n="102">0</span> tok/s</td><td data-i="p.n2">HW FP8</td></tr>
-          <tr><td>DeepSeek-R1-Qwen3-8B</td><td>Q4_K_M</td><td>8B</td><td>A100 (SM80)</td><td><span class="sv" data-n="124.87">0</span> tok/s</td><td>GGUF</td></tr>
-          <tr><td>Llama-3.1-8B</td><td>ISQ Q4K</td><td>8B</td><td>A100 (SM80)</td><td><span class="sv" data-n="120.74">0</span> tok/s</td><td data-i="p.n3">SW quant</td></tr>
-          <tr><td>MiniMax-M2.5</td><td>NVFP4</td><td>229B MoE</td><td>H800 ×2 (SM90)</td><td><span class="sv" data-n="62">0</span> tok/s</td><td data-i="p.n4">SW NVFP4 (no HW)</td></tr>
-          <tr><td>Qwen3-30B-A3B</td><td>NVFP4</td><td>30B MoE</td><td>V100 (SM70)</td><td><span class="sv" data-n="67.10">0</span> tok/s</td><td data-i="p.n5">SW FP4</td></tr>
-          <tr><td>Qwen3.6-27B</td><td>FP8</td><td>27B Dense</td><td>H800 (SM90)</td><td><span class="sv" data-n="42">0</span> tok/s</td><td data-i="p.n2">HW FP8</td></tr>
+          <tr><td>Qwen3-30B-A3B</td><td>NVFP4</td><td>30B MoE</td><td>RTX 5090 (SM120)</td><td><span class="sv" data-n="181.59">0</span> tok/s</td><td data-i="p.n1">HW NVFP4</td></tr>
+          <tr><td>Gemma4-26B-A4B</td><td>NVFP4</td><td>26B MoE</td><td>RTX 5090 (SM120)</td><td><span class="sv" data-n="137.23">0</span> tok/s</td><td data-i="p.n1">HW NVFP4</td></tr>
+          <tr><td>Qwen3.6-35B-A3B</td><td>FP8</td><td>35B MoE</td><td>H800 (SM90)</td><td><span class="sv" data-n="110">0</span> tok/s</td><td data-i="p.n2">HW FP8</td></tr>
+          <tr><td>DeepSeek-R1-Qwen3-8B</td><td>Q4_K_M</td><td>8B</td><td>A100 (SM80)</td><td><span class="sv" data-n="139.25">0</span> tok/s</td><td>GGUF</td></tr>
+          <tr><td>Llama-3.1-8B</td><td>ISQ Q4K</td><td>8B</td><td>A100 (SM80)</td><td><span class="sv" data-n="133.10">0</span> tok/s</td><td data-i="p.n3">SW quant</td></tr>
+          <tr><td>MiniMax-M2.5</td><td>NVFP4</td><td>229B MoE</td><td>H800 ×2 (SM90)</td><td><span class="sv" data-n="64.50">0</span> tok/s</td><td data-i="p.n4">SW NVFP4 (no HW)</td></tr>
+          <tr><td>Qwen3-30B-A3B</td><td>NVFP4</td><td>30B MoE</td><td>V100 (SM70)</td><td><span class="sv" data-n="72.86">0</span> tok/s</td><td data-i="p.n5">SW FP4</td></tr>
+          <tr><td>Qwen3.6-27B</td><td>FP8</td><td>27B Dense</td><td>H800 (SM90)</td><td><span class="sv" data-n="45">0</span> tok/s</td><td data-i="p.n2">HW FP8</td></tr>
         </tbody>
       </table>
     </div>
@@ -509,7 +509,7 @@ en:{
 'f.label':'Features','f.title':'Built for Speed & Simplicity',
 'f.desc':'Everything you need for production LLM inference — without the Python baggage.',
 'f.1t':'Zero Dependencies','f.1d':'Pure Rust backend — no PyTorch, no CUDA Python bindings, no Python runtime.',
-'f.2t':'Blazing Fast','f.2d':'Flash Attention, FlashInfer, CUDA Graphs, continuous batching. Up to 175+ tok/s.',
+'f.2t':'Blazing Fast','f.2d':'Flash Attention, FlashInfer, CUDA Graphs, continuous batching. Up to 180+ tok/s.',
 'f.3t':'Tiny Footprint','f.3d':'Core scheduling & attention logic in under 5,000 lines of Rust.',
 'f.4t':'Cross-Platform','f.4d':'CUDA on Linux, Metal on macOS. Same binary, same API everywhere.',
 'f.5t':'Production Ready','f.5d':'OpenAI & Anthropic APIs, built-in Web UI, MCP tool calling, structured outputs.',
@@ -548,7 +548,7 @@ cn:{
 'f.label':'功能特性','f.title':'为速度与简洁而生',
 'f.desc':'生产级 LLM 推理所需的一切 — 无需 Python 依赖。',
 'f.1t':'零依赖','f.1d':'纯 Rust 后端 — 无需 PyTorch、CUDA Python 绑定或 Python 运行时。',
-'f.2t':'极速推理','f.2d':'Flash Attention、FlashInfer、CUDA Graphs、连续批处理。175+ tok/s。',
+'f.2t':'极速推理','f.2d':'Flash Attention、FlashInfer、CUDA Graphs、连续批处理。180+ tok/s。',
 'f.3t':'轻量核心','f.3d':'核心调度与注意力逻辑不足 5,000 行 Rust 代码。',
 'f.4t':'跨平台','f.4d':'Linux 上 CUDA，macOS 上 Metal。同一二进制，同一 API。',
 'f.5t':'生产就绪','f.5d':'OpenAI/Anthropic API、内置 Web UI、MCP 工具、结构化输出。',

--- a/pages/index.html
+++ b/pages/index.html
@@ -630,7 +630,7 @@ document.querySelectorAll('.cb').forEach(function(bl){
 });
 
 /* ═══ Download cards ═══ */
-var XINFER_VER='0.12.7';
+var XINFER_VER='0.12.8';
 var DL='https://github.com/guoqingbao/xinfer/releases/download/v'+XINFER_VER+'/';
 var archs=[
   {sm:'sm70',n:'70',name:'SM70',gpu:'V100',cuda:'CUDA 12',d:0},

--- a/src/mcp/manager.rs
+++ b/src/mcp/manager.rs
@@ -219,7 +219,7 @@ impl McpClientManager {
                     let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
                     match StdioTransport::spawn_with_env(command, &args_refs, env) {
                         Ok(transport) => {
-                            let mut client = McpClient::new(transport, "xinfer", "0.12.7");
+                            let mut client = McpClient::new(transport, "xinfer", "0.12.8");
                             if let Err(err) = client.initialize() {
                                 crate::log_error!(
                                     "Failed to initialize MCP server {}: {:?}",
@@ -246,7 +246,7 @@ impl McpClientManager {
                 McpTransportType::Http { url, headers } => {
                     match super::transport::HttpTransport::new(url.clone(), headers.clone()) {
                         Ok(transport) => {
-                            let mut client = McpClient::new(transport, "xinfer", "0.12.7");
+                            let mut client = McpClient::new(transport, "xinfer", "0.12.8");
                             if let Err(err) = client.initialize() {
                                 crate::log_error!(
                                     "Failed to initialize remote MCP server {}: {:?}",

--- a/src/models/layers/distributed.rs
+++ b/src/models/layers/distributed.rs
@@ -854,6 +854,13 @@ impl MergedParallelColumnLinear {
                             Shard::default(),
                             DType::U8,
                         )?
+                    } else if v.contains_tensor("weight") {
+                        v.get_with_hints_dtype(
+                            (out_dim, in_dim / pack_factor),
+                            "weight",
+                            Shard::default(),
+                            DType::U8,
+                        )?
                     } else {
                         v.get_with_hints_dtype(
                             (out_dim, in_dim / pack_factor),

--- a/src/utils/graph.rs
+++ b/src/utils/graph.rs
@@ -339,6 +339,25 @@ where
     }
 }
 
+#[derive(Clone, Copy)]
+enum CapturePhase {
+    CachePrewarm,
+    Warmup,
+    Capture,
+}
+
+impl CapturePhase {
+    const ALL: [Self; 3] = [Self::CachePrewarm, Self::Warmup, Self::Capture];
+
+    fn is_cache_prewarm(self) -> bool {
+        matches!(self, Self::CachePrewarm)
+    }
+
+    fn is_warmup(self) -> bool {
+        !matches!(self, Self::Capture)
+    }
+}
+
 pub struct GraphCaptureVars {
     pub input_ids: Tensor,
     pub positions: Tensor,
@@ -497,8 +516,9 @@ impl<M: CudaGraphModule> GraphCapturer<M> {
         let capture_in_warmup = false;
 
         let mut outputs = BTreeMap::<usize, Tensor>::new();
-        for is_warmup in [true, false] {
-            let iter: Box<dyn Iterator<Item = usize>> = if is_warmup {
+        let _guard = candle_core::cuda_backend::cuda_param_cache_scope(true);
+        for phase in CapturePhase::ALL {
+            let iter: Box<dyn Iterator<Item = usize>> = if phase.is_warmup() {
                 Box::new(0..self.graph_bs.len())
             } else {
                 Box::new(tqdm(0..self.graph_bs.len()).desc(Some("Graph capturing")))
@@ -581,10 +601,12 @@ impl<M: CudaGraphModule> GraphCapturer<M> {
                     flashinfer_metadata,
                 };
 
-                if !is_warmup || capture_in_warmup {
+                let should_capture =
+                    !phase.is_cache_prewarm() && (!phase.is_warmup() || capture_in_warmup);
+                if should_capture {
                     self.model.start_capture(bs)?;
                 }
-                if is_warmup {
+                if phase.is_warmup() {
                     let _ = self.model.forward(
                         &input_ids_bs,
                         &positions_bs,
@@ -602,8 +624,8 @@ impl<M: CudaGraphModule> GraphCapturer<M> {
                     )?;
                     outputs.insert(bs, out);
                 }
-                if !is_warmup || capture_in_warmup {
-                    self.model.end_capture(!is_warmup)?;
+                if should_capture {
+                    self.model.end_capture(!phase.is_warmup())?;
                 }
             }
         }


### PR DESCRIPTION
Revised candle backend for kernel launch parameter caching under cuda graph, clearing captured CUDA graph nodes. 

This should delivers **10%** overall decoding speedup for all models under CUDA graph, e.g., Qwen3.5 35B FP8 from **95 tokens/s to 108 tokens/s**.