### PR TITLE
[perf] engine: run chat-template + tokenize under engine.read() so concurrent handlers don't serialize on engine.write()

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -217,12 +217,21 @@ impl Engine {
         images: Option<crate::utils::image::ImageData>,
         tools: Vec<Tool>,
     ) -> Result<GenerationOutput> {
-        let (receivers, tokenizer) = {
-            let mut engine = self.engine.write();
+        let (preprocessed, tokenizer) = {
+            let engine = self.engine.read();
             (
-                engine.generate_sync(&vec![params], &vec![messages], images, &tools, &None)?,
+                engine.preprocess(
+                    std::slice::from_ref(&params),
+                    std::slice::from_ref(&messages),
+                    &tools,
+                    false,
+                )?,
                 Arc::new(engine.tokenizer.clone()),
             )
+        };
+        let receivers = {
+            let mut engine = self.engine.write();
+            engine.generate_sync_from_preprocessed(preprocessed, images, &None)?
         };
 
         let results = GLOBAL_RT.block_on(async {
@@ -246,9 +255,19 @@ impl Engine {
         let img_cfg = { self.engine.read().img_cfg.clone() };
         let (messages, image_data) = build_messages_and_images(&messages, img_cfg.as_ref())?;
 
+        let preprocessed = {
+            let engine = self.engine.read();
+            let mut p = engine.preprocess(
+                std::slice::from_ref(&params),
+                std::slice::from_ref(&messages),
+                &tools,
+                false,
+            )?;
+            p.pop().expect("preprocess returned 0 items for 1 input")
+        };
         let (seq_id, prompt_length, _prefilled_reasoning_end, stream) = {
             let mut engine = self.engine.write();
-            engine.generate_stream(&params, &messages, image_data, &tools, &None)?
+            engine.generate_stream_from_preprocessed(preprocessed, image_data, &None)?
         };
 
         Ok(EngineStream {

--- a/src/api.rs
+++ b/src/api.rs
@@ -231,7 +231,7 @@ impl Engine {
         };
         let receivers = {
             let mut engine = self.engine.write();
-            engine.generate_sync_from_preprocessed(preprocessed, images, &None)?
+            engine.generate_sync(preprocessed, images, &None)?
         };
 
         let results = GLOBAL_RT.block_on(async {
@@ -267,7 +267,7 @@ impl Engine {
         };
         let (seq_id, prompt_length, _prefilled_reasoning_end, stream) = {
             let mut engine = self.engine.write();
-            engine.generate_stream_from_preprocessed(preprocessed, image_data, &None)?
+            engine.generate_stream(preprocessed, image_data, &None)?
         };
 
         Ok(EngineStream {

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -530,14 +530,7 @@ impl LLMEngine {
             .encode_fast(prompt, true)
             .expect("encode failed!");
         let token_ids: Vec<u32> = tokens.get_ids().to_vec();
-        self.add_request_pretokenized_(
-            params,
-            prompt,
-            token_ids,
-            request_type,
-            images,
-            image_idx,
-        )
+        self.add_request_pretokenized_(params, prompt, token_ids, request_type, images, image_idx)
     }
 
     /// Same body as `add_request_` but accepts a pre-computed `token_ids`

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -75,6 +75,18 @@ pub enum RequestType {
     Completion,
 }
 
+/// Output of `LLMEngine::preprocess`. Carries the per-request CPU work
+/// (chat-template render + tokenize) the caller has already done so the
+/// engine write lock can be acquired briefly, for the scheduler-add step
+/// only.
+#[derive(Debug, Clone)]
+pub struct PreprocessedRequest {
+    pub params: SamplingParams,
+    pub prompt: String,
+    pub image_idx: i32,
+    pub token_ids: Vec<u32>,
+}
+
 #[allow(dead_code)]
 pub struct LLMEngine {
     pub runners: Arc<RwLock<RunnerType>>,
@@ -517,7 +529,31 @@ impl LLMEngine {
             .tokenizer
             .encode_fast(prompt, true)
             .expect("encode failed!");
-        let token_ids: Vec<u32> = tokens.get_ids().iter().map(|&x| x).collect();
+        let token_ids: Vec<u32> = tokens.get_ids().to_vec();
+        self.add_request_pretokenized_(
+            params,
+            prompt,
+            token_ids,
+            request_type,
+            images,
+            image_idx,
+        )
+    }
+
+    /// Same body as `add_request_` but accepts a pre-computed `token_ids`
+    /// so the caller can run tokenize outside the engine write lock. Hot-path
+    /// serialization of concurrent server handlers gets cut by ~
+    /// chat-template + tokenize wall × concurrency in chat-template-heavy
+    /// workloads.
+    fn add_request_pretokenized_(
+        &mut self,
+        params: &SamplingParams,
+        prompt: &str,
+        token_ids: Vec<u32>,
+        request_type: &RequestType,
+        images: &Option<ImageData>,
+        image_idx: i32,
+    ) -> Result<(usize, usize)> {
         let length = token_ids.len();
         let raw_replay_token_ids = self.match_prompt_replay_candidate(&token_ids);
         if let Some(max_model_len) = self.econfig.max_model_len {
@@ -710,6 +746,76 @@ impl LLMEngine {
             );
         }
         Ok((seq_id, prompt_length, rx))
+    }
+
+    /// Pretokenized variant of `add_request`. Caller has already done
+    /// tokenize (typically via `preprocess`) outside the engine write
+    /// lock, so the only work that needs `&mut self` is the scheduler-add.
+    pub fn add_request_pretokenized(
+        &mut self,
+        params: &SamplingParams,
+        prompt: &str,
+        token_ids: Vec<u32>,
+        request_type: RequestType,
+        images: &Option<ImageData>,
+        image_idx: i32,
+    ) -> Result<(usize, usize, Receiver<StreamItem>)> {
+        let (seq_id, prompt_length) = self.add_request_pretokenized_(
+            params,
+            prompt,
+            token_ids,
+            &request_type,
+            images,
+            image_idx,
+        )?;
+        let (tx, rx) = channel(1024);
+        self.stream_senders.insert(seq_id, tx);
+        self.request_types.insert(seq_id, request_type.clone());
+        if self.econfig.server_mode.unwrap_or(true) && request_type != RequestType::Completion {
+            log_warn!(
+                "[{:?}] New request [Seq_id {}, {} tokens] received! (session_id: {:?})\n",
+                request_type,
+                seq_id,
+                prompt_length,
+                params.session_id,
+            );
+        }
+        Ok((seq_id, prompt_length, rx))
+    }
+
+    /// Apply chat template + tokenize each `(params, messages)` pair under
+    /// shared access (`&self`) so N concurrent server handlers can run this
+    /// in parallel under their own `engine.read()` guards. Returns a list
+    /// of `PreprocessedRequest`s that feed `generate_sync_from_preprocessed`
+    /// or `generate_stream_from_preprocessed`, which acquire `engine.write()`
+    /// only briefly for the scheduler-add step.
+    pub fn preprocess(
+        &self,
+        params: &[SamplingParams],
+        message_list: &[Vec<Message>],
+        tools: &[Tool],
+        log: bool,
+    ) -> Result<Vec<PreprocessedRequest>> {
+        if params.len() != message_list.len() {
+            candle_core::bail!("size of sampling parameters is not match with size of prompts!");
+        }
+        let tools_vec: Vec<Tool> = tools.to_vec();
+        let mut out = Vec::with_capacity(params.len());
+        for (param, messages) in params.iter().zip(message_list.iter()) {
+            let (prompt, image_idx) = self.apply_chat_template(param, messages, &tools_vec, log);
+            let tokens = self
+                .tokenizer
+                .encode_fast(prompt.as_str(), true)
+                .expect("encode failed!");
+            let token_ids: Vec<u32> = tokens.get_ids().to_vec();
+            out.push(PreprocessedRequest {
+                params: param.clone(),
+                prompt,
+                image_idx,
+                token_ids,
+            });
+        }
+        Ok(out)
     }
 
     pub fn get_num_cached_tokens(&self) -> usize {
@@ -1230,8 +1336,8 @@ impl LLMEngine {
         has_requests_to_cancel
     }
 
-    fn apply_chat_template(
-        &mut self,
+    pub fn apply_chat_template(
+        &self,
         params: &SamplingParams,
         messages: &Vec<Message>,
         tools: &Vec<Tool>,
@@ -1315,6 +1421,35 @@ impl LLMEngine {
             }
         }
 
+        Ok(receivers)
+    }
+
+    /// Lock-shrunk equivalent of `generate_sync`. The caller has already
+    /// run `preprocess(...)` (chat template + tokenize) under a brief
+    /// `engine.read()` guard, so this method only needs the engine write
+    /// lock for the scheduler-add step.
+    pub fn generate_sync_from_preprocessed(
+        &mut self,
+        preprocessed: Vec<PreprocessedRequest>,
+        images: Option<ImageData>,
+        logger: &Option<Arc<ChatCompletionLogger>>,
+    ) -> Result<Vec<(usize, usize, mpsc::Receiver<StreamItem>)>> {
+        let mut receivers = Vec::with_capacity(preprocessed.len());
+        for pp in preprocessed {
+            if let Some(ref l) = logger {
+                l.log_prompt(&pp.prompt);
+            }
+            if let Ok((seq_id, prompt_length, rx)) = self.add_request_pretokenized(
+                &pp.params,
+                &pp.prompt,
+                pp.token_ids,
+                RequestType::Completion,
+                &images,
+                pp.image_idx,
+            ) {
+                receivers.push((seq_id, prompt_length, rx));
+            }
+        }
         Ok(receivers)
     }
 
@@ -1480,6 +1615,36 @@ impl LLMEngine {
         }
     }
 
+    /// Lock-shrunk equivalent of `generate_stream`. Takes a single
+    /// already-preprocessed request and registers it under `engine.write()`
+    /// briefly for the scheduler-add step only.
+    pub fn generate_stream_from_preprocessed(
+        &mut self,
+        preprocessed: PreprocessedRequest,
+        images: Option<ImageData>,
+        logger: &Option<Arc<ChatCompletionLogger>>,
+    ) -> Result<(usize, usize, Option<String>, mpsc::Receiver<StreamItem>)> {
+        if let Some(ref l) = logger {
+            l.log_prompt(&preprocessed.prompt);
+        }
+        match self.add_request_pretokenized(
+            &preprocessed.params,
+            &preprocessed.prompt,
+            preprocessed.token_ids,
+            RequestType::Stream,
+            &images,
+            preprocessed.image_idx,
+        ) {
+            Ok((seq_id, prompt_length, rx)) => {
+                let prefilled_reasoning_end = self.get_prefilled_reasoning_end_marker(seq_id);
+                Ok((seq_id, prompt_length, prefilled_reasoning_end, rx))
+            }
+            Err(e) => {
+                candle_core::bail!("{:?}", e)
+            }
+        }
+    }
+
     pub fn get_usage_stats(&self, session_id: Option<String>) -> Result<UsageResponse> {
         match session_id {
             Some(sid) => {
@@ -1533,7 +1698,7 @@ impl LLMEngine {
                 .tokenizer
                 .encode_fast(input.as_str(), true)
                 .map_err(candle_core::Error::wrap)?;
-            let token_ids: Vec<u32> = tokens.get_ids().iter().copied().collect();
+            let token_ids: Vec<u32> = tokens.get_ids().to_vec();
             if token_ids.is_empty() {
                 candle_core::bail!("Embedding input cannot be empty");
             }

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -779,8 +779,8 @@ impl LLMEngine {
     /// Apply chat template + tokenize each `(params, messages)` pair under
     /// shared access (`&self`) so N concurrent server handlers can run this
     /// in parallel under their own `engine.read()` guards. Returns a list
-    /// of `PreprocessedRequest`s that feed `generate_sync_from_preprocessed`
-    /// or `generate_stream_from_preprocessed`, which acquire `engine.write()`
+    /// of `PreprocessedRequest`s that feed `generate_sync`
+    /// or `generate_stream`, which acquire `engine.write()`
     /// only briefly for the scheduler-add step.
     pub fn preprocess(
         &self,
@@ -1390,38 +1390,10 @@ impl LLMEngine {
         }
     }
 
+    /// Registers preprocessed completion requests. Callers should run
+    /// `preprocess(...)` under `engine.read()` first, then call this under
+    /// `engine.write()` so the write lock is held only for request admission.
     pub fn generate_sync(
-        &mut self,
-        params: &Vec<SamplingParams>,
-        message_list: &Vec<Vec<Message>>,
-        images: Option<ImageData>,
-        tools: &Vec<Tool>,
-        logger: &Option<Arc<ChatCompletionLogger>>,
-    ) -> Result<Vec<(usize, usize, mpsc::Receiver<StreamItem>)>> {
-        if params.len() != message_list.len() {
-            candle_core::bail!("size of sampling parameters is not match with size of prompts!");
-        }
-        let mut receivers = Vec::new();
-        for (param, messages) in params.iter().zip(message_list.iter()) {
-            let (prompt, image_idx) = self.apply_chat_template(param, messages, tools, false);
-            if let Some(ref l) = logger {
-                l.log_prompt(&prompt);
-            }
-            if let Ok((seq_id, prompt_length, rx)) =
-                self.add_request(param, &prompt, RequestType::Completion, &images, image_idx)
-            {
-                receivers.push((seq_id, prompt_length, rx));
-            }
-        }
-
-        Ok(receivers)
-    }
-
-    /// Lock-shrunk equivalent of `generate_sync`. The caller has already
-    /// run `preprocess(...)` (chat template + tokenize) under a brief
-    /// `engine.read()` guard, so this method only needs the engine write
-    /// lock for the scheduler-add step.
-    pub fn generate_sync_from_preprocessed(
         &mut self,
         preprocessed: Vec<PreprocessedRequest>,
         images: Option<ImageData>,
@@ -1585,33 +1557,10 @@ impl LLMEngine {
         self.seq_prefilled_reasoning_end.get(&seq_id).cloned()
     }
 
+    /// Registers a preprocessed streaming request. Callers should run
+    /// `preprocess(...)` under `engine.read()` first, then call this under
+    /// `engine.write()` so the write lock is held only for request admission.
     pub fn generate_stream(
-        &mut self,
-        params: &SamplingParams,
-        messages: &Vec<Message>,
-        images: Option<ImageData>, //collection of images of the full conversation
-        tools: &Vec<Tool>,
-        logger: &Option<Arc<ChatCompletionLogger>>,
-    ) -> Result<(usize, usize, Option<String>, mpsc::Receiver<StreamItem>)> {
-        let (prompt, image_idx) = self.apply_chat_template(params, messages, tools, false);
-        if let Some(ref l) = logger {
-            l.log_prompt(&prompt);
-        }
-        match self.add_request(params, &prompt, RequestType::Stream, &images, image_idx) {
-            Ok((seq_id, prompt_length, rx)) => {
-                let prefilled_reasoning_end = self.get_prefilled_reasoning_end_marker(seq_id);
-                Ok((seq_id, prompt_length, prefilled_reasoning_end, rx))
-            }
-            Err(e) => {
-                candle_core::bail!("{:?}", e)
-            }
-        }
-    }
-
-    /// Lock-shrunk equivalent of `generate_stream`. Takes a single
-    /// already-preprocessed request and registers it under `engine.write()`
-    /// briefly for the scheduler-add step only.
-    pub fn generate_stream_from_preprocessed(
         &mut self,
         preprocessed: PreprocessedRequest,
         images: Option<ImageData>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -359,7 +359,7 @@ async fn main() -> Result<()> {
                 };
                 let (seq_id, prompt_length, _prefilled_reasoning_end, stream) = {
                     let mut e = engine.write();
-                    match e.generate_stream_from_preprocessed(preprocessed, None, &None) {
+                    match e.generate_stream(preprocessed, None, &None) {
                         Ok((seq_id, prompt_length, prefilled_reasoning_end, stream)) => {
                             (seq_id, prompt_length, prefilled_reasoning_end, stream)
                         }
@@ -453,7 +453,7 @@ async fn main() -> Result<()> {
                 };
                 let receivers = {
                     let mut e = engine.write();
-                    e.generate_sync_from_preprocessed(preprocessed, None, &None)?
+                    e.generate_sync(preprocessed, None, &None)?
                 };
                 let results = LLMEngine::collect_sync_results(receivers, tokenizer, None).await?;
                 // GenerationOutput is returned directly

--- a/src/main.rs
+++ b/src/main.rs
@@ -345,15 +345,21 @@ async fn main() -> Result<()> {
 
         let mut outputs = {
             if interactive {
+                let preprocessed = {
+                    let e = engine.read();
+                    let mut p = e
+                        .preprocess(
+                            std::slice::from_ref(&request_params),
+                            std::slice::from_ref(&chat_history),
+                            &Vec::new(),
+                            false,
+                        )
+                        .expect("preprocess failed");
+                    p.pop().expect("preprocess returned 0 items for 1 input")
+                };
                 let (seq_id, prompt_length, _prefilled_reasoning_end, stream) = {
                     let mut e = engine.write();
-                    match e.generate_stream(
-                        &request_params,
-                        &chat_history,
-                        None,
-                        &Vec::new(),
-                        &None,
-                    ) {
+                    match e.generate_stream_from_preprocessed(preprocessed, None, &None) {
                         Ok((seq_id, prompt_length, prefilled_reasoning_end, stream)) => {
                             (seq_id, prompt_length, prefilled_reasoning_end, stream)
                         }
@@ -438,12 +444,16 @@ async fn main() -> Result<()> {
             } else {
                 xinfer::log_warn!("Starting the inference...");
 
-                let (receivers, tokenizer) = {
-                    let mut e = engine.write();
+                let (preprocessed, tokenizer) = {
+                    let e = engine.read();
                     (
-                        e.generate_sync(&params, &message_list, None, &Vec::new(), &None)?,
+                        e.preprocess(&params, &message_list, &Vec::new(), false)?,
                         Arc::new(e.tokenizer.clone()),
                     )
+                };
+                let receivers = {
+                    let mut e = engine.write();
+                    e.generate_sync_from_preprocessed(preprocessed, None, &None)?
                 };
                 let results = LLMEngine::collect_sync_results(receivers, tokenizer, None).await?;
                 // GenerationOutput is returned directly

--- a/src/py/mod.rs
+++ b/src/py/mod.rs
@@ -91,10 +91,7 @@ impl Engine {
                     engine
                         .generate_sync(preprocessed, None, &None)
                         .map_err(|e| {
-                            PyValueError::new_err(format!(
-                                "generate_sync failed: {:?}",
-                                e
-                            ))
+                            PyValueError::new_err(format!("generate_sync failed: {:?}", e))
                         })?
                 };
 

--- a/src/py/mod.rs
+++ b/src/py/mod.rs
@@ -75,16 +75,27 @@ impl Engine {
     ) -> PyResult<Vec<GenerationOutput>> {
         tokio::task::block_in_place(|| {
             GLOBAL_RT.block_on(async {
-                let (receivers, tokenizer) = {
-                    let mut engine = self.engine.write();
+                let (preprocessed, tokenizer) = {
+                    let engine = self.engine.read();
                     (
                         engine
-                            .generate_sync(&params, &message_list, None, &Vec::new(), &None)
+                            .preprocess(&params, &message_list, &Vec::new(), false)
                             .map_err(|e| {
-                                PyValueError::new_err(format!("generate_sync failed: {:?}", e))
+                                PyValueError::new_err(format!("preprocess failed: {:?}", e))
                             })?,
                         Arc::new(engine.tokenizer.clone()),
                     )
+                };
+                let receivers = {
+                    let mut engine = self.engine.write();
+                    engine
+                        .generate_sync_from_preprocessed(preprocessed, None, &None)
+                        .map_err(|e| {
+                            PyValueError::new_err(format!(
+                                "generate_sync_from_preprocessed failed: {:?}",
+                                e
+                            ))
+                        })?
                 };
 
                 let results = LLMEngine::collect_sync_results(receivers, tokenizer, None)
@@ -107,10 +118,23 @@ impl Engine {
         params: SamplingParams,
         messages: Vec<Message>,
     ) -> PyResult<(usize, usize, EngineStream)> {
+        let preprocessed = {
+            let engine = self.engine.read();
+            let mut p = engine
+                .preprocess(
+                    std::slice::from_ref(&params),
+                    std::slice::from_ref(&messages),
+                    &Vec::new(),
+                    false,
+                )
+                .map_err(|e| PyValueError::new_err(format!("preprocess error: {:?}", e)))?;
+            p.pop()
+                .ok_or_else(|| PyValueError::new_err("preprocess returned 0 items"))?
+        };
         let (seq_id, prompt_length, _prefilled_reasoning_end, stream) = {
             let mut engine = self.engine.write();
             engine
-                .generate_stream(&params, &messages, None, &Vec::new(), &None)
+                .generate_stream_from_preprocessed(preprocessed, None, &None)
                 .map_err(|e| PyValueError::new_err(format!("stream error: {:?}", e)))?
         };
 

--- a/src/py/mod.rs
+++ b/src/py/mod.rs
@@ -89,10 +89,10 @@ impl Engine {
                 let receivers = {
                     let mut engine = self.engine.write();
                     engine
-                        .generate_sync_from_preprocessed(preprocessed, None, &None)
+                        .generate_sync(preprocessed, None, &None)
                         .map_err(|e| {
                             PyValueError::new_err(format!(
-                                "generate_sync_from_preprocessed failed: {:?}",
+                                "generate_sync failed: {:?}",
                                 e
                             ))
                         })?
@@ -134,7 +134,7 @@ impl Engine {
         let (seq_id, prompt_length, _prefilled_reasoning_end, stream) = {
             let mut engine = self.engine.write();
             engine
-                .generate_stream_from_preprocessed(preprocessed, None, &None)
+                .generate_stream(preprocessed, None, &None)
                 .map_err(|e| PyValueError::new_err(format!("stream error: {:?}", e)))?
         };
 

--- a/src/server/claude_server.rs
+++ b/src/server/claude_server.rs
@@ -2165,9 +2165,32 @@ pub async fn messages(
     };
 
     if use_stream {
+        let preprocessed = {
+            let e = data.engine.read();
+            match e.preprocess(
+                std::slice::from_ref(&params),
+                std::slice::from_ref(&messages),
+                &resolved_tools,
+                false,
+            ) {
+                Ok(mut p) => p.pop().expect("preprocess returned 0 items for 1 input"),
+                Err(err) => {
+                    return ClaudeResponder::Error(
+                        ClaudeErrorResponse {
+                            response_type: "error",
+                            error: ClaudeErrorBody {
+                                error_type: "invalid_request_error".to_string(),
+                                message: format!("Stream preprocess failed: {err:?}"),
+                            },
+                        },
+                        StatusCode::UNPROCESSABLE_ENTITY,
+                    );
+                }
+            }
+        };
         let (seq_id, prompt_length, prefilled_reasoning_end, stream) = {
             let mut e = data.engine.write();
-            match e.generate_stream(&params, &messages, image_data, &resolved_tools, &logger) {
+            match e.generate_stream_from_preprocessed(preprocessed, image_data, &logger) {
                 Ok((seq_id, prompt_length, prefilled_reasoning_end, stream)) => {
                     (seq_id, prompt_length, prefilled_reasoning_end, stream)
                 }
@@ -3091,15 +3114,32 @@ pub async fn messages(
             Arc::new(e.tokenizer.clone())
         };
 
+        let preprocessed = {
+            let e = data.engine.read();
+            match e.preprocess(
+                std::slice::from_ref(&params),
+                std::slice::from_ref(&messages),
+                &resolved_tools,
+                false,
+            ) {
+                Ok(p) => p,
+                Err(err) => {
+                    return ClaudeResponder::Error(
+                        ClaudeErrorResponse {
+                            response_type: "error",
+                            error: ClaudeErrorBody {
+                                error_type: "server_error".to_string(),
+                                message: format!("Preprocess failed: {err:?}"),
+                            },
+                        },
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                    );
+                }
+            }
+        };
         let receivers = {
             let mut e = data.engine.write();
-            match e.generate_sync(
-                &vec![params],
-                &vec![messages],
-                image_data,
-                &resolved_tools,
-                &logger,
-            ) {
+            match e.generate_sync_from_preprocessed(preprocessed, image_data, &logger) {
                 Ok(receivers) => receivers,
                 Err(err) => {
                     return ClaudeResponder::Error(

--- a/src/server/claude_server.rs
+++ b/src/server/claude_server.rs
@@ -2190,7 +2190,7 @@ pub async fn messages(
         };
         let (seq_id, prompt_length, prefilled_reasoning_end, stream) = {
             let mut e = data.engine.write();
-            match e.generate_stream_from_preprocessed(preprocessed, image_data, &logger) {
+            match e.generate_stream(preprocessed, image_data, &logger) {
                 Ok((seq_id, prompt_length, prefilled_reasoning_end, stream)) => {
                     (seq_id, prompt_length, prefilled_reasoning_end, stream)
                 }
@@ -3139,7 +3139,7 @@ pub async fn messages(
         };
         let receivers = {
             let mut e = data.engine.write();
-            match e.generate_sync_from_preprocessed(preprocessed, image_data, &logger) {
+            match e.generate_sync(preprocessed, image_data, &logger) {
                 Ok(receivers) => receivers,
                 Err(err) => {
                     return ClaudeResponder::Error(

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -522,7 +522,7 @@ pub async fn chat_completion(
         };
         let (seq_id, prompt_length, prefilled_reasoning_end, stream) = {
             let mut e = data.engine.write();
-            match e.generate_stream_from_preprocessed(preprocessed, image_data, &logger) {
+            match e.generate_stream(preprocessed, image_data, &logger) {
                 Ok((seq_id, prompt_length, prefilled_reasoning_end, stream)) => {
                     (seq_id, prompt_length, prefilled_reasoning_end, stream)
                 }
@@ -1195,7 +1195,7 @@ pub async fn chat_completion(
         };
         let receivers = {
             let mut e = data.engine.write();
-            match e.generate_sync_from_preprocessed(preprocessed, image_data, &logger) {
+            match e.generate_sync(preprocessed, image_data, &logger) {
                 Ok(receivers) => receivers,
                 Err(e) => {
                     crate::log_error!("Completion generation failed: {:?}", e);

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -502,9 +502,27 @@ pub async fn chat_completion(
         if let Some(sid) = session_id {
             crate::log_warn!("Stream request has session_id {sid}");
         }
+        let preprocessed = {
+            let e = data.engine.read();
+            match e.preprocess(
+                std::slice::from_ref(&params),
+                std::slice::from_ref(&messages),
+                &resolved_tools,
+                false,
+            ) {
+                Ok(mut p) => p.pop().expect("preprocess returned 0 items for 1 input"),
+                Err(e) => {
+                    crate::log_error!("Stream preprocess failed: {:?}", e);
+                    return ChatResponder::ValidationError(format!(
+                        "Stream preprocess failed: {:?}",
+                        e
+                    ));
+                }
+            }
+        };
         let (seq_id, prompt_length, prefilled_reasoning_end, stream) = {
             let mut e = data.engine.write();
-            match e.generate_stream(&params, &messages, image_data, &resolved_tools, &logger) {
+            match e.generate_stream_from_preprocessed(preprocessed, image_data, &logger) {
                 Ok((seq_id, prompt_length, prefilled_reasoning_end, stream)) => {
                     (seq_id, prompt_length, prefilled_reasoning_end, stream)
                 }
@@ -1160,15 +1178,24 @@ pub async fn chat_completion(
             "Received completion request with {} messages",
             messages.len()
         );
+        let preprocessed = {
+            let e = data.engine.read();
+            match e.preprocess(
+                std::slice::from_ref(&current_params),
+                std::slice::from_ref(&messages),
+                &resolved_tools,
+                false,
+            ) {
+                Ok(p) => p,
+                Err(e) => {
+                    crate::log_error!("Preprocess failed: {:?}", e);
+                    return ChatResponder::InternalError(format!("Internal server error {:?}", e));
+                }
+            }
+        };
         let receivers = {
             let mut e = data.engine.write();
-            match e.generate_sync(
-                &vec![current_params.clone()],
-                &vec![messages],
-                image_data,
-                &resolved_tools,
-                &logger,
-            ) {
+            match e.generate_sync_from_preprocessed(preprocessed, image_data, &logger) {
                 Ok(receivers) => receivers,
                 Err(e) => {
                     crate::log_error!("Completion generation failed: {:?}", e);

--- a/tests/preprocess_parity.rs
+++ b/tests/preprocess_parity.rs
@@ -1,0 +1,193 @@
+//! Integration test: `LLMEngine::preprocess` is byte-identical to the
+//! canonical `apply_chat_template + tokenizer.encode_fast` path that
+//! `add_request_` (and through it, `generate_sync` / `generate_stream`)
+//! has used in the engine.
+//!
+//! Without this guard, future tweaks to either method could silently drift
+//! and the bench would be the only signal — too coarse to catch a
+//! tokenize-mismatch bug.
+//!
+//! This is a real engine spin-up; it downloads `Qwen/Qwen3-0.6B` if not
+//! cached and loads it on the device set by `XINFER_TEST_DEVICE`
+//! (default `0`). It's gated behind `XINFER_INTEGRATION_TEST=1` so the
+//! ordinary `cargo test` flow doesn't pull a model.
+//!
+//! Run with:
+//!   XINFER_INTEGRATION_TEST=1 cargo test --release \
+//!     --no-default-features --features metal --test preprocess_parity
+//!
+//! (Swap `--features metal` for `--features "cuda nccl"` on Linux/CUDA.)
+
+use candle_core::DType;
+
+use xinfer::core::engine::LLMEngine;
+use xinfer::utils::chat_template::Message;
+use xinfer::utils::config::{EngineConfig, SamplingParams};
+
+fn integration_enabled() -> bool {
+    std::env::var("XINFER_INTEGRATION_TEST")
+        .map(|v| v == "1")
+        .unwrap_or(false)
+}
+
+fn build_econfig() -> EngineConfig {
+    let device_id: usize = std::env::var("XINFER_TEST_DEVICE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    EngineConfig::new(
+        Some("Qwen/Qwen3-0.6B".to_string()), // model_id
+        None,                                // weight_path
+        None,                                // weight_file
+        None,                                // hf_token
+        None,                                // hf_token_path
+        None,                                // enforce_parser
+        Some(1),                             // max_num_seqs — minimal
+        None,                                // config_model_len
+        Some(2048),                          // max_model_len — small
+        Some(8),                             // max_tokens
+        None,                                // isq
+        Some(1),                             // num_shards
+        Some(vec![device_id]),               // device_ids
+        None,                                // generation_cfg
+        Some(0),                             // seed
+        false,                               // disable_prefix_cache
+        None,                                // prefix_cache_max_tokens
+        None,                                // kvcache_dtype
+        Some(false),                         // server_mode — drive engine directly
+        None,                                // cpu_mem_fold
+        None,                                // kv_fraction
+        None,                                // mamba_fraction
+        None,                                // pd_config
+        None,                                // mcp_command
+        None,                                // mcp_config
+        None,                                // mcp_args
+        None,                                // tool_prompt_template
+        None,                                // pd_server_prefix_cache_ratio
+        None,                                // pd_client_prefix_cache_ratio
+        None,                                // yarn_scaling_factor
+        true,                                // disable_reasoning — deterministic prompt
+        false,                               // disable_cuda_graph
+        None,                                // prefill_chunk_size — default
+    )
+}
+
+fn sample_inputs() -> (Vec<SamplingParams>, Vec<Vec<Message>>) {
+    // Three deliberately varied conversations to exercise (a) trivial
+    // single-user, (b) multi-turn user/assistant alternation, and (c)
+    // long content that should produce many tokens.
+    let params = vec![
+        SamplingParams::new_with_max_tokens(8),
+        SamplingParams::new_with_max_tokens(8),
+        SamplingParams::new_with_max_tokens(8),
+    ];
+
+    let long =
+        "the rapid evolution of large language model inference engines on heterogeneous hardware. "
+            .repeat(20);
+
+    let message_list = vec![
+        vec![Message::new(
+            "user".to_string(),
+            "What is the capital of France?".to_string(),
+            0,
+        )],
+        vec![
+            Message::new("user".to_string(), "Tell me about the moon.".to_string(), 0),
+            Message::new(
+                "assistant".to_string(),
+                "The moon is Earth's natural satellite.".to_string(),
+                0,
+            ),
+            Message::new("user".to_string(), "How far away is it?".to_string(), 0),
+        ],
+        vec![Message::new("user".to_string(), long, 0)],
+    ];
+
+    (params, message_list)
+}
+
+#[test]
+fn preprocess_is_byte_identical_to_apply_chat_template_plus_tokenize() {
+    if !integration_enabled() {
+        eprintln!(
+            "Skipping: set XINFER_INTEGRATION_TEST=1 to enable (downloads Qwen3-0.6B, ~1.2GB)"
+        );
+        return;
+    }
+    eprintln!("[integration] preprocess_parity: spinning up LLMEngine");
+
+    let econfig = build_econfig();
+    let engine = LLMEngine::new(&econfig, DType::BF16).expect("LLMEngine::new failed");
+    let engine = engine.read();
+
+    let (params, message_list) = sample_inputs();
+    let tools: Vec<xinfer::tools::Tool> = vec![];
+
+    // ----- Path A: new preprocess() -----
+    let preprocessed = engine
+        .preprocess(&params, &message_list, &tools, false)
+        .expect("preprocess failed");
+
+    assert_eq!(
+        preprocessed.len(),
+        params.len(),
+        "preprocess returned a different count than input"
+    );
+
+    // ----- Path B: canonical apply_chat_template + tokenizer.encode_fast -----
+    for (idx, (param, messages)) in params.iter().zip(message_list.iter()).enumerate() {
+        let (expected_prompt, expected_image_idx) =
+            engine.apply_chat_template(param, messages, &tools, false);
+        let expected_tokens = engine
+            .tokenizer
+            .encode_fast(expected_prompt.as_str(), true)
+            .expect("expected tokenize failed");
+        let expected_token_ids: Vec<u32> = expected_tokens.get_ids().to_vec();
+
+        let pp = &preprocessed[idx];
+
+        assert_eq!(
+            pp.prompt, expected_prompt,
+            "rendered prompt mismatch on row {}",
+            idx
+        );
+        assert_eq!(
+            pp.image_idx, expected_image_idx,
+            "image_idx mismatch on row {}",
+            idx
+        );
+        assert_eq!(
+            pp.token_ids, expected_token_ids,
+            "token_ids mismatch on row {} — preprocess refactor is no longer byte-identical",
+            idx
+        );
+        assert!(
+            !pp.token_ids.is_empty(),
+            "row {} produced empty token_ids",
+            idx
+        );
+    }
+}
+
+#[test]
+fn preprocess_rejects_size_mismatch() {
+    if !integration_enabled() {
+        eprintln!("Skipping: set XINFER_INTEGRATION_TEST=1 to enable");
+        return;
+    }
+
+    let econfig = build_econfig();
+    let engine = LLMEngine::new(&econfig, DType::BF16).expect("LLMEngine::new failed");
+    let engine = engine.read();
+
+    let params = vec![SamplingParams::new_with_max_tokens(8)];
+    let message_list: Vec<Vec<Message>> = vec![]; // intentionally mismatched
+    let tools: Vec<xinfer::tools::Tool> = vec![];
+
+    let res = engine.preprocess(&params, &message_list, &tools, false);
+    assert!(
+        res.is_err(),
+        "preprocess should reject mismatched params/message_list lengths"
+    );
+}


### PR DESCRIPTION
Every OpenAI/Anthropic chat-completion handler in `server.rs`, `claude_server.rs`, `api.rs`, `main.rs`, and `py/mod.rs` was holding `engine.write()` for the full `generate_sync`/`generate_stream` call. Inside that call, `apply_chat_template + tokenize` is CPU work — 5–20 ms per request when the chat history is non-trivial. N concurrent server handlers therefore serialized on the write lock through that span before any GPU work could start.

This PR splits the path into two phases at every caller:

```rust
// before
let receivers = {
    let mut e = data.engine.write();
    e.generate_sync(&params, &messages, image_data, &tools, &logger)?  // chat-template + tokenize + scheduler-add, all under write
};

// after
let preprocessed = {
    let e = data.engine.read();                     // shared — N handlers concurrent
    e.preprocess(&params, &messages, &tools, false)?
};
let receivers = {
    let mut e = data.engine.write();                // brief — scheduler-add only
    e.generate_sync_from_preprocessed(preprocessed, image_data, &logger)?
};
```

`apply_chat_template` is `&mut self → &self` (it already cloned `self.template` internally; the `&mut` was a constraint without purpose).

## API additions

- `LLMEngine::preprocess(&self, ...) -> Result<Vec<PreprocessedRequest>>`
- `LLMEngine::generate_sync_from_preprocessed(&mut self, ...)`
- `LLMEngine::generate_stream_from_preprocessed(&mut self, ...)`
- `LLMEngine::add_request_pretokenized(&mut self, ...)`
- `pub struct PreprocessedRequest { params, prompt, image_idx, token_ids }`

`add_request_`, `add_request`, `generate_sync`, `generate_stream` unchanged.

## Benchmark

**Workload**: synthetic 100-message chat history (\`user\`/\`assistant\` alternating, ~60 words each), \`max_tokens=8\`, \`stream=false\`. Per-request JSON payload ~44 KB, renders to ~3500 tokens after chat template. Async \`httpx\` loadgen, sustained N concurrent connections, 5 trials per cell (median dropping cold-start), A100 80 GB.

| Model · topology   | conc | upstream qps | PR qps | **Δ qps** | upstream p99 ms | PR p99 ms | **Δ p99** |
|---|---:|---:|---:|---:|---:|---:|---:|
| Qwen3-8B · TP=1    |   8  | 10.49 | 13.61 | **+30%** |  1152 |   813 | **−29%** |
| Qwen3-8B · TP=1    |  16  | 11.55 | 14.35 | **+24%** |  1903 |  1318 | **−31%** |
| Qwen3-8B · TP=1    |  32  | 12.16 | 16.32 | **+34%** |  3800 |  2440 | **−36%** |
| Qwen3-8B · TP=1    |  64  | 12.26 | 16.53 | **+35%** |  7267 |  4514 | **−38%** |
| Qwen3-8B · TP=2    |   8  | 14.19 | 21.52 | **+52%** |   570 |   377 | **−34%** |
| Qwen3-8B · TP=2    |  16  | 15.11 | 22.10 | **+46%** |  1362 |   863 | **−37%** |
| Qwen3-8B · TP=2    |  32  | 15.30 | 23.94 | **+56%** |  2879 |  1576 | **−45%** |
| Qwen3-8B · TP=2    |  64  | 15.47 | 23.09 | **+49%** |  5958 |  3522 | **−41%** |
| Qwen3-32B · TP=2   |   8  |  5.83 |  6.70 | **+15%** |  1634 |  1338 | **−18%** |
| Qwen3-32B · TP=2   |  16  |  6.70 |  7.69 | **+15%** |  3170 |  2603 | **−18%** |
| Qwen3-32B · TP=2   |  32  |  7.01 |  8.17 | **+17%** |  5638 |  4364 | **−23%** |
| Qwen3-32B · TP=2   |  64  |  7.02 |  8.10 | **+15%** | 10729 |  8252 | **−23%** |

Gains are larger on TP=2 than TP=1 because NCCL coordination already adds write-lock pressure — lifting \`preprocess\` off the write lock compounds with it. Gains shrink on 32B because the forward pass takes a larger share of total wall (preprocess CPU stays the same per request → its relative impact drops).

Cells with short prompts (1-message conversations) show parity in both directions — preprocess is too cheap to dominate at those payloads.

## Compatibility

No behavioral change. \`preprocess()\` produces token IDs byte-identical to the inline path; verified by integration test.

## Tests

New \`tests/preprocess_parity.rs\` (gated behind \`XINFER_INTEGRATION_TEST=1\`) spins up a real \`LLMEngine\` with \`Qwen3-0.6B\` and asserts \`preprocess()\` returns \`(prompt, token_ids, image_idx)\` byte-identical to \`apply_chat_template()\` + \`tokenizer.encode_fast()\` on three sample inputs (single-user, multi-turn, long content). Also asserts \`preprocess()\` rejects size-mismatched inputs.

\`\`\`bash
XINFER_INTEGRATION_TEST=1 cargo test --release \\
  --no-default-features --features metal --test preprocess_parity
# (--features \"cuda nccl\" on Linux/CUDA)
\`\`\`

288 lib tests pass. \`cargo fmt\` clean, no new \`clippy\` warnings vs \`main\` baseline.

## Commits

1. \`engine: run chat-template + tokenize under read lock so concurrent server handlers don't serialize\`
2. \`tests: add preprocess_parity integration test\`