### PR TITLE
Add --server [host[:port]|unix]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ dirs = "5.0.1"
 base64 = "0.22.1"
 metal = { version = "0.27.0", features = ["mps"], optional = true }
 uuid = { version = "1.5.0", features = ["v4"] }
-axum = { version = "0.7.4", features = ["tokio"] }
+axum = { version = "0.8.9", features = ["tokio"] }
 flume = "0.10.14"
 utoipa = { version = "4.2", features = ["axum_extras"] }
 colored = { version = "3.0.0" }

--- a/ReadMe-CN.md
+++ b/ReadMe-CN.md
@@ -432,7 +432,7 @@ xinfer --m unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF \
 | `--f` | 单独使用时为本地 GGUF 文件；配合 `--m <model_id>` 时为远程 GGUF 文件名 |
 | `--d` | 设备 ID（如 `--d 0,1`） |
 | `--ui-server` | API 服务 + ChatGPT 风格内置 Web UI |
-| `--server` | 仅 API 服务（无 Web UI） |
+| `--server` | API 服务器。无参数：`0.0.0.0:8000`；或 `host[:port]`、`file:///path`、`socket:///path`、`unix:///path` |
 | `--i` | 交互式 CLI 对话 |
 | `--isq` | 即时量化：`q2k`、`q3k`、`q4k`、`q5k`、`q6k`、`q8_0` |
 | `--kvcache-dtype` | KV 缓存量化：`fp8`、`turbo8`、`turbo4`、`turbo3` |

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -437,7 +437,7 @@ Constraint-based generation via llguidance — Lark grammars, regex, JSON Schema
 | `--f` | Local GGUF file when used alone; remote GGUF filename when paired with `--m <model_id>` |
 | `--d` | Device IDs (e.g. `--d 0,1`) |
 | `--ui-server` | API server + built-in ChatGPT-style web UI |
-| `--server` | API server only (no web UI) |
+| `--server` | API server. Bare: `0.0.0.0:8000`; or `host[:port]`, `file:///path`, `socket:///path`, `unix:///path` |
 | `--i` | Interactive CLI chat |
 | `--isq` | On-the-fly quantization: `q2k`, `q3k`, `q4k`, `q5k`, `q6k`, `q8_0` |
 | `--kvcache-dtype` | KV cache quantization: `fp8`, `turbo8`, `turbo4`, `turbo3` |

