### PR TITLE
Use Ceiling Division for Scale Tensor

### DIFF
--- a/src/models/layers/distributed.rs
+++ b/src/models/layers/distributed.rs
@@ -782,8 +782,8 @@ impl MergedParallelColumnLinear {
                             .contiguous()?;
                         local_output_splits.push(local_out);
 
-                        let scale_row_start = local_out_start / by;
-                        let scale_rows = (local_out + by - 1) / by;
+                        let scale_row_start = local_out_start.div_ceil(by);
+                        let scale_rows = local_out.div_ceil(by);
                         if scale_row_start + scale_rows > scale_dim0 {
                             candle_core::bail!(
                                 "FP8 merged chunk {} scale slice out of bounds: start={}, rows={}, total={}",
@@ -1000,10 +1000,25 @@ impl MergedParallelColumnLinear {
                         let local_out = chunk_size / chunk_shard.world_size;
                         let local_start = chunk_start + chunk_shard.rank * local_out;
 
+                        let scale_block_size: usize = if is_nvfp4_quant { 16 } else { 32 };
+                        let scale_local_start = local_start.div_ceil(scale_block_size);
+                        let scale_local_out = local_out.div_ceil(scale_block_size);
+
                         let blocks_chunk =
                             blocks.narrow(0, local_start, local_out)?.contiguous()?;
                         let scales_chunk =
-                            scales.narrow(0, local_start, local_out)?.contiguous()?;
+                            scales.narrow(0, scale_local_start, scale_local_out)?.contiguous()?;
+
+                        // Verify scale shard is within bounds
+                        let scale_dim0 = scales.dim(0)?;
+                        if scale_local_start + scale_local_out > scale_dim0 {
+                            candle_core::bail!(
+                                "FP4 scale shard out of bounds: start={}, rows={}, total={}",
+                                scale_local_start,
+                                scale_local_out,
+                                scale_dim0
+                            );
+                        }
 
                         let linear = if is_nvfp4_quant {
                             #[cfg(feature = "cuda")]


### PR DESCRIPTION
When sharding quantized weights across multiple ranks, the scale tensor must be partitioned proportionally to the weight partition. The scale has a smaller dimensionality than the weight by a factor of the block size (block_n for output dimension, block_k for input dimension).

The bug was in calculating the scale shard offset. Given:

- weight_shard_start = rank * weight_shard_size
- scale_shard_start = weight_shard_start / block_n
- Using FLOOR division (integer division in Rust): scale_shard_start = 500 / 128 = 3
- Using CEILING division: scale_shard_start = ceil(500/128) = 4

The ceiling division is required because the scale tensor represents blocks of weight data, and a partial block at the start of a weight shard still requires a full scale entry. For example, if a weight shard starts at offset 500 in a 128-block grid, it begins at block index 4 (blocks 0-3 contain weights 0-511, blocks 4-7 contain weights 512-1023).