### PR TITLE
Add check-model skill

### DIFF
--- a/.cursor/skills/add-model/SKILL.md
+++ b/.cursor/skills/add-model/SKILL.md
@@ -267,7 +267,25 @@ Fix all errors and warnings before proceeding.
 
 ---
 
-## Phase 6: Test the Model
+## Phase 6: Check Model Compatibility
+
+**Before testing**, invoke the **check-model** skill (`.cursor/skills/check-model/SKILL.md`) to validate the new model's tensor format and multi-rank compatibility.
+
+Provide:
+1. The model's `config.json` (local path or HuggingFace URL)
+2. Weight tensor info (names, shapes, dtypes) — from a local safetensors file or HuggingFace model page
+
+The check-model skill will verify:
+- Tensor names match the loader's expected format (e.g. `weight_packed` vs `weight` vs `blocks` for FP4)
+- Quantized vs unquantized layer detection matches the `ignore` list in `quantization_config`
+- All TP-sharded dimensions are divisible by common GPU counts (1, 2, 4, 8)
+- FP8 block alignment and FP4 scale group alignment are correct for multi-rank
+
+Fix any `[ERROR]` findings before proceeding to the test phase. `[WARN]` items should be reviewed but may not block loading.
+
+---
+
+## Phase 7: Test the Model
 
 ### Start the server
 