--- a/src/api.rs
+++ b/src/api.rs
@@ -192,7 +192,9 @@ impl Engine {
             run_server(
                 self.engine.clone(),
                 self.econfig.clone(),
-                port,
+                crate::server::ServerAddr::Tcp(
+                    (std::net::Ipv4Addr::UNSPECIFIED, port as u16).into(),
+                ),
                 with_ui_server,
             )
             .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,9 +9,9 @@ use xinfer::core::engine::StreamItem;
 use xinfer::core::engine::GLOBAL_RT;
 use xinfer::core::{engine::LLMEngine, GenerationOutput};
 use xinfer::log_error;
-use xinfer::server::resolve_server_addr;
 use xinfer::server::run_server;
 use xinfer::server::Args;
+use xinfer::server::{ensure_server_bindings_or_exit, resolve_server_addr};
 use xinfer::transfer::{PdConfig, PdMethod, PdRole};
 use xinfer::utils::chat_template::Message;
 use xinfer::utils::config::GenerationConfig;
@@ -140,6 +140,15 @@ async fn main() -> Result<()> {
         candle_core::bail!("PD Server cannot run with UI Server enabled!");
     }
 
+    let server_addr = if server {
+        let default_port = if args.pd_server { 7000 } else { 8000 };
+        let addr = resolve_server_addr(&args.server, args.port, default_port)?;
+        ensure_server_bindings_or_exit(&addr, args.ui_server)?;
+        Some(addr)
+    } else {
+        None
+    };
+
     #[cfg(not(feature = "cuda"))]
     if (args.pd_server || args.pd_client) && args.pd_url.is_none() {
         candle_core::bail!("Non-CUDA platform does not support LocalIPC, please provide pd-url (e.g., 0.0.0.0:8100)!");
@@ -223,9 +232,7 @@ async fn main() -> Result<()> {
     );
 
     let engine = LLMEngine::new(&econfig, dtype)?;
-    if server {
-        // Resolve the address from --server and --port.
-        let addr = resolve_server_addr(&args.server, args.port)?;
+    if let Some(addr) = server_addr {
         run_server(engine.clone(), econfig.clone(), addr, args.ui_server).await?;
         return Ok(());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use xinfer::core::engine::StreamItem;
 use xinfer::core::engine::GLOBAL_RT;
 use xinfer::core::{engine::LLMEngine, GenerationOutput};
 use xinfer::log_error;
+use xinfer::server::resolve_server_addr;
 use xinfer::server::run_server;
 use xinfer::server::Args;
 use xinfer::transfer::{PdConfig, PdMethod, PdRole};
@@ -63,7 +64,7 @@ async fn main() -> Result<()> {
     };
 
     assert!(
-        !(interactive && (args.server || args.ui_server || args.pd_server)),
+        !(interactive && (!args.server.is_empty() || args.ui_server || args.pd_server)),
         "You selected both interactive and server mode, which is not valid!"
     );
 
@@ -79,7 +80,7 @@ async fn main() -> Result<()> {
         args.max_model_len
     };
 
-    let server = args.server
+    let server = !args.server.is_empty()
         || args.ui_server
         || args.pd_server
         || (!interactive && args.prompts.is_none() && args.batch.is_none());
@@ -221,19 +222,11 @@ async fn main() -> Result<()> {
         Some(args.prefill_chunk_size),
     );
 
-    let server_port = if server {
-        let port = args
-            .port
-            .unwrap_or(if args.pd_server { 7000 } else { 8000 });
-        xinfer::utils::ensure_port_free("0.0.0.0", port as u16);
-        Some(port)
-    } else {
-        None
-    };
-
     let engine = LLMEngine::new(&econfig, dtype)?;
-    if let Some(port) = server_port {
-        run_server(engine.clone(), econfig.clone(), port, args.ui_server).await?;
+    if server {
+        // Resolve the address from --server and --port.
+        let addr = resolve_server_addr(&args.server, args.port)?;
+        run_server(engine.clone(), econfig.clone(), addr, args.ui_server).await?;
         return Ok(());
     }
 

--- a/src/py/mod.rs
+++ b/src/py/mod.rs
@@ -53,7 +53,9 @@ impl Engine {
             run_server(
                 self.engine.clone(),
                 self.econfig.clone(),
-                port,
+                crate::server::ServerAddr::Tcp(
+                    (std::net::Ipv4Addr::UNSPECIFIED, port as u16).into(),
+                ),
                 with_ui_server,
             )
             .await

--- a/src/server/claude_server.rs
+++ b/src/server/claude_server.rs
@@ -15,7 +15,7 @@ use axum::{
     extract::{Json, State},
     http::StatusCode,
     response::{
-        sse::{Event, KeepAlive},
+        sse::{Event, KeepAlive, KeepAliveStream},
         IntoResponse, Sse,
     },
 };
@@ -368,7 +368,7 @@ pub struct ClaudeErrorBody {
 }
 
 pub enum ClaudeResponder {
-    Streamer(Sse<ClaudeStreamer>),
+    Streamer(Sse<KeepAliveStream<ClaudeStreamer>>),
     Message(ClaudeMessageResponse),
     TokenCount(ClaudeTokenCountResponse),
     Error(ClaudeErrorResponse, StatusCode),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -28,9 +28,9 @@ use candle_core::{Result, Tensor};
 use colored::*;
 use local_ip_address::{local_ip, local_ipv6};
 use parking_lot::RwLock;
+use regex::Regex;
 use rustchatui::start_ui_server;
 use serde_json::json;
-use regex::Regex;
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs};
 use std::path::Path;
@@ -1424,15 +1424,34 @@ pub fn build_messages_and_images(
 }
 
 /// Represents either a TCP socket address or a Unix socket path for the API server.
+#[derive(Debug, Clone)]
 pub enum ServerAddr {
     Tcp(SocketAddr),
     Unix(std::path::PathBuf),
 }
 
+pub fn validate_tcp_port(port: usize, source: &str) -> candle_core::Result<u16> {
+    u16::try_from(port).map_err(|_| {
+        candle_core::Error::Msg(format!("{source} must be between 0 and 65535, got {port}."))
+    })
+}
+
 /// Convert raw `--server` and `--port` values into a `ServerAddr`.
-pub fn resolve_server_addr(server: &str, port: Option<usize>) -> candle_core::Result<ServerAddr> {
+pub fn resolve_server_addr(
+    server: &str,
+    port: Option<usize>,
+    default_port: u16,
+) -> candle_core::Result<ServerAddr> {
+    let port_arg = port.map(|po| validate_tcp_port(po, "--port")).transpose()?;
+
     // Unix socket URIs → extract path
-    if ["file://", "socket://", "unix://"].iter().any(|p| server.starts_with(*p)) {
+    if ["file://", "socket://", "unix://"]
+        .iter()
+        .any(|p| server.starts_with(*p))
+    {
+        if port_arg.is_some() {
+            candle_core::bail!("--port can only be used with TCP --server bindings.");
+        }
         let Ok(srv_url) = Url::parse(server) else {
             candle_core::bail!("Cannot parse --server socket path.");
         };
@@ -1440,11 +1459,13 @@ pub fn resolve_server_addr(server: &str, port: Option<usize>) -> candle_core::Re
     }
 
     // Url::parse doesn't handle bare ip6 addresses
-    let is_bare_ip6 = !server.contains('[')
-        && server.matches(':').count() - server.matches("://").count() > 1;
+    let is_bare_ip6 =
+        !server.contains('[') && server.matches(':').count() - server.matches("://").count() > 1;
 
     // bare ip6 cannot contain port
-    let brc_ip = if !is_bare_ip6 {server.to_string()} else {
+    let brc_ip = if !is_bare_ip6 {
+        server.to_string()
+    } else {
         let shr = Regex::new(r"^(?<s>(?:\w+://)?)(?<h>.*)$").unwrap();
         shr.replace(server, "$s[$h]").to_string()
     };
@@ -1461,28 +1482,126 @@ pub fn resolve_server_addr(server: &str, port: Option<usize>) -> candle_core::Re
         candle_core::bail!("Cannot parse --server value as address.");
     };
 
-    let Some(h) = srv_addr_url.host_str().map(|s| s.trim_start_matches('[').trim_end_matches(']')) else {
+    let Some(h) = srv_addr_url
+        .host_str()
+        .map(|s| s.trim_start_matches('[').trim_end_matches(']'))
+    else {
         candle_core::bail!("No host in --server value.");
     };
 
-    let p = srv_addr_url.port().map(|p| p as u16).unwrap_or(port.unwrap_or(8000) as u16);
+    let p = srv_addr_url
+        .port()
+        .unwrap_or(port_arg.unwrap_or(default_port));
 
-    if port.is_some_and(|po| p != po as u16) {
-        candle_core::bail!("--server host:{p} and --port {} are both given and don't agree.", port.unwrap());
+    if port_arg.is_some_and(|po| p != po) {
+        candle_core::bail!(
+            "--server host:{p} and --port {} are both given and don't agree.",
+            port_arg.unwrap()
+        );
     }
 
     // Resolve hostname to a socket address.
     let sock_addr = (h, p)
         .to_socket_addrs()
-        .map_err(|e| {
-            candle_core::Error::Msg(format!("Failed to resolve '{h}': {e}"))
-        })?
+        .map_err(|e| candle_core::Error::Msg(format!("Failed to resolve '{h}': {e}")))?
         .next()
-        .ok_or_else(|| {
-            candle_core::Error::Msg(format!("No addresses resolved for '{h}'"))
-        })?;
+        .ok_or_else(|| candle_core::Error::Msg(format!("No addresses resolved for '{h}'")))?;
 
     Ok(ServerAddr::Tcp(sock_addr))
+}
+
+/// Check that the normal API server bind target is available before loading a model.
+pub fn ensure_server_addr_available(addr: &ServerAddr) -> candle_core::Result<()> {
+    match addr {
+        ServerAddr::Tcp(sock_addr) => {
+            std::net::TcpListener::bind(sock_addr).map_err(|e| {
+                candle_core::Error::Msg(format!(
+                    "Address {sock_addr} is already in use ({e}). Free the address or choose a different one with --server host:port."
+                ))
+            })?;
+        }
+        ServerAddr::Unix(path) => {
+            let listener = std::os::unix::net::UnixListener::bind(path).map_err(|e| {
+                candle_core::Error::Msg(format!(
+                    "Unix socket {} is not available ({e}). Free the path or choose a different one with --server unix:///path.",
+                    path.display()
+                ))
+            })?;
+            drop(listener);
+            std::fs::remove_file(path).map_err(|e| {
+                candle_core::Error::Msg(format!(
+                    "Failed to clean up temporary Unix socket check at {} ({e}).",
+                    path.display()
+                ))
+            })?;
+        }
+    }
+    Ok(())
+}
+
+/// Check API and optional UI bind targets before loading a model.
+pub fn ensure_server_bindings_available(
+    addr: &ServerAddr,
+    with_ui_server: bool,
+) -> candle_core::Result<()> {
+    if with_ui_server {
+        let ServerAddr::Tcp(sock_addr) = addr else {
+            candle_core::bail!("--ui-server is not supported with Unix sockets.");
+        };
+        ensure_server_addr_available(addr)?;
+        let ui_port = sock_addr.port().checked_add(1).ok_or_else(|| {
+            candle_core::Error::Msg(
+                "Cannot start UI server because API port 65535 has no following UI port."
+                    .to_string(),
+            )
+        })?;
+        let ui_addr = ServerAddr::Tcp(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), ui_port));
+        ensure_server_addr_available(&ui_addr)?;
+    } else {
+        ensure_server_addr_available(addr)?;
+    }
+
+    Ok(())
+}
+
+/// CLI preflight that preserves the historical immediate-exit behavior for occupied TCP ports.
+pub fn ensure_server_bindings_or_exit(
+    addr: &ServerAddr,
+    with_ui_server: bool,
+) -> candle_core::Result<()> {
+    if with_ui_server && matches!(addr, ServerAddr::Unix(_)) {
+        candle_core::bail!("--ui-server is not supported with Unix sockets.");
+    }
+
+    match addr {
+        ServerAddr::Tcp(sock_addr) => {
+            crate::utils::ensure_port_free(&sock_addr.to_string());
+        }
+        ServerAddr::Unix(_) => ensure_server_addr_available(addr)?,
+    }
+
+    if with_ui_server {
+        let ServerAddr::Tcp(sock_addr) = addr else {
+            candle_core::bail!("--ui-server is not supported with Unix sockets.");
+        };
+        let ui_port = sock_addr.port().checked_add(1).ok_or_else(|| {
+            candle_core::Error::Msg(
+                "Cannot start UI server because API port 65535 has no following UI port."
+                    .to_string(),
+            )
+        })?;
+        crate::utils::ensure_port_free(&format!("0.0.0.0:{ui_port}"));
+    }
+
+    Ok(())
+}
+
+fn ui_api_config_for_addr(sock_addr: SocketAddr) -> (Option<u16>, Option<String>) {
+    if sock_addr.ip().is_unspecified() {
+        (Some(sock_addr.port()), None)
+    } else {
+        (None, Some(format!("http://{sock_addr}/v1/")))
+    }
 }
 
 /// Start the API server.
@@ -1633,8 +1752,7 @@ pub async fn run_server(
             } else {
                 println!(
                     "{}",
-                    format!("🧠 API server running at:\n   -  {display_url} (Bind Address)")
-                        .cyan()
+                    format!("🧠 API server running at:\n   -  {display_url} (Bind Address)").cyan()
                 );
             }
 
@@ -1645,8 +1763,19 @@ pub async fn run_server(
             }));
 
             if with_ui_server {
+                let ui_port = sock_addr.port().checked_add(1).ok_or_else(|| {
+                    candle_core::Error::Msg(
+                        "Cannot start UI server because API port 65535 has no following UI port."
+                            .to_string(),
+                    )
+                })?;
+                let (api_port, api_url) = ui_api_config_for_addr(sock_addr);
                 tasks.push(tokio::spawn(async move {
-                    start_ui_server(sock_addr.port() + 1, Some(sock_addr.port()), None, None).await.unwrap();
+                    match api_url {
+                        Some(api_url) => start_ui_server(ui_port, None, Some(api_url), None).await,
+                        None => start_ui_server(ui_port, api_port, None, None).await,
+                    }
+                    .unwrap();
                 }));
             }
         }
@@ -1675,7 +1804,10 @@ pub async fn run_server(
     );
     println!("{}", format!("   - POST /v1/chat/completions").yellow());
     println!("{}", format!("   - POST /v1/messages").yellow());
-    println!("{}", format!("   - POST /v1/messages/count_tokens").yellow());
+    println!(
+        "{}",
+        format!("   - POST /v1/messages/count_tokens").yellow()
+    );
     println!("{}", format!("   - POST /v1/embeddings").yellow());
     println!("{}", format!("   - GET  /v1/models").yellow());
     println!("{}", format!("   - GET  /v1/usage").yellow());
@@ -2306,8 +2438,7 @@ mod tests {
     #[test]
     fn test_server_flag_accepts_hostport_value() {
         let args =
-            Args::try_parse_from(["xinfer", "--m", "test", "--server", "127.0.0.1:8080"])
-                .unwrap();
+            Args::try_parse_from(["xinfer", "--m", "test", "--server", "127.0.0.1:8080"]).unwrap();
         assert_eq!(args.server, "127.0.0.1:8080");
     }
 
@@ -2351,12 +2482,21 @@ mod tests {
             ("", Some(9000), 9000),
             ("0.0.0.0", Some(9000), 9000),
         ] {
-            let addr = resolve_server_addr(input, port).unwrap();
+            let addr = resolve_server_addr(input, port, 8000).unwrap();
             assert!(matches!(addr, ServerAddr::Tcp(_)));
             if let ServerAddr::Tcp(sa) = addr {
                 assert_eq!(sa.port(), expected_port);
                 assert!(sa.ip().is_unspecified());
             }
+        }
+    }
+
+    #[test]
+    fn test_resolve_server_addr_accepts_default_port_override() {
+        let addr = resolve_server_addr("", None, 7000).unwrap();
+        if let ServerAddr::Tcp(sa) = addr {
+            assert_eq!(sa.port(), 7000);
+            assert!(sa.ip().is_unspecified());
         }
     }
 
@@ -2367,7 +2507,7 @@ mod tests {
             ("127.0.0.1", None, 8000),
             ("127.0.0.1", Some(7000), 7000),
         ] {
-            let addr = resolve_server_addr(input, port).unwrap();
+            let addr = resolve_server_addr(input, port, 8000).unwrap();
             if let ServerAddr::Tcp(sa) = addr {
                 assert_eq!(sa.port(), expected_port);
                 assert!(sa.ip().is_loopback());
@@ -2377,11 +2517,10 @@ mod tests {
 
     #[test]
     fn test_resolve_server_addr_hostname() {
-        for (input, port, expected_port) in [
-            ("localhost", None, 8000),
-            ("localhost:9000", None, 9000),
-        ] {
-            let addr = resolve_server_addr(input, port).unwrap();
+        for (input, port, expected_port) in
+            [("localhost", None, 8000), ("localhost:9000", None, 9000)]
+        {
+            let addr = resolve_server_addr(input, port, 8000).unwrap();
             if let ServerAddr::Tcp(sa) = addr {
                 assert_eq!(sa.port(), expected_port);
             }
@@ -2393,11 +2532,11 @@ mod tests {
         for (input, port, expected_port) in [
             ("[::1]:9090", None, 9090),
             ("[::1]", None, 8000),
-            ("::1", None, 8000),   // bare — url can't parse natively
+            ("::1", None, 8000), // bare — url can't parse natively
             ("::1", Some(7070), 7070),
             ("[::1]:6060", None, 6060),
         ] {
-            let addr = match resolve_server_addr(input, port) {
+            let addr = match resolve_server_addr(input, port, 8000) {
                 Ok(a) => a,
                 Err(_) => return, // skip entire test if IPv6 unavailable
             };
@@ -2411,7 +2550,7 @@ mod tests {
     #[test]
     fn test_resolve_server_addr_ipv6_unspecified() {
         for input in ["::", "[::]"] {
-            let addr = resolve_server_addr(input, None).unwrap();
+            let addr = resolve_server_addr(input, None, 8000).unwrap();
             if let ServerAddr::Tcp(sa) = addr {
                 assert_eq!(sa.port(), 8000);
                 assert!(sa.ip().is_unspecified());
@@ -2422,14 +2561,107 @@ mod tests {
     #[test]
     fn test_resolve_server_addr_unix_socket() {
         for scheme in ["file", "socket", "unix"] {
-            let addr = resolve_server_addr(&format!("{scheme}:///tmp/xinfer.sock"), None).unwrap();
+            let addr =
+                resolve_server_addr(&format!("{scheme}:///tmp/xinfer.sock"), None, 8000).unwrap();
             assert!(matches!(addr, ServerAddr::Unix(_)));
         }
     }
 
     #[test]
-    fn test_resolve_server_addr_port_mismatch_errors() {
-        let result = resolve_server_addr("0.0.0.0:8080", Some(9000));
+    fn test_resolve_server_addr_rejects_port_with_unix_socket() {
+        let result = resolve_server_addr("unix:///tmp/xinfer.sock", Some(8000), 8000);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_resolve_server_addr_port_mismatch_errors() {
+        let result = resolve_server_addr("0.0.0.0:8080", Some(9000), 8000);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_resolve_server_addr_rejects_invalid_port() {
+        assert!(resolve_server_addr("", Some(70000), 8000).is_err());
+        assert!(resolve_server_addr("127.0.0.1:8080", Some(70000), 8000).is_err());
+        assert!(validate_tcp_port(70000, "port").is_err());
+    }
+
+    #[test]
+    fn test_ensure_server_addr_available_detects_bound_tcp() {
+        let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        assert!(ensure_server_addr_available(&ServerAddr::Tcp(addr)).is_err());
+    }
+
+    #[test]
+    fn test_ensure_server_addr_available_checks_and_cleans_unix_socket() {
+        let path = temp_test_path("preflight.sock");
+        let _ = std::fs::remove_file(&path);
+        let addr = ServerAddr::Unix(path.clone());
+
+        ensure_server_addr_available(&addr).unwrap();
+        assert!(
+            !path.exists(),
+            "Unix socket preflight should not leave a socket file behind"
+        );
+
+        let listener = std::os::unix::net::UnixListener::bind(&path).unwrap();
+        drop(listener);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn test_ensure_server_addr_available_detects_bound_unix_socket() {
+        let path = temp_test_path("bound.sock");
+        let _ = std::fs::remove_file(&path);
+        let listener = std::os::unix::net::UnixListener::bind(&path).unwrap();
+
+        assert!(ensure_server_addr_available(&ServerAddr::Unix(path.clone())).is_err());
+
+        drop(listener);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn test_ensure_server_bindings_available_rejects_ui_port_overflow() {
+        let addr = ServerAddr::Tcp(SocketAddr::from((Ipv4Addr::LOCALHOST, u16::MAX)));
+        assert!(ensure_server_bindings_available(&addr, true).is_err());
+    }
+
+    #[test]
+    fn test_ensure_server_bindings_available_rejects_unix_socket_ui() {
+        let path = temp_test_path("ui.sock");
+        let _ = std::fs::remove_file(&path);
+
+        assert!(ensure_server_bindings_available(&ServerAddr::Unix(path), true).is_err());
+    }
+
+    #[test]
+    fn test_ensure_server_bindings_available_detects_bound_ui_port() {
+        let ui_listener = std::net::TcpListener::bind((Ipv4Addr::UNSPECIFIED, 0)).unwrap();
+        let ui_port = ui_listener.local_addr().unwrap().port();
+        let api_port = ui_port - 1;
+        let api_addr = ServerAddr::Tcp(SocketAddr::from((Ipv4Addr::LOCALHOST, api_port)));
+
+        assert!(ensure_server_bindings_available(&api_addr, true).is_err());
+    }
+
+    #[test]
+    fn test_ui_api_config_uses_explicit_url_for_specific_bind() {
+        let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 8080));
+        let (api_port, api_url) = ui_api_config_for_addr(addr);
+
+        assert_eq!(api_port, None);
+        assert_eq!(api_url.as_deref(), Some("http://127.0.0.1:8080/v1/"));
+    }
+
+    #[test]
+    fn test_ui_api_config_keeps_prompt_for_unspecified_bind() {
+        let addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, 8080));
+        let (api_port, api_url) = ui_api_config_for_addr(addr);
+
+        assert_eq!(api_port, Some(8080));
+        assert_eq!(api_url, None);
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -20,7 +20,7 @@ use crate::utils::image::{
 };
 use crate::utils::reasoning::ReasoningEffort;
 use axum::http::{self, StatusCode};
-use axum::response::{IntoResponse, Sse};
+use axum::response::{sse::KeepAliveStream, IntoResponse, Sse};
 use axum::routing::{get, post};
 use axum::Json;
 use axum::Router;
@@ -820,7 +820,7 @@ impl JsonError {
 impl ErrorToResponse for JsonError {}
 
 pub enum ChatResponder {
-    Streamer(Sse<Streamer>),
+    Streamer(Sse<KeepAliveStream<Streamer>>),
     Completion(ChatCompletionResponse),
     Usage(UsageResponse),
     Embedding(EmbeddingResponse),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -26,14 +26,17 @@ use axum::Json;
 use axum::Router;
 use candle_core::{Result, Tensor};
 use colored::*;
-use local_ip_address::local_ip;
+use local_ip_address::{local_ip, local_ipv6};
 use parking_lot::RwLock;
 use rustchatui::start_ui_server;
 use serde_json::json;
+use regex::Regex;
 use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs};
 use std::path::Path;
 use std::sync::Arc;
 use tower_http::cors::{Any, CorsLayer};
+use url::Url;
 
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
@@ -946,9 +949,20 @@ pub struct Args {
     #[arg(long, default_value = None)]
     pub prefix_cache_max_tokens: Option<usize>,
 
-    #[arg(long, default_value_t = false)]
-    pub server: bool, //server mode
+    /// Enable server mode. Optionally specify a bind address.
+    ///
+    /// Without a value, binds to 0.0.0.0:8000 (TCP).
+    ///
+    /// With a value, accepts one of:
+    ///   - `host:port`         → TCP (e.g. 127.0.0.1:8080)
+    ///   - `file:///path`      → Unix socket at /path
+    ///   - `socket:///path`    → Unix socket at /path
+    ///   - `unix:///path`      → Unix socket at /path
+    #[arg(long, num_args = 0..=1, default_value = "", default_missing_value = "0.0.0.0")]
+    pub server: String,
 
+    /// TCP port for server mode. Ignored when --server specifies a host:port value.
+    /// Deprecated: use `--server host:port` instead.
     #[arg(long, visible_alias = "p")]
     pub port: Option<usize>,
 
@@ -1409,10 +1423,79 @@ pub fn build_messages_and_images(
     Ok((messages, image_data))
 }
 
+/// Represents either a TCP socket address or a Unix socket path for the API server.
+pub enum ServerAddr {
+    Tcp(SocketAddr),
+    Unix(std::path::PathBuf),
+}
+
+/// Convert raw `--server` and `--port` values into a `ServerAddr`.
+pub fn resolve_server_addr(server: &str, port: Option<usize>) -> candle_core::Result<ServerAddr> {
+    // Unix socket URIs → extract path
+    if ["file://", "socket://", "unix://"].iter().any(|p| server.starts_with(*p)) {
+        let Ok(srv_url) = Url::parse(server) else {
+            candle_core::bail!("Cannot parse --server socket path.");
+        };
+        return Ok(ServerAddr::Unix(std::path::PathBuf::from(srv_url.path())));
+    }
+
+    // Url::parse doesn't handle bare ip6 addresses
+    let is_bare_ip6 = !server.contains('[')
+        && server.matches(':').count() - server.matches("://").count() > 1;
+
+    // bare ip6 cannot contain port
+    let brc_ip = if !is_bare_ip6 {server.to_string()} else {
+        let shr = Regex::new(r"^(?<s>(?:\w+://)?)(?<h>.*)$").unwrap();
+        shr.replace(server, "$s[$h]").to_string()
+    };
+
+    let srv_addr_str = if brc_ip.is_empty() {
+        "tcp://0.0.0.0".to_string()
+    } else if brc_ip.contains("://") {
+        brc_ip.to_string()
+    } else {
+        format!("tcp://{brc_ip}")
+    };
+
+    let Ok(srv_addr_url) = Url::parse(&srv_addr_str) else {
+        candle_core::bail!("Cannot parse --server value as address.");
+    };
+
+    let Some(h) = srv_addr_url.host_str().map(|s| s.trim_start_matches('[').trim_end_matches(']')) else {
+        candle_core::bail!("No host in --server value.");
+    };
+
+    let p = srv_addr_url.port().map(|p| p as u16).unwrap_or(port.unwrap_or(8000) as u16);
+
+    if port.is_some_and(|po| p != po as u16) {
+        candle_core::bail!("--server host:{p} and --port {} are both given and don't agree.", port.unwrap());
+    }
+
+    // Resolve hostname to a socket address.
+    let sock_addr = (h, p)
+        .to_socket_addrs()
+        .map_err(|e| {
+            candle_core::Error::Msg(format!("Failed to resolve '{h}': {e}"))
+        })?
+        .next()
+        .ok_or_else(|| {
+            candle_core::Error::Msg(format!("No addresses resolved for '{h}'"))
+        })?;
+
+    Ok(ServerAddr::Tcp(sock_addr))
+}
+
+/// Start the API server.
+///
+/// `addr` determines how the server listens:
+///   - `ServerAddr::Tcp(sock_addr)`  → TCP at `sock_addr`
+///   - `ServerAddr::Unix(path)`      → Unix socket at `path`
+///
+/// When `--pd-server` is active the address is ignored (binds `0.0.0.0:0` instead).
 pub async fn run_server(
     engine: Arc<RwLock<LLMEngine>>,
     econfig: EngineConfig,
-    port: usize,
+    addr: ServerAddr,
     with_ui_server: bool,
 ) -> Result<()> {
     use axum::extract::DefaultBodyLimit;
@@ -1514,61 +1597,98 @@ pub async fn run_server(
         .layer(cors)
         .with_state(Arc::new(server_data));
 
-    let addr = if is_pd_server {
+    // ── PD server ───────────────────────────────────────────────────────
+    if is_pd_server {
         crate::log_warn!("🚀 PD server started, waiting for prefill request(s)...",);
-        format!("0.0.0.0:{}", 0)
-    } else {
-        let ip = local_ip().unwrap_or("127.0.0.1".parse().unwrap());
-        let local_url = format!("http://localhost:{port}/v1/");
-        let lan_url = format!("http://{ip}:{port}/v1/");
-
-        let api_server_url = format!(
-            "🧠 API server running at:\n   -  {} (Local Access) \n   -  {} (Remote Access, IP may not correct under Docker)",
-            local_url, lan_url
-        );
-        println!("{}", api_server_url.cyan());
-
-        println!(
-            "{}",
-            format!("📡 Supported endpoints (OpenAI/Claude):").yellow()
-        );
-        println!("{}", format!("   - POST /v1/chat/completions").yellow());
-        println!("{}", format!("   - POST /v1/messages").yellow());
-        println!(
-            "{}",
-            format!("   - POST /v1/messages/count_tokens").yellow()
-        );
-        println!("{}", format!("   - POST /v1/embeddings").yellow());
-        println!("{}", format!("   - GET  /v1/models").yellow());
-        println!("{}", format!("   - GET  /v1/usage").yellow());
-        println!("{}", format!("   - POST /tokenize").yellow());
-        println!("{}", format!("   - POST /detokenize").yellow());
-        println!("");
-        println!(
-            "🛑 {}",
-            format!("EXIT: Ctrl+C to quit. If unresponsive: Ctrl+P → Ctrl+Q (last resort).")
-                .bold()
-                .red()
-        );
-        println!("");
-        format!("0.0.0.0:{}", port)
-    };
-
-    let listener = tokio::net::TcpListener::bind(addr).await?;
-    let mut tasks = Vec::new();
-    tasks.push(tokio::spawn(async move {
+        let listener = tokio::net::TcpListener::bind("0.0.0.0:0").await?;
         if let Err(e) = axum::serve(listener, app).await {
             eprintln!("API server error: {e:?}");
         }
-    }));
-
-    if with_ui_server {
-        tasks.push(tokio::spawn(async move {
-            start_ui_server((port + 1) as u16, Some(port as u16), None, None)
-                .await
-                .unwrap();
-        }));
+        return Ok(());
     }
+
+    // ── Normal server: bind the appropriate listener ────────────────────
+    let mut tasks = Vec::new();
+
+    match addr {
+        ServerAddr::Tcp(sock_addr) => {
+            let listener = tokio::net::TcpListener::bind(sock_addr).await?;
+
+            // Display
+            let display_url = format!("http://{}/v1/", sock_addr);
+            if sock_addr.ip().is_unspecified() {
+                // local_ip returns one address but the machine may have multiple.
+                let example_ip = if sock_addr.is_ipv4() {
+                    local_ip().unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST))
+                } else {
+                    local_ipv6().unwrap_or(IpAddr::V6(Ipv6Addr::LOCALHOST))
+                };
+                let example_sock = SocketAddr::new(example_ip, sock_addr.port());
+                let example_url = format!("http://{example_sock}/v1/");
+                println!(
+                    "{}",
+                    format!("🧠 API server running at:\n   -  {display_url} (Bind Address) \n   -  {example_url}")
+                        .cyan()
+                );
+            } else {
+                println!(
+                    "{}",
+                    format!("🧠 API server running at:\n   -  {display_url} (Bind Address)")
+                        .cyan()
+                );
+            }
+
+            tasks.push(tokio::spawn(async move {
+                if let Err(e) = axum::serve(listener, app).await {
+                    eprintln!("API server error: {e:?}");
+                }
+            }));
+
+            if with_ui_server {
+                tasks.push(tokio::spawn(async move {
+                    start_ui_server(sock_addr.port() + 1, Some(sock_addr.port()), None, None).await.unwrap();
+                }));
+            }
+        }
+        ServerAddr::Unix(path) => {
+            if with_ui_server {
+                candle_core::bail!("--ui-server is not supported with Unix sockets.");
+            }
+            let listener = tokio::net::UnixListener::bind(&path)?;
+
+            println!(
+                "{}",
+                format!("🧠 API server running at: http+unix://{}", path.display()).cyan()
+            );
+
+            tasks.push(tokio::spawn(async move {
+                if let Err(e) = axum::serve(listener, app).await {
+                    eprintln!("API server error: {e:?}");
+                }
+            }));
+        }
+    }
+
+    println!(
+        "{}",
+        format!("📡 Supported endpoints (OpenAI/Claude):").yellow()
+    );
+    println!("{}", format!("   - POST /v1/chat/completions").yellow());
+    println!("{}", format!("   - POST /v1/messages").yellow());
+    println!("{}", format!("   - POST /v1/messages/count_tokens").yellow());
+    println!("{}", format!("   - POST /v1/embeddings").yellow());
+    println!("{}", format!("   - GET  /v1/models").yellow());
+    println!("{}", format!("   - GET  /v1/usage").yellow());
+    println!("{}", format!("   - POST /tokenize").yellow());
+    println!("{}", format!("   - POST /detokenize").yellow());
+    println!("");
+    println!(
+        "🛑 {}",
+        format!("EXIT: Ctrl+C to quit. If unresponsive: Ctrl+P → Ctrl+Q (last resort).")
+            .bold()
+            .red()
+    );
+    println!("");
 
     futures::future::try_join_all(tasks)
         .await
@@ -2175,5 +2295,141 @@ mod tests {
             Some(192),
             "reasoning_tokens should round-trip under completion_tokens_details, got: {value}",
         );
+    }
+
+    #[test]
+    fn test_server_flag_accepts_no_value() {
+        let args = Args::try_parse_from(["xinfer", "--m", "test", "--server"]).unwrap();
+        assert_eq!(args.server, "0.0.0.0");
+    }
+
+    #[test]
+    fn test_server_flag_accepts_hostport_value() {
+        let args =
+            Args::try_parse_from(["xinfer", "--m", "test", "--server", "127.0.0.1:8080"])
+                .unwrap();
+        assert_eq!(args.server, "127.0.0.1:8080");
+    }
+
+    #[test]
+    fn test_server_flag_accepts_ipv6_value() {
+        let args =
+            Args::try_parse_from(["xinfer", "--m", "test", "--server", "[::1]:8080"]).unwrap();
+        assert_eq!(args.server, "[::1]:8080");
+    }
+
+    #[test]
+    fn test_server_flag_optional_with_port_fallback() {
+        // --port alone still works
+        let args = Args::try_parse_from(["xinfer", "--m", "test", "--port", "9000"]).unwrap();
+        assert_eq!(args.server, "");
+        assert_eq!(args.port, Some(9000));
+    }
+
+    #[test]
+    fn test_server_prefers_value_over_port() {
+        // Both --server value and --port; --server value takes precedence in main.rs logic
+        let args = Args::try_parse_from([
+            "xinfer",
+            "--m",
+            "test",
+            "--server",
+            "0.0.0.0:8080",
+            "--port",
+            "9000",
+        ])
+        .unwrap();
+        assert_eq!(args.server, "0.0.0.0:8080");
+        assert_eq!(args.port, Some(9000));
+    }
+
+    #[test]
+    fn test_resolve_server_addr_defaults_to_unspecified() {
+        for (input, port, expected_port) in [
+            ("", None, 8000),
+            ("0.0.0.0", None, 8000),
+            ("", Some(9000), 9000),
+            ("0.0.0.0", Some(9000), 9000),
+        ] {
+            let addr = resolve_server_addr(input, port).unwrap();
+            assert!(matches!(addr, ServerAddr::Tcp(_)));
+            if let ServerAddr::Tcp(sa) = addr {
+                assert_eq!(sa.port(), expected_port);
+                assert!(sa.ip().is_unspecified());
+            }
+        }
+    }
+
+    #[test]
+    fn test_resolve_server_addr_ipv4() {
+        for (input, port, expected_port) in [
+            ("127.0.0.1:8080", None, 8080),
+            ("127.0.0.1", None, 8000),
+            ("127.0.0.1", Some(7000), 7000),
+        ] {
+            let addr = resolve_server_addr(input, port).unwrap();
+            if let ServerAddr::Tcp(sa) = addr {
+                assert_eq!(sa.port(), expected_port);
+                assert!(sa.ip().is_loopback());
+            }
+        }
+    }
+
+    #[test]
+    fn test_resolve_server_addr_hostname() {
+        for (input, port, expected_port) in [
+            ("localhost", None, 8000),
+            ("localhost:9000", None, 9000),
+        ] {
+            let addr = resolve_server_addr(input, port).unwrap();
+            if let ServerAddr::Tcp(sa) = addr {
+                assert_eq!(sa.port(), expected_port);
+            }
+        }
+    }
+
+    #[test]
+    fn test_resolve_server_addr_ipv6_loopback() {
+        for (input, port, expected_port) in [
+            ("[::1]:9090", None, 9090),
+            ("[::1]", None, 8000),
+            ("::1", None, 8000),   // bare — url can't parse natively
+            ("::1", Some(7070), 7070),
+            ("[::1]:6060", None, 6060),
+        ] {
+            let addr = match resolve_server_addr(input, port) {
+                Ok(a) => a,
+                Err(_) => return, // skip entire test if IPv6 unavailable
+            };
+            if let ServerAddr::Tcp(sa) = addr {
+                assert_eq!(sa.port(), expected_port);
+                assert!(sa.ip().is_loopback());
+            }
+        }
+    }
+
+    #[test]
+    fn test_resolve_server_addr_ipv6_unspecified() {
+        for input in ["::", "[::]"] {
+            let addr = resolve_server_addr(input, None).unwrap();
+            if let ServerAddr::Tcp(sa) = addr {
+                assert_eq!(sa.port(), 8000);
+                assert!(sa.ip().is_unspecified());
+            }
+        }
+    }
+
+    #[test]
+    fn test_resolve_server_addr_unix_socket() {
+        for scheme in ["file", "socket", "unix"] {
+            let addr = resolve_server_addr(&format!("{scheme}:///tmp/xinfer.sock"), None).unwrap();
+            assert!(matches!(addr, ServerAddr::Unix(_)));
+        }
+    }
+
+    #[test]
+    fn test_resolve_server_addr_port_mismatch_errors() {
+        let result = resolve_server_addr("0.0.0.0:8080", Some(9000));
+        assert!(result.is_err());
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2460,17 +2460,16 @@ mod tests {
     }
 }
 
-/// Fail fast if `host:port` is already bound, before spending minutes loading
-/// model weights.  Prints a user-friendly error and exits the process when the
-/// port is occupied.
-pub fn ensure_port_free(host: &str, port: u16) {
-    let addr = format!("{host}:{port}");
-    match std::net::TcpListener::bind(&addr) {
+/// Fail fast if `addr` (e.g. `0.0.0.0:8000` or `[::1]:8080`) is already bound,
+/// before spending minutes loading model weights.
+/// Prints a user-friendly error and exits the process when the port is occupied.
+pub fn ensure_port_free(addr: &str) {
+    match std::net::TcpListener::bind(addr) {
         Ok(_listener) => { /* port is free; drop the listener immediately */ }
         Err(e) => {
             eprintln!(
-                "\n❌ Port {port} is already in use ({e}).\n   \
-                 Free the port or choose a different one with --port <port>.\n"
+                "\n❌ Address {addr} is already in use ({e}).\n   \
+                 Free the address or choose a different one with --server host:port.\n"
             );
             std::process::exit(1);
         }


### PR DESCRIPTION
This fixes https://github.com/guoqingbao/xinfer/issues/395.

Needed to update axum to v0.8.x to handle unix sockets.

ipv6 addresses are supported too.

Unfortunately I cannot test it in an actual deployment now, and possibly for the next few day. Something like the following should work:
```bash
xinfer --server unix:///tmp/xf.sock --m ....
curl --unix-socket /tmp/xf.sock http://localhost/v1/models
```