### PR TITLE
Row-Mjor Weight-Scale Layout on SM120

### DIFF
--- a/src/models/layers/linear.rs
+++ b/src/models/layers/linear.rs
@@ -1064,8 +1064,9 @@ fn load_ln_fp8_with_hints(
     let sm_version = 0;
 
     #[cfg(feature = "cutlass")]
-    let weight_scale_cutlass = if sm_version >= 100 {
-        // SM100+: Column-major scale layout
+    let weight_scale_cutlass = if sm_version >= 100 && sm_version < 120 {
+        // SM100-103 Blackwell: Column-major scale layout
+        // PCIE cards and embedded chips fall back to sm90 path
         Some(weight_scale.t()?)
     } else if sm_version >= 90 {
         // SM90: CUTLASS expects scales_b as [K/128, N/128] row-major contiguous


### PR DESCRIPTION
Seems to help with 397B on 4xSM120 not collapsing into insanity quite as quickly:
```rust
vllm-rs-svc0  | 2026-06-09T04:13:22.183881Z  WARN xinfer::server::server: --- Performance Metrics ---
vllm-rs-svc0  | 2026-06-09T04:13:22.183902Z  INFO xinfer::server::server: [Seq 1] ⏱️ Prompt: 89822 tokens in 0.10s (863673.06 t/s)
vllm-rs-svc0  | 2026-06-09T04:13:22.183910Z  INFO xinfer::server::server: [Seq 1] ⏱️ Decoded: 1935 tokens in 36.15s (53.53 t/s)
```
produced a rational assessment of `src/models/layers/`