--- a/.cursor/skills/check-model/SKILL.md
+++ b/.cursor/skills/check-model/SKILL.md
@@ -1,0 +1,348 @@
+---
+name: check-model
+description: >-
+  Check model compatibility with xinfer before loading. Validates config.json,
+  weight tensor shapes and naming, quantization format correctness, and
+  multi-rank (tensor-parallel) divisibility. Use when the user asks to check,
+  validate, audit, or verify a model will load correctly — from a HuggingFace
+  URL/config, local path, or pasted tensor info.
+---
+
+# Check Model — Pre-Load Compatibility Audit for xinfer
+
+## Phase 0: Gather Model Information
+
+Collect model config and tensor info. Accept **any** of:
+
+| Input | How to use |
+|-------|-----------|
+| **HuggingFace config URL** | Fetch `config.json` from the URL (e.g. `https://huggingface.co/<id>/blob/main/config.json`) |
+| **HuggingFace model ID** | Fetch config from `https://huggingface.co/<id>/raw/main/config.json` |
+| **Local model path** | Read `<path>/config.json` directly |
+| **Pasted config JSON** | Parse inline |
+| **Tensor info** | User pastes tensor names/shapes/dtypes from HuggingFace safetensor viewer or provides local weights |
+
+If tensor info is missing, ask the user to provide it. They can get it by clicking any `.safetensors` file in the HuggingFace model page and copying the tensor tree.
+
+For local models, extract tensor info with:
+
+```python
+import json, struct, sys, glob, os
+path = sys.argv[1]
+for sf in sorted(glob.glob(os.path.join(path, "*.safetensors"))):
+    with open(sf, "rb") as f:
+        n = struct.unpack("<Q", f.read(8))[0]
+        header = json.loads(f.read(n))
+    for k, v in sorted(header.items()):
+        if k != "__metadata__":
+            print(f"{k}\t{v.get('shape')}\t{v.get('dtype')}")
+```
+
+---
+
+## Phase 1: Parse Config and Identify Model Type
+
+Extract from `config.json`:
+
+### Core parameters
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `architectures` | Yes | Determines model type and loader path |
+| `hidden_size` | Yes | Or nested under `text_config` for multimodal |
+| `num_attention_heads` | Yes | Q heads for full attention |
+| `num_key_value_heads` | Yes | KV heads for GQA |
+| `head_dim` | If available | Defaults to `hidden_size / num_attention_heads` |
+| `num_hidden_layers` | Yes | Total layer count |
+| `vocab_size` | Yes | Embedding table size |
+
+### Hybrid (Qwen3.5/Qwen3Next) parameters
+
+| Field | When present | Notes |
+|-------|-------------|-------|
+| `layer_types` | Qwen3.5/Qwen3Next | Array of `"linear_attention"` / `"full_attention"` |
+| `linear_num_key_heads` | Hybrid models | GDN K heads (may differ from V heads) |
+| `linear_num_value_heads` | Hybrid models | GDN V heads |
+| `linear_key_head_dim` | Hybrid models | Per-head K dimension |
+| `linear_value_head_dim` | Hybrid models | Per-head V dimension |
+| `linear_conv_kernel_dim` | Hybrid models | Conv1d kernel size (typically 4) |
+| `full_attention_interval` | Hybrid models | How often full attention appears |
+
+### MoE parameters
+
+| Field | When present | Notes |
+|-------|-------------|-------|
+| `num_experts` | MoE models | Expert count per layer |
+| `num_experts_per_tok` | MoE models | Top-K routing |
+| `moe_intermediate_size` | MoE models | Per-expert FFN hidden dim |
+| `shared_expert_intermediate_size` | Some MoE | Shared expert dim |
+
+### Quantization config
+
+| Field | Notes |
+|-------|-------|
+| `quantization_config.quant_method` | `"modelopt"`, `"compressed-tensors"`, `"fp8"`, `"gptq"`, `"awq"` |
+| `quantization_config.quant_algo` | For modelopt: `"NVFP4"`, `"FP4"` |
+| `quantization_config.format` | For compressed-tensors: `"nvfp4-pack-quantized"`, `"mxfp4-pack-quantized"` |
+| `quantization_config.config_groups` | Weight/activation quant specs |
+| `quantization_config.ignore` | Layers excluded from quantization (stored as BF16/FP16) |
+| `quantization_config.weight_block_size` | FP8 block dimensions (e.g. `[128, 128]`) |
+
+### Normalize quant_method
+
+Apply the same normalization as `QuantConfig::normalize_compressed_tensors()`:
+
+| Raw `quant_method` | `quant_algo` / `format` | Normalized |
+|--------------------|------------------------|------------|
+| `modelopt` | `NVFP4` or `FP4` | `nvfp4` |
+| `modelopt` | (detect from config_groups) | `nvfp4` |
+| `compressed-tensors` | format contains `nvfp4` | `nvfp4` |
+| `compressed-tensors` | format contains `mxfp4` | `mxfp4` |
+| `fp8` | - | `fp8` |
+| `gptq` | - | `gptq` |
+| `awq` | - | `awq` |
+
+---
+
+## Phase 2: Validate Tensor Format Against Quantization Config
+
+For each layer type, check that tensor names and dtypes match the expected format.
+
+### 2a. Determine which layers are quantized vs skipped
+
+Parse the `ignore` list from `quantization_config`. Layers in the ignore list should have BF16/FP16 weights (`weight` tensor only). Layers NOT in the ignore list should have quantized tensors.
+
+The ignore list supports:
+- Literal paths: `"model.language_model.layers.0.linear_attn.in_proj_qkv"`
+- Regex patterns: `"re:.*linear_attn.*"`
+- Glob-style wildcards: `"model.visual*"`, `"mtp.layers.0*"`
+
+### 2b. Format-specific tensor checks
+
+#### Unquantized (BF16/FP16)
+
+Expected tensors per linear layer:
+- `weight` — dtype BF16 or F16, shape `[out_dim, in_dim]`
+- `bias` (optional) — dtype BF16 or F16
+
+**Check**: No extra scale/packed tensors should be present.
+
+#### FP8 (quant_method == "fp8")
+
+Expected tensors per linear layer:
+- `weight` — dtype U8 (F8_E4M3), shape `[out_dim, in_dim]`
+- `weight_scale` or `weight_scale_inv` — dtype F32, shape `[out_dim/by, in_dim/bx]` where `[by, bx]` = `weight_block_size` (default `[128, 128]`)
+- `bias` (optional)
+
+**Check**: `weight_block_size` must have exactly 2 elements. Scale dimensions must match `ceil(out_dim/by) x ceil(in_dim/bx)`.
+
+#### NVFP4 — ModelOpt format (quant_method == "modelopt" + quant_algo == "NVFP4")
+
+Expected tensors per quantized linear layer:
+- `weight` — dtype U8, shape `[out_dim, in_dim/2]` (packed FP4, 2 values per byte)
+- `weight_scale` — dtype F8_E4M3 (U8), shape `[out_dim, in_dim/16]` (group_size=16)
+- `weight_scale_2` — dtype F32, scalar (global weight scale, direct multiplier)
+- `input_scale` — dtype F32, scalar (activation scale)
+
+**Check**: `weight` shape dim1 must be exactly `in_dim/2`. Scale dim1 must be `in_dim/16`.
+
+#### NVFP4 — Compressed-tensors format (quant_method == "compressed-tensors" + nvfp4 format)
+
+Expected tensors per quantized linear layer:
+- `weight_packed` — dtype U8, shape `[out_dim, in_dim/2]`
+- `weight_scale` — dtype F8_E4M3 (U8), shape `[out_dim, in_dim/16]`
+- `weight_global_scale` — dtype F32, scalar or `[1]` (divisor, inverted at load time)
+- `input_global_scale` — dtype F32, scalar or `[1]` (divisor, inverted at load time)
+
+**Check**: Same shape rules as ModelOpt, but different tensor names.
+
+#### MXFP4 (quant_method == "mxfp4" or compressed-tensors with mxfp4)
+
+Expected tensors per quantized linear layer:
+- `weight_packed` or `blocks` — dtype U8, shape `[out_dim, in_dim/2]`
+- `weight_scale` or `scales` — dtype U8 (F8_E8M0), shape `[out_dim, in_dim/32]` (group_size=32)
+
+**Check**: Scale dim1 must be `in_dim/32`.
+
+#### GGUF
+
+GGUF models are self-contained (no `config.json`). Weight tensor names use `blk.{i}` prefix mapped to `model.layers.{i}`. Quantization is per-tensor via GGML dtypes (Q4_K, Q6_K, Q8_0, etc.).
+
+**Check**: Not applicable for safetensors checks. GGUF has its own loader path via `QLinear` / `QMatMul`.
+
+### 2c. Loader path tensor name resolution
+
+The xinfer loaders try tensor names in priority order. Verify the model's tensors match at least one:
+
+| Component | Tensor name priority (first match wins) |
+|-----------|---------------------------------------|
+| NVFP4/MXFP4 packed weights | `weight_packed` > `weight` > `blocks` |
+| NVFP4/MXFP4 scales | `weight_scale` > `scales` |
+| NVFP4 global scale | `weight_global_scale` (inverted) > `weight_scale_2` (direct) |
+| NVFP4 input scale | `input_scale` (direct) > `input_global_scale` (inverted) |
+| FP8 scale | `weight_scale` > `weight_scale_inv` |
+
+**Flag any mismatch** where the model uses a tensor name not in the priority list.
+
+### 2d. Hybrid model (GDN) quantization detection
+
+For Qwen3.5/Qwen3Next models with quantization config, the `GatedDeltaNet` layer has its own quantization detection (`is_weight_quantized`) that checks each linear_attn sublayer independently:
+
+| quant_method | Detection logic |
+|-------------|----------------|
+| `fp8` | Has `weight_scale` or `weight_scale_inv` |
+| `mxfp4` | Has `weight_packed` or `blocks` |
+| `nvfp4` | (`weight_packed` or `blocks`) AND (`weight_scale` or `scales`) **OR** (`weight_scale_2` or `input_scale`) AND (`weight_scale` or `scales`) |
+
+If a linear_attn sublayer is in the ignore list and has only BF16 `weight`, the detection returns false, and the layer loads as unquantized. **Verify** this matches the tensor info.
+
+---
+
+## Phase 3: Multi-Rank Divisibility Analysis
+
+For each candidate `world_size` in `[1, 2, 4, 8]`, check all TP-sharded dimensions.
+
+### 3a. Full Attention
+
+| Component | Global dim | Shard dim | Divisibility requirement |
+|-----------|-----------|-----------|------------------------|
+| Q projection | `num_attention_heads * head_dim` | dim 0 | `num_attention_heads % world_size == 0` |
+| K/V projection | `num_kv_heads * head_dim` | dim 0 | `num_kv_heads >= world_size`: `num_kv_heads % world_size == 0`; `num_kv_heads < world_size`: `world_size % num_kv_heads == 0` (replicated KV mode) |
+| O projection | `num_attention_heads * head_dim` | dim 1 | Same as Q |
+
+For quantized (FP8/NVFP4/MXFP4) Q/K/V:
+- Column linear shard dim 0: per-rank `out_dim / world_size` must be cleanly divisible
+- For FP8: per-rank start must be aligned to `weight_block_size[0]` (default 128)
+- For NVFP4: per-rank output must be divisible (no block alignment needed for dim 0 shard)
+
+### 3b. GatedDeltaNet (Linear Attention)
+
+| Component | Global dim | Requirement |
+|-----------|-----------|-------------|
+| `num_v_heads` | `linear_num_value_heads` | `% world_size == 0` |
+| `num_k_heads` | `linear_num_key_heads` | `% world_size == 0` |
+| `in_proj_qkv` (merged) | Q=`key_dim_global`, K=`key_dim_global`, V=`value_dim_global` | Each chunk `% world_size == 0` |
+| `in_proj_z` | `value_dim_global` | `% world_size == 0` |
+| `in_proj_b/a` | `num_v_heads_global` | `% world_size == 0` |
+| `A_log / dt_bias` | `num_v_heads_global` | `% world_size == 0` |
+| `conv1d` (Q block) | `key_dim_global` | `key_dim / world_size` channels per rank |
+| `conv1d` (V block) | `value_dim_global` | `% world_size == 0` |
+| `out_proj` | `value_dim_global` | Row linear dim 1 `% world_size == 0` |
+
+Where:
+- `key_dim_global = linear_num_key_heads * linear_key_head_dim`
+- `value_dim_global = linear_num_value_heads * linear_value_head_dim`
+
+### 3c. MoE Experts
+
+| Component | Global dim | Shard dim | Requirement |
+|-----------|-----------|-----------|-------------|
+| gate/up_proj | `moe_intermediate_size` | dim 0 | `% world_size == 0` |
+| down_proj | `moe_intermediate_size` | dim 1 | `% world_size == 0` |
+
+For NVFP4/MXFP4 MoE:
+- gate/up packed dim0: `moe_intermediate_size / world_size` per rank
+- down packed dim1: `(moe_intermediate_size / pack_factor) / world_size` per rank
+
+### 3d. Shared Expert MLP
+
+Same rules as standard MLP with `shared_expert_intermediate_size`:
+- Column linear (gate/up): `shared_expert_intermediate_size % world_size == 0`
+- Row linear (down): `shared_expert_intermediate_size % world_size == 0`
+
+### 3e. NVFP4/MXFP4 Scale Alignment
+
+For NVFP4 (group_size=16): after sharding, verify `per_rank_in_dim % 16 == 0` for dim-1 shards.
+For MXFP4 (group_size=32): verify `per_rank_in_dim % 32 == 0` for dim-1 shards.
+For FP8: verify per-rank boundaries align to `weight_block_size`.
+
+### 3f. Embedding / LM Head
+
+- `embed_tokens`: replicated (not sharded), no divisibility constraint.
+- `lm_head`: replicated, no constraint. But if `tie_word_embeddings` is true, verify `lm_head` doesn't exist as a separate tensor (should reuse `embed_tokens.weight`).
+
+---
+
+## Phase 4: Report Findings
+
+Present results in a structured format:
+
+### Model Summary
+```
+Architecture: Qwen3_5MoeForConditionalGeneration
+Model Type: qwen3_5_moe (Hybrid MoE with linear attention)
+Quantization: nvfp4 (compressed-tensors format)
+Layers: 48 (36 linear_attention + 12 full_attention)
+Hidden size: 3072
+Full attention: 32 Q heads, 2 KV heads, head_dim=256
+Linear attention: 16 K heads, 64 V heads, head_dim=128
+MoE: 256 experts, top-8, intermediate=1024
+Shared expert: intermediate=1024
+```
+
+### Tensor Format Validation
+```
+[OK] Linear attention layers (BF16, in ignore list)
+[OK] Full attention layers (NVFP4 compressed-tensors: weight_packed + weight_scale + weight_global_scale)
+[OK] MoE experts (NVFP4 compressed-tensors: per-expert weight_packed)
+[OK] Shared expert MLP (NVFP4 compressed-tensors: weight_packed)
+[WARN] lm_head: in ignore list, stored as BF16
+```
+
+### Multi-Rank Compatibility
+```
+| Component | 1 GPU | 2 GPUs | 4 GPUs | 8 GPUs |
+|-----------|-------|--------|--------|--------|
+| Full attn Q heads (32) | OK | 16 | 8 | 4 |
+| Full attn KV heads (2) | OK | 1 | repl(2) | repl(4) |
+| GDN K heads (16) | OK | 8 | 4 | 2 |
+| GDN V heads (64) | OK | 32 | 16 | 8 |
+| MoE inter (1024) | OK | 512 | 256 | 128 |
+| Overall | OK | OK | OK | OK |
+```
+
+### Issues Found
+
+Flag any problems:
+- `[ERROR]` — Will fail to load (missing tensors, wrong names, indivisible dims)
+- `[WARN]` — May cause issues (unusual format, edge case)
+- `[INFO]` — Informational (features detected, fallback paths)
+
+---
+
+## Phase 5: Common Issues Reference
+
+### Known tensor name mismatches
+
+| Model source | Packed weight name | xinfer loader support |
+|-------------|-------------------|---------------------|
+| ModelOpt NVFP4 | `weight` (U8) | Single-GPU: OK. Multi-GPU merged chunks: requires `weight` fallback in `load_merged_chunks` |
+| Compressed-tensors NVFP4 | `weight_packed` | OK everywhere |
+| Legacy MXFP4/NVFP4 | `blocks` | OK (final fallback) |
+
+### GatedDeltaNet TP-safe loading
+
+The `in_proj_qkv` tensor requires special merged-chunk loading for multi-GPU:
+- `MergedParallelColumnLinear::load_merged_chunks` splits Q, K, V independently
+- For quantized models (FP8/NVFP4/MXFP4), each chunk must be sharded within the quantized domain
+- For BF16 (ignore-listed layers), falls through to the unquantized path
+
+### Replicated KV heads
+
+When `num_kv_heads < world_size`:
+- `kv_head_shard` uses replicated mode: `ranks_per_kv_head = world_size / num_kv_heads`
+- Each KV head is shared by `ranks_per_kv_head` consecutive ranks
+- Requires `world_size % num_kv_heads == 0`
+
+---
+
+## Key Source Files
+
+| File | Relevance |
+|------|-----------|
+| `src/models/layers/distributed.rs` | TP column/row linear, `load_merged_chunks`, `kv_head_shard` |
+| `src/models/layers/linear.rs` | `LnFp8`, `LnNvfp4`, `LnMxfp4` loaders, tensor name resolution |
+| `src/models/layers/deltanet.rs` | `GatedDeltaNet` loading, `is_weight_quantized`, projection sharding |
+| `src/models/layers/attention.rs` | Full attention QKV loading, packed QKV for FP8 |
+| `src/models/layers/moe.rs` | `FusedMoeNvfp4`, `FusedMoeMxfp4`, `FusedMoeFp8` expert loading |
+| `src/utils/config.rs` | `QuantConfig`, `normalize_compressed_tensors`, `should_skip_module` |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xinfer"
-version = "0.12.7"
+version = "0.12.8"
 edition = "2021"
 default-run = "xinfer"
 description = "xInfer — a minimal, high-performance large language model (LLM) inference engine in Rust."
