### PR TITLE
fix(cuda-graph): fix cuda graph pre warmup synchronization 

### DIFF
--- a/src/utils/graph.rs
+++ b/src/utils/graph.rs
@@ -626,6 +626,9 @@ impl<M: CudaGraphModule> GraphCapturer<M> {
                 }
                 if should_capture {
                     self.model.end_capture(!phase.is_warmup())?;
+                } else {
+                    // synchronize cuda stream for non graph capture path
+                    device.synchronize()?;
                 }
             }
         }


### PR DESCRIPTION
## Issue
Hello, I faced an error when trying to start the server with the following command using a source build:
```
 ./target/debug/xinfer --w ../.hf_home/hub/models--Qwen--Qwen3-0.6B/snapshots/c1899de289a04d12100db370d81485cdf75e47ca --server
```

Error:
```
thread 'main' (102806) panicked at /root/.cargo/git/checkouts/cudarc-47fcf0f0d3baf3eb/bfb8f27/src/driver/safe/core.rs:264:80:                                                                                                                                         
called `Result::unwrap()` on an `Err` value: DriverError(CUDA_ERROR_ILLEGAL_ADDRESS, "an illegal memory access was encountered")
```

Build command:
```
cargo build --bin xinfer --features cuda,flashinfer,cutlass,nvtx
```

model: Qwen3-0.6B
GPU: RTX 3060


## Fix
The graph warmup fails only during pre warmup and cuda stream being synchronized (inside end_capture) between forward passes was the main difference between pre warmup and graph capture phases. 
This fix adds missing cuda stream synchronization between forward passes for the non graph capture path.

I verified the fix by re-building and running the command again