@@ -12,8 +12,8 @@ categories = ["algorithms", "hardware-support", "science"]
 license = "MIT"
 
 [dependencies]
-candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "68b6d74" }
-candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "68b6d74" }
+candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "15b70c7" }
+candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "15b70c7" }
 serde = { version = "1.0.190", features = ["serde_derive"] }
 tokenizers = {version = "0.21.2", features = ["http"] }
 hf-hub = "0.4.1"
@@ -46,7 +46,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.5.8", rev = "52bec1f" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.5.8", rev = "8fdb7ab" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"

--- a/ReadMe-CN.md
+++ b/ReadMe-CN.md
@@ -11,7 +11,7 @@
 | | 特性 | 详情 |
 |---|---|---|
 | **0️⃣** | 零 Python 依赖 | 纯 Rust 后端 — 不需要 PyTorch 或 CUDA Python 绑定 |
-| **⚡** | 极致性能 | 原生 Flash Attention、FlashInfer、CUDA Graphs、持续批处理、前缀缓存、PD 分离。消费级 GPU 上 `30B+` 模型解码速度高达 **175 tok/s** |
+| **⚡** | 极致性能 | 原生 Flash Attention、FlashInfer、CUDA Graphs、持续批处理、前缀缓存、PD 分离。消费级 GPU 上 `30B+` 模型解码速度高达 **181 tok/s** |
 | **🪶** | 极简内核 | 核心调度 + 注意力逻辑仅 **< 5000 行** Rust 代码 |
 | **🌍** | 跨平台 | CUDA（Linux/Windows）、Metal（macOS），统一二进制，统一 API |
 | **🏭** | 生产就绪 | OpenAI/Anthropic 兼容 API、内置 ChatGPT 风格 Web UI、MCP 工具调用、结构化输出、Embedding + 分词器端点 |
@@ -79,21 +79,21 @@ python3 -m xinfer.server --m Qwen/Qwen3.6-27B-FP8 --kvcache-dtype turbo4 --ui-se
 
 | 模型 | 格式 | 大小 | 输出速度 |
 |---|---|---|---|
-| Ministral-3-3B (**多模态**) | ISQ (BF16→Q4K) | 3B | **171.92** tokens/s |
-| Qwen3-VL-8B-Instruct (**多模态**) | Q8_0 | 8B | **105.31** tokens/s |
-| Llama-3.1-8B | ISQ (BF16→Q4K) | 8B | **120.74** tokens/s |
-| DeepSeek-R1-0528-Qwen3-8B | Q4_K_M | 8B | **124.87** tokens/s |
-| GLM-4-9B-0414 | Q4_K_M | 9B | **70.38** tokens/s |
-| QwQ-32B | Q4_K_M | 32B | **41.36** tokens/s |
-| **Qwen3-30B-A3B** | NVFP4 | **30B (MoE)** | **175.30** tokens/s (**RTX 5090**) |
-| **Qwen3-30B-A3B** | NVFP4 | **30B (MoE)** | **67.10** tokens/s (**V100, Software FP4**) |
-| **Qwen3.5-27B** (**多模态**) | Q4_K_M | **27B (Dense)** | **45.20** tokens/s |
-| **Qwen3.5-27B/Qwen3.6-27B** | FP8 | **27B (Dense)** | **42** tokens/s (**Hopper**) |
-| **Qwen3.6-35B-A3B** (**多模态**) | FP8 | **35B (MoE)** | **102** tokens/s (**Hopper**) |
+| Ministral-3-3B (**多模态**) | ISQ (BF16→Q4K) | 3B | **193.67** tokens/s |
+| Qwen3-VL-8B-Instruct (**多模态**) | Q8_0 | 8B | **112.51** tokens/s |
+| Llama-3.1-8B | ISQ (BF16→Q4K) | 8B | **133.10** tokens/s |
+| DeepSeek-R1-0528-Qwen3-8B | Q4_K_M | 8B | **139.25** tokens/s |
+| GLM-4-9B-0414 | Q4_K_M | 9B | **77.48** tokens/s |
+| QwQ-32B | Q4_K_M | 32B | **46.02** tokens/s |
+| **Qwen3-30B-A3B** | NVFP4 | **30B (MoE)** | **181.59** tokens/s (**RTX 5090**) |
+| **Qwen3-30B-A3B** | NVFP4 | **30B (MoE)** | **72.86** tokens/s (**V100, Software FP4**) |
+| **Qwen3.5-27B** (**多模态**) | Q4_K_M | **27B (Dense)** | **49.33** tokens/s |
+| **Qwen3.5-27B/Qwen3.6-27B** | FP8 | **27B (Dense)** | **45** tokens/s (**Hopper**) |
+| **Qwen3.6-35B-A3B** (**多模态**) | FP8 | **35B (MoE)** | **110** tokens/s (**Hopper**) |
 | **GLM4.7 Flash** | NVFP4 | **30B (MoE)** | **79** tokens/s (**Hopper, Software FP4**) |
-| **Gemma4-31B** | ISQ (BF16→Q4K) | **31B (Dense)** | **41** tokens/s (**Hopper**) |
-| **Gemma4-26B-A4B** | NVFP4 | **26B (MoE)** | **131** tokens/s (**RTX 5090**) |
-| **MiniMax-M2.5** | NVFP4 | **229B (MoE)** | **62** tokens/s (**Hopper, Software FP4, TP=2**) |
+| **Gemma4-31B** | ISQ (BF16→Q4K) | **31B (Dense)** | **47** tokens/s (**Hopper**) |
+| **Gemma4-26B-A4B** | NVFP4 | **26B (MoE)** | **137.23** tokens/s (**RTX 5090**) |
+| **MiniMax-M2.5** | NVFP4 | **229B (MoE)** | **64.50** tokens/s (**Hopper, Software FP4, TP=2**) |
 
 <details>
 <summary><b>Apple Silicon (M4)</b></summary>

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -11,7 +11,7 @@
 | | Feature | Details |
 |---|---|---|
 | **0️⃣** | Zero Python dependencies | Pure Rust backend — no PyTorch, no CUDA Python bindings |
-| **⚡** | Fast | Native Flash Attention, FlashInfer, CUDA Graphs, continuous batching, prefix caching, PD disaggregation. Up to **175 tok/s** decode for `30B+` models on consumer GPUs |
+| **⚡** | Fast | Native Flash Attention, FlashInfer, CUDA Graphs, continuous batching, prefix caching, PD disaggregation. Up to **181 tok/s** decode for `30B+` models on consumer GPUs |
 | **🪶** | Tiny footprint | Core scheduling + attention logic in **< 5 000 lines** of Rust |
 | **🌍** | Cross-platform | CUDA (Linux/Windows), Metal (macOS). Same binary, same API |
 | **🏭** | Production-ready | OpenAI/Anthropic-compatible APIs, built-in ChatGPT-style Web UI, MCP tool calling, structured outputs, embedding + tokenizer endpoints |
@@ -79,21 +79,21 @@ Add `--kvcache-dtype` to compress KV cache and extend context length:
 
 | Model | Format | Size | Decoding Speed |
 |---|---|---|---|
-| Ministral-3-3B (**Multimodal**) | ISQ (BF16→Q4K) | 3B | **171.92** tokens/s |
-| Qwen3-VL-8B-Instruct (**Multimodal**) | Q8_0 | 8B | **105.31** tokens/s |
-| Llama-3.1-8B | ISQ (BF16→Q4K) | 8B | **120.74** tokens/s |
-| DeepSeek-R1-0528-Qwen3-8B | Q4_K_M | 8B | **124.87** tokens/s |
-| GLM-4-9B-0414 | Q4_K_M | 9B | **70.38** tokens/s |
-| QwQ-32B | Q4_K_M | 32B | **41.36** tokens/s |
-| **Qwen3-30B-A3B** | NVFP4 | **30B (MoE)** | **175.30** tokens/s (**RTX 5090**) |
-| **Qwen3-30B-A3B** | NVFP4 | **30B (MoE)** | **67.10** tokens/s (**V100, Software FP4**) |
-| **Qwen3.5-27B** (**Multimodal**) | Q4_K_M | **27B (Dense)** | **45.20** tokens/s |
-| **Qwen3.5-27B/Qwen3.6-27B** | FP8 | **27B (Dense)** | **42** tokens/s (**Hopper**) |
-| **Qwen3.6-35B-A3B** (**Multimodal**) | FP8 | **35B (MoE)** | **102** tokens/s (**Hopper**) |
+| Ministral-3-3B (**Multimodal**) | ISQ (BF16→Q4K) | 3B | **193.67** tokens/s |
+| Qwen3-VL-8B-Instruct (**Multimodal**) | Q8_0 | 8B | **112.51** tokens/s |
+| Llama-3.1-8B | ISQ (BF16→Q4K) | 8B | **133.10** tokens/s |
+| DeepSeek-R1-0528-Qwen3-8B | Q4_K_M | 8B | **139.25** tokens/s |
+| GLM-4-9B-0414 | Q4_K_M | 9B | **77.48** tokens/s |
+| QwQ-32B | Q4_K_M | 32B | **46.02** tokens/s |
+| **Qwen3-30B-A3B** | NVFP4 | **30B (MoE)** | **181.59** tokens/s (**RTX 5090**) |
+| **Qwen3-30B-A3B** | NVFP4 | **30B (MoE)** | **72.86** tokens/s (**V100, Software FP4**) |
+| **Qwen3.5-27B** (**Multimodal**) | Q4_K_M | **27B (Dense)** | **49.33** tokens/s |
+| **Qwen3.5-27B/Qwen3.6-27B** | FP8 | **27B (Dense)** | **45** tokens/s (**Hopper**) |
+| **Qwen3.6-35B-A3B** (**Multimodal**) | FP8 | **35B (MoE)** | **110** tokens/s (**Hopper**) |
 | **GLM4.7 Flash** | NVFP4 | **30B (MoE)** | **79** tokens/s (**Hopper, Software FP4**) |
-| **Gemma4-31B** | ISQ (BF16→Q4K) | **31B (Dense)** | **41** tokens/s (**Hopper**) |
-| **Gemma4-26B-A4B** | NVFP4 | **26B (MoE)** | **131** tokens/s (**RTX 5090**) |
-| **MiniMax-M2.5** | NVFP4 | **229B (MoE)** | **62** tokens/s (**Hopper, Software FP4, TP=2**) |
+| **Gemma4-31B** | ISQ (BF16→Q4K) | **31B (Dense)** | **47** tokens/s (**Hopper**) |
+| **Gemma4-26B-A4B** | NVFP4 | **26B (MoE)** | **137.23** tokens/s (**RTX 5090**) |
+| **MiniMax-M2.5** | NVFP4 | **229B (MoE)** | **64.50** tokens/s (**Hopper, Software FP4, TP=2**) |
 
 <details>
 <summary><b>Apple Silicon (M4)</b></summary>

--- a/docs/add_model.md
+++ b/docs/add_model.md
@@ -20,7 +20,8 @@ The skill lives at `.cursor/skills/add-model/SKILL.md` and is **automatically ac
 | **3 — Implement** | Creates the model file (`src/models/<arch>.rs`), handles HF and GGUF weight paths, MoE construction, packed expert layouts. |
 | **4 — Register** | Wires the model into `mod.rs`, `config.rs`, `utils/mod.rs`, `runner.rs`, and `parser.rs`. |
 | **5 — Build** | Compiles with the correct platform features and fixes all errors/warnings. |
-| **6 — Test** | Starts the server, sends OpenAI-compatible requests, debugs common issues (NaN, crashes, wrong output). |
+| **6 — Check** | Invokes the [check-model skill](check_model.md) to validate tensor format, quantization consistency, and multi-GPU TP divisibility before testing. |
+| **7 — Test** | Starts the server, sends OpenAI-compatible requests, debugs common issues (NaN, crashes, wrong output). |
 
 ## Quick Start
 

--- a/docs/check_model.md
+++ b/docs/check_model.md
@@ -1,0 +1,133 @@
+# Model Compatibility Checking (AI-Assisted)
+
+xInfer ships with a **Cursor Agent Skill** that validates model compatibility before loading. It checks config correctness, weight tensor format, quantization consistency, and multi-GPU (tensor-parallel) divisibility — catching issues that would otherwise cause runtime panics or silent precision bugs.
+
+## Prerequisites
+
+- [Cursor IDE](https://cursor.sh/) with Agent mode enabled (for other Agents, mention the skill file manually)
+- The xInfer repository cloned locally
+- A model to check: HuggingFace URL/ID, local path, or pasted config + tensor info
+
+## How It Works
+
+The skill lives at `.cursor/skills/check-model/SKILL.md` and is **automatically activated** when you ask the agent to check, validate, audit, or verify a model. It walks the agent through five phases:
+
+| Phase | What happens |
+|-------|-------------|
+| **0 — Gather info** | Collects model config and tensor info from HuggingFace URL, local path, or user-provided data. |
+| **1 — Parse config** | Identifies architecture, extracts attention/MoE/hybrid parameters, normalizes quantization config. |
+| **2 — Validate tensors** | Checks that tensor names, shapes, and dtypes match the expected format for the detected quantization. |
+| **3 — Multi-rank analysis** | Tests TP divisibility for world_size 1, 2, 4, and 8 across all sharded components. |
+| **4 — Report** | Produces a structured summary with OK/WARN/ERROR flags for each check. |
+
+## Quick Start
+
+Open the project in Cursor and ask the agent:
+
+```
+Check this model: https://huggingface.co/AxionML/Qwen3.5-27B-NVFP4/blob/main/config.json
+```
+
+You can also provide tensor info by clicking a `.safetensors` file in the HuggingFace model page and copying the tensor tree:
+
+```
+Check this model for multi-GPU compatibility:
+<paste config.json URL>
+<paste tensor info>
+```
+
+Or check a local model:
+
+```
+Check the model at /data/Qwen3.5-122B-A10B-NVFP4/ for 4-GPU loading
+```
+
+## What Gets Checked
+
+### Tensor Format Validation
+
+For each quantization format, the skill verifies tensor naming and shapes:
+
+| Format | Expected tensors per linear layer |
+|--------|----------------------------------|
+| **BF16/FP16** | `weight` only |
+| **FP8** | `weight` (U8) + `weight_scale` or `weight_scale_inv` (F32) |
+| **NVFP4 (ModelOpt)** | `weight` (U8) + `weight_scale` (F8_E4M3) + `weight_scale_2` (F32) + `input_scale` (F32) |
+| **NVFP4 (compressed-tensors)** | `weight_packed` (U8) + `weight_scale` (F8_E4M3) + `weight_global_scale` (F32) + `input_global_scale` (F32) |
+| **MXFP4** | `weight_packed` or `blocks` (U8) + `weight_scale` or `scales` (U8) |
+
+### Quantization Ignore List
+
+For models with mixed precision (e.g., NVFP4 MoE with BF16 attention), the skill parses the `ignore` list from `quantization_config` and verifies that:
+- Ignored layers have BF16/FP16 weights only (no quantized tensors)
+- Non-ignored layers have the expected quantized tensor structure
+- The `ignore` list supports literal paths, regex patterns (`re:...`), and glob wildcards
+
+### Multi-Rank Divisibility
+
+For each candidate GPU count (1, 2, 4, 8), the skill checks:
+
+| Component | What must divide evenly |
+|-----------|------------------------|
+| Full attention Q heads | `num_attention_heads % world_size` |
+| Full attention KV heads | `num_kv_heads % world_size` (or `world_size % num_kv_heads` for replicated mode) |
+| GDN K/V heads | `linear_num_key_heads % world_size` and `linear_num_value_heads % world_size` |
+| GDN projections | All projection output dims by `world_size` |
+| MoE intermediate | `moe_intermediate_size % world_size` |
+| Shared expert | `shared_expert_intermediate_size % world_size` |
+| FP8 block alignment | Per-rank boundaries aligned to `weight_block_size` |
+| FP4 scale alignment | Per-rank inner dims are multiples of group_size (16 for NVFP4, 32 for MXFP4) |
+
+### Loader Path Compatibility
+
+The skill checks tensor naming against xinfer's loader priority order:
+
+| Component | Tensor name priority (first match wins) |
+|-----------|---------------------------------------|
+| FP4 packed weights | `weight_packed` > `weight` > `blocks` |
+| FP4 scales | `weight_scale` > `scales` |
+| FP4 global scale | `weight_global_scale` (inverted) > `weight_scale_2` (direct) |
+| FP4 input scale | `input_scale` (direct) > `input_global_scale` (inverted) |
+| FP8 scale | `weight_scale` > `weight_scale_inv` |
+
+## Example Output
+
+```
+## Model Summary
+Architecture: Qwen3_5MoeForConditionalGeneration
+Quantization: nvfp4 (compressed-tensors)
+Layers: 48 (36 linear_attention + 12 full_attention)
+Hidden: 3072, Q heads: 32, KV heads: 2, GDN K: 16, V: 64
+
+## Tensor Format
+[OK]  Linear attention: BF16 (in ignore list)
+[OK]  Full attention: NVFP4 (weight_packed + weight_scale + weight_global_scale)
+[OK]  MoE experts: NVFP4 per-expert (weight_packed)
+[OK]  Shared expert: NVFP4 (weight_packed)
+
+## Multi-Rank Compatibility
+| Component           | 1 GPU | 2 GPUs | 4 GPUs | 8 GPUs |
+|---------------------|-------|--------|--------|--------|
+| Q heads (32)        |  OK   |   16   |    8   |    4   |
+| KV heads (2)        |  OK   |    1   | repl(2)| repl(4)|
+| GDN K heads (16)    |  OK   |    8   |    4   |    2   |
+| GDN V heads (64)    |  OK   |   32   |   16   |    8   |
+| MoE inter (1024)    |  OK   |  512   |  256   |  128   |
+| Overall             |  OK   |   OK   |   OK   |   OK   |
+```
+
+## Integration with Add Model
+
+The [add-model skill](add_model.md) automatically invokes the check-model skill after implementing a new architecture, ensuring the model loads correctly on single and multi-GPU configurations before testing.
+
+## File Reference
+
+| File | Role |
+|------|------|
+| `.cursor/skills/check-model/SKILL.md` | The skill definition (read by the AI agent) |
+| `src/models/layers/distributed.rs` | TP column/row linear, merged chunk loading, KV head sharding |
+| `src/models/layers/linear.rs` | FP8/NVFP4/MXFP4 linear layer loaders |
+| `src/models/layers/deltanet.rs` | GatedDeltaNet loading, per-weight quantization detection |
+| `src/models/layers/attention.rs` | Full attention QKV loading and packed QKV for FP8 |
+| `src/models/layers/moe.rs` | MoE expert loading for all quantization formats |
+| `src/utils/config.rs` | QuantConfig normalization, ignore list parsing |

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -10,21 +10,21 @@ This document contains detailed performance benchmarks for xInfer across differe
 
 | Model | Format | Size | Hardware | Decoding Speed |
 |-------|--------|------|----------|----------------|
-| Qwen3-30B-A3B | NVFP4 | 30B MoE | RTX 5090 (SM120) | **175.30** tokens/s |
-| Gemma4-26B-A4B | NVFP4 | 26B MoE | RTX 5090 (SM120) | **131** tokens/s |
-| Ministral-3-3B (Multimodal) | ISQ (BF16→Q4K) | 3B | A100 (SM80) | **171.92** tokens/s |
-| DeepSeek-R1-0528-Qwen3-8B | Q4_K_M | 8B | A100 (SM80) | **124.87** tokens/s |
-| Llama-3.1-8B | ISQ (BF16→Q4K) | 8B | A100 (SM80) | **120.74** tokens/s |
-| Qwen3-VL-8B-Instruct (Multimodal) | Q8_0 | 8B | A100 (SM80) | **105.31** tokens/s |
-| Qwen3.6-35B-A3B (Multimodal) | FP8 | 35B MoE | H800 (SM90) | **102** tokens/s |
-| GLM4.7 Flash | NVFP4 | 30B MoE | H800 (SM90) | **79** tokens/s |
-| Qwen3-30B-A3B | NVFP4 | 30B MoE | V100 (SM70) | **67.10** tokens/s |
-| GLM-4-9B-0414 | Q4_K_M | 9B | A100 (SM80) | **70.38** tokens/s |
-| MiniMax-M2.5 | NVFP4 | 229B MoE | H800 ×2 (SM90) | **62** tokens/s |
-| Qwen3.5-27B (Multimodal) | Q4_K_M | 27B Dense | A100 (SM80) | **45.20** tokens/s |
-| Qwen3.5-27B/Qwen3.6-27B | FP8 | 27B Dense | H800 (SM90) | **42** tokens/s |
-| QwQ-32B | Q4_K_M | 32B | A100 (SM80) | **41.36** tokens/s |
-| Gemma4-31B | ISQ (BF16→Q4K) | 31B Dense | H800 (SM90) | **41** tokens/s |
+| Ministral-3-3B (**Multimodal**) | ISQ (BF16→Q4K) | 3B | A100| **193.67** tokens/s |
+| Qwen3-VL-8B-Instruct (**Multimodal**) | Q8_0 | 8B | A100| **112.51** tokens/s |
+| Llama-3.1-8B | ISQ (BF16→Q4K) | 8B | A100| **133.10** tokens/s |
+| DeepSeek-R1-0528-Qwen3-8B | Q4_K_M | 8B | A100| **139.25** tokens/s |
+| GLM-4-9B-0414 | Q4_K_M | 9B | A100| **77.48** tokens/s |
+| QwQ-32B | Q4_K_M | 32B | A100| **46.02** tokens/s |
+| **Qwen3-30B-A3B** | NVFP4 | **30B (MoE)** | RTX 5090 | **181.59** tokens/s|
+| **Qwen3-30B-A3B** | NVFP4 | **30B (MoE)** | V100 | **72.86** tokens/s (**Software FP4**) |
+| **Qwen3.5-27B** (**Multimodal**) | Q4_K_M | **27B (Dense)** | Hopper | **49.33** tokens/s |
+| **Qwen3.5-27B/Qwen3.6-27B** | FP8 | **27B (Dense)** | Hopper | **45** tokens/s|
+| **Qwen3.6-35B-A3B** (**Multimodal**) | FP8 | **35B (MoE)** | Hopper | **110** tokens/s |
+| **GLM4.7 Flash** | NVFP4 | **30B (MoE)** | Hopper | **79** tokens/s (**Software FP4**) |
+| **Gemma4-31B** | ISQ (BF16→Q4K) | **31B (Dense)** | Hopper| **47** tokens/s |
+| **Gemma4-26B-A4B** | NVFP4 | **26B (MoE)** | RTX 5090 | **137.23** tokens/s|
+| **MiniMax-M2.5** | NVFP4 | **229B (MoE)** | Hopper | **64.50** tokens/s (**Software FP4, TP=2**) |
 
 ### V100 + NVFP4 + TurboQuant (First-Ever)
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xinfer-ai",
-  "version": "0.12.7",
-  "assetVersion": "0.12.7",
+  "version": "0.12.8",
+  "assetVersion": "0.12.8",
   "description": "xInfer — a high-performance LLM inference engine in Rust with CUDA/Metal acceleration",
   "license": "MIT",
   "homepage": "https://github.com/guoqingbao/xinfer#readme",

--- a/pages/index.html
+++ b/pages/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>xInfer — Blazing-fast LLM Inference in Pure Rust</title>
-<meta name="description" content="High-performance LLM inference engine in pure Rust. No PyTorch. CUDA &amp; Metal. 175+ tok/s.">
+<meta name="description" content="High-performance LLM inference engine in pure Rust. No PyTorch. CUDA &amp; Metal. 180+ tok/s.">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><text y='20' font-size='20'>⚡</text></svg>">
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
@@ -282,14 +282,14 @@ footer{padding:56px 0 28px;border-top:1px solid var(--c-border);position:relativ
       <table>
         <thead><tr><th data-i="p.m">Model</th><th data-i="p.fmt">Format</th><th data-i="p.sz">Size</th><th data-i="p.hw">Hardware</th><th data-i="p.sp">Speed</th><th data-i="p.note">Note</th></tr></thead>
         <tbody>
-          <tr><td>Qwen3-30B-A3B</td><td>NVFP4</td><td>30B MoE</td><td>RTX 5090 (SM120)</td><td><span class="sv" data-n="175.30">0</span> tok/s</td><td data-i="p.n1">HW NVFP4</td></tr>
-          <tr><td>Gemma4-26B-A4B</td><td>NVFP4</td><td>26B MoE</td><td>RTX 5090 (SM120)</td><td><span class="sv" data-n="131">0</span> tok/s</td><td data-i="p.n1">HW NVFP4</td></tr>
-          <tr><td>Qwen3.6-35B-A3B</td><td>FP8</td><td>35B MoE</td><td>H800 (SM90)</td><td><span class="sv" data-n="102">0</span> tok/s</td><td data-i="p.n2">HW FP8</td></tr>
-          <tr><td>DeepSeek-R1-Qwen3-8B</td><td>Q4_K_M</td><td>8B</td><td>A100 (SM80)</td><td><span class="sv" data-n="124.87">0</span> tok/s</td><td>GGUF</td></tr>
-          <tr><td>Llama-3.1-8B</td><td>ISQ Q4K</td><td>8B</td><td>A100 (SM80)</td><td><span class="sv" data-n="120.74">0</span> tok/s</td><td data-i="p.n3">SW quant</td></tr>
-          <tr><td>MiniMax-M2.5</td><td>NVFP4</td><td>229B MoE</td><td>H800 ×2 (SM90)</td><td><span class="sv" data-n="62">0</span> tok/s</td><td data-i="p.n4">SW NVFP4 (no HW)</td></tr>
-          <tr><td>Qwen3-30B-A3B</td><td>NVFP4</td><td>30B MoE</td><td>V100 (SM70)</td><td><span class="sv" data-n="67.10">0</span> tok/s</td><td data-i="p.n5">SW FP4</td></tr>
-          <tr><td>Qwen3.6-27B</td><td>FP8</td><td>27B Dense</td><td>H800 (SM90)</td><td><span class="sv" data-n="42">0</span> tok/s</td><td data-i="p.n2">HW FP8</td></tr>
+          <tr><td>Qwen3-30B-A3B</td><td>NVFP4</td><td>30B MoE</td><td>RTX 5090 (SM120)</td><td><span class="sv" data-n="181.59">0</span> tok/s</td><td data-i="p.n1">HW NVFP4</td></tr>
+          <tr><td>Gemma4-26B-A4B</td><td>NVFP4</td><td>26B MoE</td><td>RTX 5090 (SM120)</td><td><span class="sv" data-n="137.23">0</span> tok/s</td><td data-i="p.n1">HW NVFP4</td></tr>
+          <tr><td>Qwen3.6-35B-A3B</td><td>FP8</td><td>35B MoE</td><td>H800 (SM90)</td><td><span class="sv" data-n="110">0</span> tok/s</td><td data-i="p.n2">HW FP8</td></tr>
+          <tr><td>DeepSeek-R1-Qwen3-8B</td><td>Q4_K_M</td><td>8B</td><td>A100 (SM80)</td><td><span class="sv" data-n="139.25">0</span> tok/s</td><td>GGUF</td></tr>
+          <tr><td>Llama-3.1-8B</td><td>ISQ Q4K</td><td>8B</td><td>A100 (SM80)</td><td><span class="sv" data-n="133.10">0</span> tok/s</td><td data-i="p.n3">SW quant</td></tr>
+          <tr><td>MiniMax-M2.5</td><td>NVFP4</td><td>229B MoE</td><td>H800 ×2 (SM90)</td><td><span class="sv" data-n="64.50">0</span> tok/s</td><td data-i="p.n4">SW NVFP4 (no HW)</td></tr>
+          <tr><td>Qwen3-30B-A3B</td><td>NVFP4</td><td>30B MoE</td><td>V100 (SM70)</td><td><span class="sv" data-n="72.86">0</span> tok/s</td><td data-i="p.n5">SW FP4</td></tr>
+          <tr><td>Qwen3.6-27B</td><td>FP8</td><td>27B Dense</td><td>H800 (SM90)</td><td><span class="sv" data-n="45">0</span> tok/s</td><td data-i="p.n2">HW FP8</td></tr>
         </tbody>
       </table>
     </div>
@@ -509,7 +509,7 @@ en:{
 'f.label':'Features','f.title':'Built for Speed & Simplicity',
 'f.desc':'Everything you need for production LLM inference — without the Python baggage.',
 'f.1t':'Zero Dependencies','f.1d':'Pure Rust backend — no PyTorch, no CUDA Python bindings, no Python runtime.',
-'f.2t':'Blazing Fast','f.2d':'Flash Attention, FlashInfer, CUDA Graphs, continuous batching. Up to 175+ tok/s.',
+'f.2t':'Blazing Fast','f.2d':'Flash Attention, FlashInfer, CUDA Graphs, continuous batching. Up to 180+ tok/s.',
 'f.3t':'Tiny Footprint','f.3d':'Core scheduling & attention logic in under 5,000 lines of Rust.',
 'f.4t':'Cross-Platform','f.4d':'CUDA on Linux, Metal on macOS. Same binary, same API everywhere.',
 'f.5t':'Production Ready','f.5d':'OpenAI & Anthropic APIs, built-in Web UI, MCP tool calling, structured outputs.',
@@ -548,7 +548,7 @@ cn:{
 'f.label':'功能特性','f.title':'为速度与简洁而生',
 'f.desc':'生产级 LLM 推理所需的一切 — 无需 Python 依赖。',
 'f.1t':'零依赖','f.1d':'纯 Rust 后端 — 无需 PyTorch、CUDA Python 绑定或 Python 运行时。',
-'f.2t':'极速推理','f.2d':'Flash Attention、FlashInfer、CUDA Graphs、连续批处理。175+ tok/s。',
+'f.2t':'极速推理','f.2d':'Flash Attention、FlashInfer、CUDA Graphs、连续批处理。180+ tok/s。',
 'f.3t':'轻量核心','f.3d':'核心调度与注意力逻辑不足 5,000 行 Rust 代码。',
 'f.4t':'跨平台','f.4d':'Linux 上 CUDA，macOS 上 Metal。同一二进制，同一 API。',
 'f.5t':'生产就绪','f.5d':'OpenAI/Anthropic API、内置 Web UI、MCP 工具、结构化输出。',

--- a/pages/index.html
+++ b/pages/index.html
@@ -630,7 +630,7 @@ document.querySelectorAll('.cb').forEach(function(bl){
 });
 
 /* ═══ Download cards ═══ */
-var XINFER_VER='0.12.7';
+var XINFER_VER='0.12.8';
 var DL='https://github.com/guoqingbao/xinfer/releases/download/v'+XINFER_VER+'/';
 var archs=[
   {sm:'sm70',n:'70',name:'SM70',gpu:'V100',cuda:'CUDA 12',d:0},

--- a/src/mcp/manager.rs
+++ b/src/mcp/manager.rs
@@ -219,7 +219,7 @@ impl McpClientManager {
                     let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
                     match StdioTransport::spawn_with_env(command, &args_refs, env) {
                         Ok(transport) => {
-                            let mut client = McpClient::new(transport, "xinfer", "0.12.7");
+                            let mut client = McpClient::new(transport, "xinfer", "0.12.8");
                             if let Err(err) = client.initialize() {
                                 crate::log_error!(
                                     "Failed to initialize MCP server {}: {:?}",
@@ -246,7 +246,7 @@ impl McpClientManager {
                 McpTransportType::Http { url, headers } => {
                     match super::transport::HttpTransport::new(url.clone(), headers.clone()) {
                         Ok(transport) => {
-                            let mut client = McpClient::new(transport, "xinfer", "0.12.7");
+                            let mut client = McpClient::new(transport, "xinfer", "0.12.8");
                             if let Err(err) = client.initialize() {
                                 crate::log_error!(
                                     "Failed to initialize remote MCP server {}: {:?}",

--- a/src/models/layers/distributed.rs
+++ b/src/models/layers/distributed.rs
@@ -854,6 +854,13 @@ impl MergedParallelColumnLinear {
                             Shard::default(),
                             DType::U8,
                         )?
+                    } else if v.contains_tensor("weight") {
+                        v.get_with_hints_dtype(
+                            (out_dim, in_dim / pack_factor),
+                            "weight",
+                            Shard::default(),
+                            DType::U8,
+                        )?
                     } else {
                         v.get_with_hints_dtype(
                             (out_dim, in_dim / pack_factor),

--- a/src/utils/graph.rs
+++ b/src/utils/graph.rs
@@ -339,6 +339,25 @@ where
     }
 }
 
+#[derive(Clone, Copy)]
+enum CapturePhase {
+    CachePrewarm,
+    Warmup,
+    Capture,
+}
+
+impl CapturePhase {
+    const ALL: [Self; 3] = [Self::CachePrewarm, Self::Warmup, Self::Capture];
+
+    fn is_cache_prewarm(self) -> bool {
+        matches!(self, Self::CachePrewarm)
+    }
+
+    fn is_warmup(self) -> bool {
+        !matches!(self, Self::Capture)
+    }
+}
+
 pub struct GraphCaptureVars {
     pub input_ids: Tensor,
     pub positions: Tensor,
@@ -497,8 +516,9 @@ impl<M: CudaGraphModule> GraphCapturer<M> {
         let capture_in_warmup = false;
 
         let mut outputs = BTreeMap::<usize, Tensor>::new();
-        for is_warmup in [true, false] {
-            let iter: Box<dyn Iterator<Item = usize>> = if is_warmup {
+        let _guard = candle_core::cuda_backend::cuda_param_cache_scope(true);
+        for phase in CapturePhase::ALL {
+            let iter: Box<dyn Iterator<Item = usize>> = if phase.is_warmup() {
                 Box::new(0..self.graph_bs.len())
             } else {
                 Box::new(tqdm(0..self.graph_bs.len()).desc(Some("Graph capturing")))
@@ -581,10 +601,12 @@ impl<M: CudaGraphModule> GraphCapturer<M> {
                     flashinfer_metadata,
                 };
 
-                if !is_warmup || capture_in_warmup {
+                let should_capture =
+                    !phase.is_cache_prewarm() && (!phase.is_warmup() || capture_in_warmup);
+                if should_capture {
                     self.model.start_capture(bs)?;
                 }
-                if is_warmup {
+                if phase.is_warmup() {
                     let _ = self.model.forward(
                         &input_ids_bs,
                         &positions_bs,
@@ -602,8 +624,8 @@ impl<M: CudaGraphModule> GraphCapturer<M> {
                     )?;
                     outputs.insert(bs, out);
                 }
-                if !is_warmup || capture_in_warmup {
-                    self.model.end_capture(!is_warmup)?;
+                if should_capture {
+                    self.model.end_capture(!phase.is_warmup())?;
                 }
             }
         }


### PR DESCRIPTION
Skill to check compatibility of this project against any given model.

Sample check output:

```
Check Results for /weights/Qwen3.5-0.8B-nvfp4/

## Model Summary
Architecture: Qwen3_5ForConditionalGeneration
Model Type: qwen3_5 (Hybrid Dense with linear attention)
Quantization: MLX-style NVFP4 (mode: "nvfp4") 
Layers: 24 (18 linear_attention + 6 full_attention)
Hidden: 1024, Q heads: 8, KV heads: 2
GDN: K heads: 16, V heads: 16, head_dim: 128
Intermediate: 3584
## Tensor Format Validation
[ERROR] MLX-style NVFP4 format detected — INCOMPATIBLE with xinfer
        - Weights packed as U32 (8 FP4 values per U32 word)
        - xinfer expects U8 packing (2 FP4 values per byte)
        - No weight_scale_2/weight_global_scale/input_scale tensors
        - Embedding table (embed_tokens) is also quantized (U32)
[ERROR] Conv1d weight shape is [6144, 4, 1] — xinfer expects [6144, 1, 4]
[WARN]  quantization_config has "mode":"nvfp4" instead of "quant_method"
        — xinfer correctly rejects this as unsupported MLX format
[INFO]  tie_word_embeddings: true (lm_head reuses embed_tokens)
## Multi-Rank Compatibility (moot due to format incompatibility)
Not applicable — model cannot load at all due to MLX format.
## Recommendation
This model uses MLX-community NVFP4 quantization which is NOT supported.
Use one of these alternatives:
- ModelOpt format: AxionML/Qwen3.5-0.8B-NVFP4 (if available)
- Compressed-tensors format: RedHatAI/Qwen3.5-*-NVFP4
- Unquantized BF16 with ISQ: --isq q4k for on-the-fly quantization
```