### PR TITLE
Support Multi-node inference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xinfer"
-version = "0.13.3"
+version = "0.13.4"
 edition = "2021"
 default-run = "xinfer"
 description = "xInfer — a minimal, high-performance large language model (LLM) inference engine in Rust."

--- a/ReadMe-CN.md
+++ b/ReadMe-CN.md
@@ -333,6 +333,24 @@ pip install target/wheels/xinfer_ai-*.whl --force-reinstall
 
 ---
 
+## 🌐 多机张量并行推理
+
+跨多台机器分布式推理，基于 TCP 的 NCCL 引导，无需 MPI。
+
+```bash
+# 节点 0（主节点，192.168.1.100）：调度器 + API 服务
+xinfer --d 0,1,2,3 --m /data/DeepSeek-R1/ \
+  --num-nodes 2 --node-rank 0 --master-addr 192.168.1.100 --ui-server
+
+# 节点 1（工作节点，192.168.1.101）：仅执行前向推理
+xinfer --d 0,1,2,3 --m /data/DeepSeek-R1/ \
+  --num-nodes 2 --node-rank 1 --master-addr 192.168.1.100
+```
+
+所有节点需本地存放模型权重，并通过 TCP 连接 `--master-port`（默认 29500）。详见 [Get Started](docs/get_started.md)。
+
+---
+
 ## 🔀 Prefill-Decode 分离（PD 分离）
 
 将预填充（prompt 处理）和解码（token 生成）拆分到不同 GPU 或机器。消除长上下文预填充时的解码卡顿。PD 服务器与 PD 客户端必须使用相同 KvCache 数据类型（`--kvcache-dtype`）。对话请求需发送至 PD 客户端，PD 服务端只处理 PD 客户端发来的预填充请求。
@@ -446,6 +464,10 @@ xinfer --m unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF \
 | `--disable-prefix-cache` | 禁用前缀缓存 |
 | `--prefix-cache-max-tokens` | 前缀缓存大小上限 |
 | `--prefill-chunk-size` | 预填充分块大小 (默认: CUDA 8K, Metal: 4k) |
+| `--num-nodes` | 多机推理节点总数（默认 1） |
+| `--node-rank` | 当前节点编号（0 = 主节点） |
+| `--master-addr` | 主节点 IP（多机推理必填） |
+| `--master-port` | NCCL 引导端口（默认 29500） |
 | `--disable-cuda-graph` | 禁用 CUDA 图捕获 |
 | `--yarn-scaling-factor` | YARN RoPE 上下文扩展因子 |
 | `--temperature` | 采样温度（0–1） |
@@ -483,6 +505,7 @@ XINFER_NVFP4_FORCE_LUT=1 xinfer --m nvidia/Qwen3-30B-A3B-FP4 --ui-server
 * [x] OpenAI API 兼容服务器（支持流式输出）
 * [x] 持续批处理
 * [x] 多卡并行推理（Safetensors 模型、GPTQ/AWQ 及 GGUF 量化模型）
+* [x] 多机张量并行推理（基于 TCP 的 NCCL 引导，无需 MPI）
 * [x] Metal/macOS 平台 Prompt 处理加速
 * [x] 分块预填充（Chunked Prefill）
 * [x] 前缀缓存（使用 `prefix-cache` 参数）

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -338,6 +338,24 @@ See [more Python examples →](python/ReadMe.md)
 
 ---
 
+## 🌐 Multi-Node Tensor Parallelism
+
+Distribute inference across multiple machines using TCP-based NCCL bootstrap. No MPI required.
+
+```bash
+# Node 0 (master, 192.168.1.100): scheduler + API
+xinfer --d 0,1,2,3 --m /data/DeepSeek-R1/ \
+  --num-nodes 2 --node-rank 0 --master-addr 192.168.1.100 --ui-server
+
+# Node 1 (worker, 192.168.1.101): forward-only daemon
+xinfer --d 0,1,2,3 --m /data/DeepSeek-R1/ \
+  --num-nodes 2 --node-rank 1 --master-addr 192.168.1.100
+```
+
+All nodes must have model weights locally and be TCP-reachable on `--master-port` (default 29500). See [Get Started](docs/get_started.md) for details.
+
+---
+
 ## 🔀 Prefill-Decode Disaggregation
 
 Split prefill (prompt processing) and decode (token generation) across GPUs or machines. Eliminates decode stalls during long-context prefilling. PD Server and PD Client must use **same** KvCache type (`--kvcache-dtype`). API request(s) must send to PD Client and the PD Server only process internal prefill requests sent from PD Client.
@@ -488,6 +506,7 @@ XINFER_NVFP4_FORCE_LUT=1 xinfer --m nvidia/Qwen3-30B-A3B-FP4 --ui-server
 * [x] OpenAI-compatible API (streaming support)
 * [x] Continuous batching
 * [x] Multi-gpu inference (Safetensors, GPTQ, AWQ, GGUF)
+* [x] Multi-node tensor parallelism (TCP-based NCCL bootstrap, no MPI required)
 * [x] Speedup prompt processing on Metal/macOS
 * [x] Chunked Prefill
 * [x] Prefix cache (available on `CUDA` when `prefix-cache` enabled)

--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -65,6 +65,52 @@ Reasoning defaults to enabled when a request omits `thinking` / `enable_thinking
   ```
 - **Graph capture**: CUDA graph is auto-enabled with `cuda` feature. Use `--disable-cuda-graph` at runtime to skip graph capture.
 
+## 4.1) Multi-node tensor parallelism
+
+Distribute tensor-parallel inference across multiple machines via TCP-based NCCL bootstrap. Node 0 is the coordinator (runs scheduler + API); worker nodes run forward-only daemon loops.
+
+**Requirements:**
+- All nodes must have the same model weights available locally (same path or HuggingFace cache).
+- All nodes must be reachable via TCP on the `--master-port` (default 29500) and `--master-port + 1` (forward coordination).
+- Build with `--features cuda,nccl,flashinfer,cutlass` on all nodes.
+
+**Example: 2 nodes × 4 GPUs = 8-way tensor parallelism**
+
+```bash
+# Node 0 (master, at 192.168.1.100): runs scheduler + API server
+xinfer --m /data/DeepSeek-R1/ --d 0,1,2,3 \
+  --num-nodes 2 --node-rank 0 \
+  --master-addr 192.168.1.100 --master-port 29500 \
+  --ui-server
+
+# Node 1 (worker, at 192.168.1.101): runs forward-only daemon
+xinfer --m /data/DeepSeek-R1/ --d 0,1,2,3 \
+  --num-nodes 2 --node-rank 1 \
+  --master-addr 192.168.1.100 --master-port 29500
+```
+
+**How it works:**
+1. Node 0 generates a NCCL unique ID and distributes it to worker nodes via TCP.
+2. Each node spawns local runner subprocesses with global NCCL ranks (`node_rank × local_gpus + local_rank`).
+3. All ranks join a single global NCCL communicator for all-reduce / all-gather operations.
+4. Node 0 broadcasts forward-pass commands to worker nodes via TCP; NCCL synchronizes the actual tensor computations.
+5. Only node 0 runs the scheduler and API server; worker nodes are stateless forward engines.
+
+**CLI flags:**
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--num-nodes` | 1 | Total number of nodes |
+| `--node-rank` | 0 | This node's rank (0 = master) |
+| `--master-addr` | _(required)_ | Master node's IP address |
+| `--master-port` | 29500 | TCP port for NCCL bootstrap |
+
+**NCCL environment variables** (optional tuning):
+```bash
+export NCCL_IB_DISABLE=1      # Disable InfiniBand if unavailable
+export NCCL_SOCKET_IFNAME=eth0 # Specify network interface
+export NCCL_DEBUG=INFO          # Enable NCCL debug logging
+```
+
 ## 5) PD Disaggregation (prefill/decoding split)
 - **PD server (prefill host, usually memory-rich)**  
   ```bash

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xinfer-ai",
-  "version": "0.13.3",
-  "assetVersion": "0.13.3",
+  "version": "0.13.4",
+  "assetVersion": "0.13.4",
   "description": "xInfer — a high-performance LLM inference engine in Rust with CUDA/Metal acceleration",
   "license": "MIT",
   "homepage": "https://github.com/guoqingbao/xinfer#readme",

--- a/pages/index.html
+++ b/pages/index.html
@@ -630,7 +630,7 @@ document.querySelectorAll('.cb').forEach(function(bl){
 });
 
 /* ═══ Download cards ═══ */
-var XINFER_VER='0.13.3';
+var XINFER_VER='0.13.4';
 var DL='https://github.com/guoqingbao/xinfer/releases/download/v'+XINFER_VER+'/';
 var archs=[
   {sm:'sm70',n:'70',name:'SM70',gpu:'V100',cuda:'CUDA 12',arch:'x64',d:0},

--- a/src/api.rs
+++ b/src/api.rs
@@ -167,6 +167,10 @@ impl EngineBuilder {
             false,
             false,
             None,
+            1,     // num_nodes
+            0,     // node_rank
+            None,  // master_addr
+            29500, // master_port
         );
 
         if let Some(kv_dtype) = self.kvcache_dtype {

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -273,8 +273,30 @@ impl LLMEngine {
         } else {
             log_info!("Loading model with runner(s)...");
 
+            let is_multi_node = econfig.num_nodes > 1;
+            let node_rank = econfig.node_rank;
+            let num_nodes = econfig.num_nodes;
+            let local_num_gpus = device_ids.len();
+            let global_rank_offset = node_rank * local_num_gpus;
+
             #[cfg(feature = "nccl")]
-            let nccl_id = Id::new().unwrap();
+            let nccl_id = if is_multi_node {
+                let master_addr = econfig
+                    .master_addr
+                    .as_ref()
+                    .expect("master_addr required for multi-node");
+                crate::utils::multi_node::coordinate_nccl_id(
+                    num_nodes,
+                    node_rank,
+                    master_addr,
+                    econfig.master_port,
+                )
+                .map_err(|e| {
+                    candle_core::Error::Msg(format!("Multi-node NCCL ID exchange failed: {}", e))
+                })?
+            } else {
+                Id::new().unwrap()
+            };
 
             let runner_path = get_runner_path()?;
 
@@ -303,11 +325,8 @@ impl LLMEngine {
             }
 
             let progress_sock_name = format!("{}@xinfer-progress", unique_id);
-            let progress_handle = spawn_progress_thread(
-                econfig.num_shards.unwrap_or(1),
-                config.num_hidden_layers,
-                progress_sock_name,
-            );
+            let progress_handle =
+                spawn_progress_thread(local_num_gpus, config.num_hidden_layers, progress_sock_name);
             heartbeat_worker(Some(device_ids.len()), false, stop_flag.clone(), unique_id);
             use rayon::iter::IndexedParallelIterator;
             use rayon::iter::IntoParallelRefIterator;
@@ -316,9 +335,10 @@ impl LLMEngine {
             let runner_streams: Result<Vec<LocalStream>> = device_ids
                 .par_iter()
                 .enumerate()
-                .map(|(rank, dev_id)| {
+                .map(|(local_rank, dev_id)| {
+                    let global_rank = global_rank_offset + local_rank;
                     let model_type = model_type.clone();
-                    let sock_name = format!("{}@xinfer-runner-{}", unique_id, rank);
+                    let sock_name = format!("{}@xinfer-runner-{}", unique_id, local_rank);
                     let listener = ListenerOptions::new()
                         .name(
                             sock_name
@@ -329,11 +349,19 @@ impl LLMEngine {
                         .create_sync()
                         .expect("Failed to create listener");
 
-                    crate::log_info!("listener starting accepting runner {}", rank);
+                    crate::log_info!(
+                        "listener starting accepting runner {} (global rank {})",
+                        local_rank,
+                        global_rank
+                    );
 
                     // Accept one connection
                     let mut stream = listener.accept()?;
-                    crate::log_info!("Accepted runner {}", rank);
+                    crate::log_info!(
+                        "Accepted runner {} (global rank {})",
+                        local_rank,
+                        global_rank
+                    );
 
                     // Wait for "ready"
                     let mut reader = BufReader::new(&mut stream);
@@ -342,15 +370,15 @@ impl LLMEngine {
                     if message.trim() != "ready" {
                         return Err(candle_core::Error::Msg(format!(
                             "Runner {} did not send ready",
-                            rank
+                            local_rank
                         )));
                     }
 
-                    // Build init message
+                    // Build init message with global rank for NCCL
                     let mut econfig_rank = econfig.clone();
                     econfig_rank.device_ids = Some(vec![*dev_id]);
                     let init_msg = MessageType::Init(RunnerInitRequest {
-                        rank,
+                        rank: global_rank,
                         dev_id: *dev_id,
                         num_shards: econfig.num_shards.unwrap_or(1),
                         model_type,
@@ -364,12 +392,11 @@ impl LLMEngine {
                         nccl_id: crate::runner::NcclId(nccl_id.clone()),
                     });
 
-                    send_and_expect_ack(&mut stream, &init_msg, "initialize", rank)?;
+                    send_and_expect_ack(&mut stream, &init_msg, "initialize", global_rank)?;
 
                     // Always validate/plan allocation after model loading for accurate memory readings
                     let ecfg = engine_config.get_or_init(|| {
                         let mut econfig = econfig.clone();
-                        // Use new KVCacheAllocator for multi-rank negotiation
                         let allocator = KVCacheAllocator::new(&econfig, &config, dtype);
                         econfig.kvcache_dtype = allocator.resolved_kvcache_dtype();
                         let device_ids = econfig.device_ids.clone().unwrap_or(vec![0]);
@@ -389,10 +416,14 @@ impl LLMEngine {
                         &mut stream,
                         &MessageType::UsableMemoryLeft(ecfg.clone()),
                         "init kvcache",
-                        rank,
+                        global_rank,
                     )?;
 
-                    crate::log_info!("Runner {} started!", rank);
+                    crate::log_info!(
+                        "Runner {} (global rank {}) started!",
+                        local_rank,
+                        global_rank
+                    );
                     Ok(stream)
                 })
                 .collect();
@@ -403,7 +434,31 @@ impl LLMEngine {
             if let Some(cfg) = engine_config.get() {
                 econfig = cfg.clone();
             }
-            RunnerType::Process(runner_streams?)
+
+            let local_streams = runner_streams?;
+
+            // Multi-node forward coordination setup
+            if is_multi_node && node_rank == 0 {
+                let mn_config = crate::utils::multi_node::MultiNodeConfig {
+                    num_nodes,
+                    node_rank,
+                    master_addr: econfig.master_addr.clone().unwrap_or_default(),
+                    master_port: econfig.master_port,
+                    local_num_gpus,
+                };
+                let worker_tcp_streams = crate::utils::multi_node::master_accept_worker_streams(
+                    &mn_config,
+                )
+                .map_err(|e| {
+                    candle_core::Error::Msg(format!("Multi-node forward coord failed: {}", e))
+                })?;
+                RunnerType::MultiNodeMaster {
+                    local_streams,
+                    remote_streams: worker_tcp_streams,
+                }
+            } else {
+                RunnerType::Process(local_streams)
+            }
         };
 
         if econfig.max_model_len.is_none() {
@@ -906,6 +961,20 @@ impl LLMEngine {
                 }
                 Ok(())
             }
+            RunnerType::MultiNodeMaster {
+                ref mut local_streams,
+                ref mut remote_streams,
+            } => {
+                let msg = MessageType::FinishDecode(id);
+                for stream in local_streams.iter_mut() {
+                    send_local(&mut vec![stream.try_clone()?], &msg, false)?;
+                }
+                let serialized = bincode::serialize(&msg).expect("Bincode serialization failed");
+                for tcp_stream in remote_streams.iter_mut() {
+                    crate::utils::multi_node::send_tcp(tcp_stream, &serialized)?;
+                }
+                Ok(())
+            }
         }
     }
 
@@ -949,6 +1018,12 @@ impl LLMEngine {
                 model_runner.run(Seqs::SeqRefs(&seq_refs), is_prefill)
             }
             RunnerType::Process(ref mut runner_streams) => {
+                Self::run_forward_on_local_streams(runner_streams, owned_seqs, is_prefill)
+            }
+            RunnerType::MultiNodeMaster {
+                ref mut local_streams,
+                ref mut remote_streams,
+            } => {
                 let request = if is_prefill {
                     MessageType::RunPrefill((owned_seqs.to_vec(), true))
                 } else {
@@ -958,41 +1033,95 @@ impl LLMEngine {
                         .collect::<Vec<_>>();
                     MessageType::RunDecode((sequences, false))
                 };
+                let serialized =
+                    bincode::serialize(&request).expect("Bincode serialization failed");
 
-                let cloned_streams: Vec<LocalStream> = runner_streams
-                    .iter_mut()
-                    .map(|s| s.try_clone().expect("clone failed"))
-                    .collect();
+                // Send to remote worker nodes via TCP (fire-and-forget the responses;
+                // NCCL all-reduce synchronizes the actual computation)
+                for tcp_stream in remote_streams.iter_mut() {
+                    if let Err(e) = crate::utils::multi_node::send_tcp(tcp_stream, &serialized) {
+                        candle_core::bail!("Failed to send forward to remote worker: {}", e);
+                    }
+                }
 
-                let all_outputs: Result<Vec<Vec<u32>>> = cloned_streams
-                    .into_par_iter()
-                    .map(|mut stream| {
-                        let msg = request.clone();
-                        send_local(&mut vec![stream.try_clone()?], &msg, false)?;
-                        let response = receive_local(&mut stream, false)?;
+                // Run on local runners (which also participate in the NCCL collective)
+                let result =
+                    Self::run_forward_on_local_streams(local_streams, owned_seqs, is_prefill);
 
-                        match response {
-                            MessageType::RunResponse(output_ids) => {
-                                if output_ids.len() == 0 {
-                                    candle_core::bail!("Runner step error, no response!")
-                                } else {
-                                    Ok(output_ids)
+                // Collect acks from remote workers
+                for tcp_stream in remote_streams.iter_mut() {
+                    match crate::utils::multi_node::recv_tcp(tcp_stream) {
+                        Ok(data) => {
+                            let resp: MessageType = bincode::deserialize(&data)
+                                .expect("Failed to deserialize remote worker response");
+                            match resp {
+                                MessageType::RunResponse(ref ids) if ids.is_empty() => {
+                                    candle_core::bail!("Remote worker returned empty response");
+                                }
+                                MessageType::RunResponse(_) => {} // OK
+                                other => {
+                                    candle_core::bail!("Unexpected remote response: {:?}", other);
                                 }
                             }
-                            other => {
-                                candle_core::bail!("Unexpected response type: {:?}", other)
-                            }
                         }
-                    })
-                    .collect();
-
-                let all_outputs = all_outputs.map_err(candle_core::Error::wrap)?;
-                if let Some(output_ids) = all_outputs.first() {
-                    Ok(output_ids.clone())
-                } else {
-                    candle_core::bail!("No output ids received from model runners");
+                        Err(e) => {
+                            candle_core::bail!("Failed to receive from remote worker: {}", e);
+                        }
+                    }
                 }
+
+                result
             }
+        }
+    }
+
+    fn run_forward_on_local_streams(
+        runner_streams: &mut Vec<LocalStream>,
+        owned_seqs: &[Sequence],
+        is_prefill: bool,
+    ) -> Result<Vec<u32>> {
+        let request = if is_prefill {
+            MessageType::RunPrefill((owned_seqs.to_vec(), true))
+        } else {
+            let sequences = owned_seqs
+                .iter()
+                .map(|s| DecodeSequence::new(s))
+                .collect::<Vec<_>>();
+            MessageType::RunDecode((sequences, false))
+        };
+
+        let cloned_streams: Vec<LocalStream> = runner_streams
+            .iter_mut()
+            .map(|s| s.try_clone().expect("clone failed"))
+            .collect();
+
+        let all_outputs: Result<Vec<Vec<u32>>> = cloned_streams
+            .into_par_iter()
+            .map(|mut stream| {
+                let msg = request.clone();
+                send_local(&mut vec![stream.try_clone()?], &msg, false)?;
+                let response = receive_local(&mut stream, false)?;
+
+                match response {
+                    MessageType::RunResponse(output_ids) => {
+                        if output_ids.len() == 0 {
+                            candle_core::bail!("Runner step error, no response!")
+                        } else {
+                            Ok(output_ids)
+                        }
+                    }
+                    other => {
+                        candle_core::bail!("Unexpected response type: {:?}", other)
+                    }
+                }
+            })
+            .collect();
+
+        let all_outputs = all_outputs.map_err(candle_core::Error::wrap)?;
+        if let Some(output_ids) = all_outputs.first() {
+            Ok(output_ids.clone())
+        } else {
+            candle_core::bail!("No output ids received from model runners");
         }
     }
 
@@ -1685,7 +1814,11 @@ impl LLMEngine {
                 let chunk_tokens = std::cmp::min(chunk_size, remaining);
                 let embedding_result = match &mut *self.runners.write() {
                     RunnerType::Thread(model_runner) => model_runner.embed(&[&seq], &strategy),
-                    RunnerType::Process(ref mut runner_streams) => {
+                    RunnerType::Process(ref mut runner_streams)
+                    | RunnerType::MultiNodeMaster {
+                        local_streams: ref mut runner_streams,
+                        ..
+                    } => {
                         let request = MessageType::RunEmbed((vec![seq.clone()], strategy.clone()));
                         let cloned_streams: Vec<LocalStream> = runner_streams
                             .iter_mut()

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -1814,11 +1814,7 @@ impl LLMEngine {
                 let chunk_tokens = std::cmp::min(chunk_size, remaining);
                 let embedding_result = match &mut *self.runners.write() {
                     RunnerType::Thread(model_runner) => model_runner.embed(&[&seq], &strategy),
-                    RunnerType::Process(ref mut runner_streams)
-                    | RunnerType::MultiNodeMaster {
-                        local_streams: ref mut runner_streams,
-                        ..
-                    } => {
+                    RunnerType::Process(ref mut runner_streams) => {
                         let request = MessageType::RunEmbed((vec![seq.clone()], strategy.clone()));
                         let cloned_streams: Vec<LocalStream> = runner_streams
                             .iter_mut()
@@ -1848,6 +1844,78 @@ impl LLMEngine {
                             .collect();
                         let all_outputs = all_outputs.map_err(candle_core::Error::wrap)?;
                         if let Some(output_embed) = all_outputs.first() {
+                            Ok(output_embed.clone())
+                        } else {
+                            candle_core::bail!(
+                                "No output embedding states received from model runners"
+                            );
+                        }
+                    }
+                    RunnerType::MultiNodeMaster {
+                        local_streams: ref mut runner_streams,
+                        ref mut remote_streams,
+                    } => {
+                        let request = MessageType::RunEmbed((vec![seq.clone()], strategy.clone()));
+                        let serialized =
+                            bincode::serialize(&request).expect("Bincode serialization failed");
+
+                        for tcp_stream in remote_streams.iter_mut() {
+                            crate::utils::multi_node::send_tcp(tcp_stream, &serialized)?;
+                        }
+
+                        let cloned_streams: Vec<LocalStream> = runner_streams
+                            .iter_mut()
+                            .map(|s| s.try_clone().expect("clone failed"))
+                            .collect();
+
+                        let all_outputs: Result<Vec<Vec<Vec<f32>>>> = cloned_streams
+                            .into_par_iter()
+                            .map(|mut stream| {
+                                let msg = request.clone();
+                                send_local(&mut vec![stream.try_clone()?], &msg, false)?;
+                                let response = receive_local(&mut stream, false)?;
+
+                                match response {
+                                    MessageType::RunResponseEmbed(output_embed) => {
+                                        if output_embed.is_empty() {
+                                            candle_core::bail!("Runner step error, no response!")
+                                        } else {
+                                            Ok(output_embed)
+                                        }
+                                    }
+                                    other => {
+                                        candle_core::bail!("Unexpected response type: {:?}", other)
+                                    }
+                                }
+                            })
+                            .collect();
+                        let all_outputs = all_outputs.map_err(candle_core::Error::wrap);
+
+                        for tcp_stream in remote_streams.iter_mut() {
+                            let data = crate::utils::multi_node::recv_tcp(tcp_stream)?;
+                            let response: MessageType = bincode::deserialize(&data)
+                                .expect("Failed to deserialize remote worker response");
+                            match response {
+                                MessageType::RunResponseEmbed(output_embed) => {
+                                    if output_embed.is_empty() {
+                                        candle_core::bail!(
+                                            "Remote worker returned empty embedding response"
+                                        );
+                                    }
+                                }
+                                MessageType::Error(err) => {
+                                    candle_core::bail!("Remote worker embedding failed: {}", err);
+                                }
+                                other => {
+                                    candle_core::bail!(
+                                        "Unexpected remote embedding response: {:?}",
+                                        other
+                                    );
+                                }
+                            }
+                        }
+
+                        if let Some(output_embed) = all_outputs?.first() {
                             Ok(output_embed.clone())
                         } else {
                             candle_core::bail!(

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -100,6 +100,11 @@ pub enum Model {
 pub enum RunnerType {
     Thread(ModelRunner),
     Process(Vec<LocalStream>),
+    /// Master node in multi-node inference: local IPC streams + TCP streams to worker nodes.
+    MultiNodeMaster {
+        local_streams: Vec<LocalStream>,
+        remote_streams: Vec<std::net::TcpStream>,
+    },
 }
 
 pub struct CpuTqLayerCache {

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,6 +195,19 @@ async fn main() -> Result<()> {
             )
         });
     }
+    if args.num_nodes > 1 {
+        if args.master_addr.is_none() {
+            candle_core::bail!("--master-addr is required when --num-nodes > 1");
+        }
+        if args.node_rank >= args.num_nodes {
+            candle_core::bail!(
+                "--node-rank {} must be less than --num-nodes {}",
+                args.node_rank,
+                args.num_nodes
+            );
+        }
+    }
+
     let econfig = EngineConfig::new(
         args.model_id,
         args.weight_path,
@@ -229,7 +242,22 @@ async fn main() -> Result<()> {
         args.disable_reasoning,
         args.disable_cuda_graph,
         Some(args.prefill_chunk_size),
+        args.num_nodes,
+        args.node_rank,
+        args.master_addr.clone(),
+        args.master_port,
     );
+
+    // Multi-node worker nodes run a daemon loop instead of the full engine
+    if econfig.num_nodes > 1 && econfig.node_rank > 0 {
+        tracing::info!(
+            "Starting multi-node worker daemon (node_rank={}, num_nodes={})",
+            econfig.node_rank,
+            econfig.num_nodes
+        );
+        xinfer::utils::multi_node::run_worker_daemon(&econfig, dtype)?;
+        return Ok(());
+    }
 
     let engine = LLMEngine::new(&econfig, dtype)?;
     if let Some(addr) = server_addr {

--- a/src/mcp/manager.rs
+++ b/src/mcp/manager.rs
@@ -219,7 +219,7 @@ impl McpClientManager {
                     let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
                     match StdioTransport::spawn_with_env(command, &args_refs, env) {
                         Ok(transport) => {
-                            let mut client = McpClient::new(transport, "xinfer", "0.13.3");
+                            let mut client = McpClient::new(transport, "xinfer", "0.13.4");
                             if let Err(err) = client.initialize() {
                                 crate::log_error!(
                                     "Failed to initialize MCP server {}: {:?}",
@@ -246,7 +246,7 @@ impl McpClientManager {
                 McpTransportType::Http { url, headers } => {
                     match super::transport::HttpTransport::new(url.clone(), headers.clone()) {
                         Ok(transport) => {
-                            let mut client = McpClient::new(transport, "xinfer", "0.13.3");
+                            let mut client = McpClient::new(transport, "xinfer", "0.13.4");
                             if let Err(err) = client.initialize() {
                                 crate::log_error!(
                                     "Failed to initialize remote MCP server {}: {:?}",

--- a/src/py/mod.rs
+++ b/src/py/mod.rs
@@ -306,7 +306,8 @@ impl EngineConfig {
         mcp_command=None, mcp_config=None, mcp_args=None,
         tool_prompt_template=None,
         pd_server_prefix_cache_ratio=None, pd_client_prefix_cache_ratio=None, yarn_scaling_factor=None,
-        disable_reasoning=false, disable_cuda_graph=false, prefill_chunk_size=Some(8192),))]
+        disable_reasoning=false, disable_cuda_graph=false, prefill_chunk_size=Some(8192),
+        num_nodes=1, node_rank=0, master_addr=None, master_port=29500,))]
     pub fn new(
         model_id: Option<String>,
         weight_path: Option<String>,
@@ -341,6 +342,10 @@ impl EngineConfig {
         disable_reasoning: bool,
         disable_cuda_graph: bool,
         prefill_chunk_size: Option<usize>,
+        num_nodes: usize,
+        node_rank: usize,
+        master_addr: Option<String>,
+        master_port: u16,
     ) -> Self {
         let mut device_ids = device_ids.unwrap_or_default();
         if device_ids.is_empty() {
@@ -395,6 +400,10 @@ impl EngineConfig {
             prefill_chunk_size: crate::utils::config::normalize_prefill_chunk_size(
                 prefill_chunk_size.unwrap_or(crate::utils::config::DEFAULT_PREFILL_CHUNK_SIZE),
             ),
+            num_nodes,
+            node_rank,
+            master_addr,
+            master_port,
         }
     }
 }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -349,9 +349,8 @@ macro_rules! def_broadcast_message_to_runners {
                     // Thread Mode: Call the method directly.
                     model_runner.$thread_fn_name($($arg_name),*)
                 }
-                RunnerType::Process(ref mut runner_streams)
-                | RunnerType::MultiNodeMaster { local_streams: ref mut runner_streams, .. } => {
-                    // Process Mode: Broadcast to all local subprocess runners.
+                RunnerType::Process(ref mut runner_streams) => {
+                    // Process Mode: Broadcast to all subprocess runners.
                     let cloned_streams: Vec<LocalStream> = runner_streams
                         .iter_mut()
                         .map(|s| s.try_clone().expect("Failed to clone runner stream"))
@@ -394,6 +393,59 @@ macro_rules! def_broadcast_message_to_runners {
                         }
                         Err(e) => Err(e),
                     }
+                }
+                RunnerType::MultiNodeMaster {
+                    local_streams: ref mut runner_streams,
+                    remote_streams: ref mut remote_streams,
+                } => {
+                    let request = $msg_variant($($msg_arg),*);
+                    let cloned_streams: Vec<LocalStream> = runner_streams
+                        .iter_mut()
+                        .map(|s| s.try_clone().expect("Failed to clone runner stream"))
+                        .collect();
+
+                    let local_results: Result<Vec<$return_ty>> = cloned_streams
+                        .into_par_iter()
+                        .map(|mut stream| {
+                            let msg = request.clone();
+                            send_local(&mut vec![stream.try_clone()?], &msg, false)?;
+
+                            let response = receive_local(&mut stream, false)?;
+                            match response {
+                                $resp_variant(value) => Ok(value),
+                                other => {
+                                    candle_core::bail!("Unexpected local response for {}: {:?}", stringify!($fn_name), other)
+                                }
+                            }
+                        })
+                        .collect();
+
+                    let mut values = local_results?;
+                    let serialized = bincode::serialize(&request).expect("Bincode serialization failed");
+
+                    for tcp_stream in remote_streams.iter_mut() {
+                        crate::utils::multi_node::send_tcp(tcp_stream, &serialized)?;
+                    }
+
+                    for tcp_stream in remote_streams.iter_mut() {
+                        let data = crate::utils::multi_node::recv_tcp(tcp_stream)?;
+                        let response: MessageType = bincode::deserialize(&data)
+                            .expect("Bincode deserialization failed");
+                        match response {
+                            $resp_variant(value) => values.push(value),
+                            MessageType::Error(err) => {
+                                candle_core::bail!("Remote worker failed for {}: {}", stringify!($fn_name), err)
+                            }
+                            other => {
+                                candle_core::bail!("Unexpected remote response for {}: {:?}", stringify!($fn_name), other)
+                            }
+                        }
+                    }
+
+                    if values.is_empty() {
+                        candle_core::bail!("No values received from runners for {}", stringify!($fn_name));
+                    }
+                    Ok(values.remove(0))
                 }
             }
         }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -349,8 +349,9 @@ macro_rules! def_broadcast_message_to_runners {
                     // Thread Mode: Call the method directly.
                     model_runner.$thread_fn_name($($arg_name),*)
                 }
-                RunnerType::Process(ref mut runner_streams) => {
-                    // Process Mode: Broadcast to all subprocess runners.
+                RunnerType::Process(ref mut runner_streams)
+                | RunnerType::MultiNodeMaster { local_streams: ref mut runner_streams, .. } => {
+                    // Process Mode: Broadcast to all local subprocess runners.
                     let cloned_streams: Vec<LocalStream> = runner_streams
                         .iter_mut()
                         .map(|s| s.try_clone().expect("Failed to clone runner stream"))

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1021,6 +1021,24 @@ pub struct Args {
     /// Metal uses half of this value after rounding.
     #[arg(long, default_value_t = crate::utils::config::DEFAULT_PREFILL_CHUNK_SIZE)]
     pub prefill_chunk_size: usize,
+
+    /// Total number of nodes for multi-node tensor-parallel inference.
+    /// Each node runs local GPU workers; NCCL is bootstrapped across nodes via TCP.
+    #[arg(long, default_value_t = 1)]
+    pub num_nodes: usize,
+
+    /// This node's rank (0-indexed). Node 0 is the coordinator (runs scheduler + API).
+    #[arg(long, default_value_t = 0)]
+    pub node_rank: usize,
+
+    /// Master node address for multi-node NCCL bootstrap (e.g., 192.168.1.100).
+    /// Required on all nodes when --num-nodes > 1.
+    #[arg(long, default_value = None)]
+    pub master_addr: Option<String>,
+
+    /// Master node port for multi-node NCCL bootstrap and forward-pass coordination.
+    #[arg(long, default_value_t = 29500)]
+    pub master_port: u16,
 }
 
 impl Args {

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -1427,7 +1427,7 @@ mod tests {
             "quantization_status": "compressed",
             "sparsity_config": {},
             "transform_config": {},
-            "version": "0.13.3.dev53+gd96634b"
+            "version": "0.13.4.dev54+g704d57b"
         }"#;
         let mut cfg: QuantConfig = serde_json::from_str(json).unwrap();
         cfg.normalize_compressed_tensors();

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -422,6 +422,20 @@ pub struct EngineConfig {
     pub disable_cuda_graph: bool,
     #[serde(default = "default_prefill_chunk_size")]
     pub prefill_chunk_size: usize,
+    #[serde(default = "default_num_nodes")]
+    pub num_nodes: usize,
+    #[serde(default)]
+    pub node_rank: usize,
+    pub master_addr: Option<String>,
+    #[serde(default = "default_master_port")]
+    pub master_port: u16,
+}
+
+fn default_num_nodes() -> usize {
+    1
+}
+fn default_master_port() -> u16 {
+    29500
 }
 
 #[cfg(feature = "python")]
@@ -508,6 +522,17 @@ pub struct EngineConfig {
     #[pyo3(get, set)]
     #[serde(default = "default_prefill_chunk_size")]
     pub prefill_chunk_size: usize,
+    #[pyo3(get, set)]
+    #[serde(default = "default_num_nodes")]
+    pub num_nodes: usize,
+    #[pyo3(get, set)]
+    #[serde(default)]
+    pub node_rank: usize,
+    #[pyo3(get, set)]
+    pub master_addr: Option<String>,
+    #[pyo3(get, set)]
+    #[serde(default = "default_master_port")]
+    pub master_port: u16,
 }
 
 impl EngineConfig {
@@ -559,6 +584,10 @@ impl EngineConfig {
         disable_reasoning: bool,
         disable_cuda_graph: bool,
         prefill_chunk_size: Option<usize>,
+        num_nodes: usize,
+        node_rank: usize,
+        master_addr: Option<String>,
+        master_port: u16,
     ) -> Self {
         let mut device_ids = device_ids.unwrap_or_default();
         if device_ids.is_empty() {
@@ -612,6 +641,10 @@ impl EngineConfig {
             prefill_chunk_size: normalize_prefill_chunk_size(
                 prefill_chunk_size.unwrap_or(DEFAULT_PREFILL_CHUNK_SIZE),
             ),
+            num_nodes,
+            node_rank,
+            master_addr,
+            master_port,
         }
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -13,6 +13,7 @@ pub mod heartbeat;
 pub mod image;
 pub mod kvcache_allocator;
 pub mod logits_processor;
+pub mod multi_node;
 pub mod progress;
 pub mod reasoning;
 pub mod special_tokens;
@@ -2096,9 +2097,19 @@ pub fn prepare_engine_config(
     if device_ids.is_empty() {
         device_ids.push(0);
     }
-    let num_shards = device_ids.len();
+    let local_num_gpus = device_ids.len();
+    let num_shards = local_num_gpus * econfig.num_nodes;
     econfig.device_ids = Some(device_ids);
     econfig.num_shards = Some(num_shards);
+    if econfig.num_nodes > 1 {
+        crate::log_warn!(
+            "Multi-node: {} nodes x {} local GPUs = {} global shards (node_rank={})",
+            econfig.num_nodes,
+            local_num_gpus,
+            num_shards,
+            econfig.node_rank
+        );
+    }
 
     #[cfg(not(feature = "nccl"))]
     assert!(

--- a/src/utils/multi_node.rs
+++ b/src/utils/multi_node.rs
@@ -1,0 +1,407 @@
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+
+#[cfg(feature = "nccl")]
+use crate::models::layers::distributed::Id;
+
+/// TCP-based NCCL unique ID exchange for multi-node tensor parallelism.
+///
+/// Node 0 generates the NCCL ID, listens on `master_addr:master_port`,
+/// and sends the 128-byte ID to each connecting worker node.
+/// Worker nodes connect, receive the ID, and use it to join the NCCL
+/// communicator with their global rank.
+
+#[cfg(feature = "nccl")]
+pub fn coordinate_nccl_id(
+    num_nodes: usize,
+    node_rank: usize,
+    master_addr: &str,
+    master_port: u16,
+) -> std::io::Result<Id> {
+    if node_rank == 0 {
+        master_distribute_nccl_id(num_nodes, master_addr, master_port)
+    } else {
+        worker_receive_nccl_id(master_addr, master_port)
+    }
+}
+
+/// Master (node 0): generate NCCL ID, accept connections from (num_nodes - 1)
+/// worker nodes, send them the 128-byte raw ID.
+#[cfg(feature = "nccl")]
+fn master_distribute_nccl_id(
+    num_nodes: usize,
+    master_addr: &str,
+    master_port: u16,
+) -> std::io::Result<Id> {
+    let id = Id::new().map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("Failed to create NCCL ID: {:?}", e),
+        )
+    })?;
+
+    let raw_id: &[i8; 128] = id.internal();
+    let raw_bytes: &[u8] = unsafe { std::slice::from_raw_parts(raw_id.as_ptr() as *const u8, 128) };
+
+    let bind_addr = format!("{}:{}", master_addr, master_port);
+    crate::log_info!(
+        "[Multi-Node] Master node listening on {} for {} worker node(s)...",
+        bind_addr,
+        num_nodes - 1
+    );
+
+    let listener = TcpListener::bind(&bind_addr).map_err(|e| {
+        std::io::Error::new(
+            e.kind(),
+            format!(
+                "Failed to bind multi-node coordinator at {}: {}",
+                bind_addr, e
+            ),
+        )
+    })?;
+
+    let mut connected = 0;
+    while connected < num_nodes - 1 {
+        let (mut stream, peer_addr) = listener.accept()?;
+        crate::log_info!(
+            "[Multi-Node] Worker connected from {} ({}/{})",
+            peer_addr,
+            connected + 1,
+            num_nodes - 1
+        );
+        stream.write_all(raw_bytes)?;
+        stream.flush()?;
+
+        let mut ack = [0u8; 1];
+        stream.read_exact(&mut ack)?;
+        if ack[0] != 1 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Worker did not acknowledge NCCL ID",
+            ));
+        }
+        connected += 1;
+    }
+
+    crate::log_info!(
+        "[Multi-Node] All {} worker node(s) received NCCL ID",
+        num_nodes - 1
+    );
+    Ok(id)
+}
+
+/// Worker (node > 0): connect to master, receive 128-byte NCCL ID.
+#[cfg(feature = "nccl")]
+fn worker_receive_nccl_id(master_addr: &str, master_port: u16) -> std::io::Result<Id> {
+    let addr = format!("{}:{}", master_addr, master_port);
+    crate::log_info!("[Multi-Node] Worker connecting to master at {}...", addr);
+
+    let mut stream = {
+        let mut attempts = 0;
+        loop {
+            match TcpStream::connect(&addr) {
+                Ok(s) => break s,
+                Err(e) => {
+                    attempts += 1;
+                    if attempts > 120 {
+                        return Err(std::io::Error::new(
+                            e.kind(),
+                            format!(
+                                "Failed to connect to master at {} after {} attempts: {}",
+                                addr, attempts, e
+                            ),
+                        ));
+                    }
+                    crate::log_info!(
+                        "[Multi-Node] Waiting for master at {} (attempt {})...",
+                        addr,
+                        attempts
+                    );
+                    std::thread::sleep(std::time::Duration::from_secs(1));
+                }
+            }
+        }
+    };
+
+    let mut raw_bytes = [0u8; 128];
+    stream.read_exact(&mut raw_bytes)?;
+
+    stream.write_all(&[1u8])?;
+    stream.flush()?;
+
+    let mut arr = [0i8; 128];
+    unsafe {
+        std::ptr::copy_nonoverlapping(raw_bytes.as_ptr(), arr.as_mut_ptr() as *mut u8, 128);
+    }
+
+    #[cfg(not(target_arch = "aarch64"))]
+    let id = Id::uninit(arr);
+    #[cfg(target_arch = "aarch64")]
+    let id = Id::uninit(arr.map(|b| b as u8));
+
+    crate::log_info!("[Multi-Node] Received NCCL ID from master");
+    Ok(id)
+}
+
+/// Multi-node forward-pass coordination.
+///
+/// On non-master nodes, runners need to receive forward-pass commands
+/// from the master node via TCP and respond with results.
+/// The master node broadcasts forward commands to all remote worker nodes'
+/// TCP listeners and collects their responses.
+
+/// Configuration for a multi-node setup
+#[derive(Clone, Debug)]
+pub struct MultiNodeConfig {
+    pub num_nodes: usize,
+    pub node_rank: usize,
+    pub master_addr: String,
+    pub master_port: u16,
+    pub local_num_gpus: usize,
+}
+
+impl MultiNodeConfig {
+    pub fn global_world_size(&self) -> usize {
+        self.num_nodes * self.local_num_gpus
+    }
+
+    pub fn global_rank_offset(&self) -> usize {
+        self.node_rank * self.local_num_gpus
+    }
+
+    pub fn is_master(&self) -> bool {
+        self.node_rank == 0
+    }
+
+    /// Port used for forward-pass coordination TCP connections.
+    /// Offset from master_port by 1 to avoid collision with NCCL ID exchange.
+    pub fn forward_coord_port(&self) -> u16 {
+        self.master_port + 1
+    }
+}
+
+/// On the master node: accept TCP connections from worker nodes for
+/// forward-pass coordination. Returns one TcpStream per worker node.
+pub fn master_accept_worker_streams(config: &MultiNodeConfig) -> std::io::Result<Vec<TcpStream>> {
+    let bind_addr = format!("{}:{}", config.master_addr, config.forward_coord_port());
+    crate::log_info!(
+        "[Multi-Node] Master listening for forward coordination on {}...",
+        bind_addr
+    );
+
+    let listener = TcpListener::bind(&bind_addr)?;
+    let mut streams = Vec::new();
+    let expected = config.num_nodes - 1;
+
+    while streams.len() < expected {
+        let (stream, peer_addr) = listener.accept()?;
+        stream.set_nodelay(true)?;
+        crate::log_info!(
+            "[Multi-Node] Forward coord: worker connected from {} ({}/{})",
+            peer_addr,
+            streams.len() + 1,
+            expected
+        );
+        streams.push(stream);
+    }
+
+    crate::log_info!("[Multi-Node] All worker nodes connected for forward coordination");
+    Ok(streams)
+}
+
+/// On worker nodes: connect to master for forward-pass coordination.
+pub fn worker_connect_to_master(config: &MultiNodeConfig) -> std::io::Result<TcpStream> {
+    let addr = format!("{}:{}", config.master_addr, config.forward_coord_port());
+    crate::log_info!(
+        "[Multi-Node] Worker node {} connecting to master for forward coordination at {}...",
+        config.node_rank,
+        addr
+    );
+
+    let stream = {
+        let mut attempts = 0;
+        loop {
+            match TcpStream::connect(&addr) {
+                Ok(s) => break s,
+                Err(e) => {
+                    attempts += 1;
+                    if attempts > 120 {
+                        return Err(std::io::Error::new(
+                            e.kind(),
+                            format!(
+                                "Failed to connect to master forward coord at {} after {} attempts: {}",
+                                addr, attempts, e
+                            ),
+                        ));
+                    }
+                    std::thread::sleep(std::time::Duration::from_secs(1));
+                }
+            }
+        }
+    };
+    stream.set_nodelay(true)?;
+    crate::log_info!(
+        "[Multi-Node] Worker node {} connected to master for forward coordination",
+        config.node_rank
+    );
+    Ok(stream)
+}
+
+/// Send a length-prefixed bincode message over a TcpStream.
+pub fn send_tcp(stream: &mut TcpStream, data: &[u8]) -> std::io::Result<()> {
+    let len = data.len() as u32;
+    stream.write_all(&len.to_le_bytes())?;
+    stream.write_all(data)?;
+    stream.flush()?;
+    Ok(())
+}
+
+/// Receive a length-prefixed bincode message from a TcpStream.
+pub fn recv_tcp(stream: &mut TcpStream) -> std::io::Result<Vec<u8>> {
+    let mut len_buf = [0u8; 4];
+    stream.read_exact(&mut len_buf)?;
+    let len = u32::from_le_bytes(len_buf) as usize;
+    let mut buf = vec![0u8; len];
+    stream.read_exact(&mut buf)?;
+    Ok(buf)
+}
+
+/// Run the worker daemon on non-master nodes.
+///
+/// This function:
+/// 1. Loads the model on local GPUs using global NCCL ranks
+/// 2. Connects to the master node for forward-pass coordination
+/// 3. Loops: receives forward commands via TCP, dispatches to local runners
+///    via their existing local IPC, sends responses back to master
+#[cfg(feature = "nccl")]
+pub fn run_worker_daemon(
+    econfig: &crate::utils::config::EngineConfig,
+    dtype: candle_core::DType,
+) -> candle_core::Result<()> {
+    use crate::core::engine::LLMEngine;
+    use crate::core::runner::RunnerType;
+    use crate::runner::{receive_local, send_local, MessageType};
+    use interprocess::local_socket::Stream as LocalStream;
+    use interprocess::TryClone;
+    use rayon::iter::{IntoParallelIterator, ParallelIterator};
+
+    crate::log_info!(
+        "[Multi-Node Worker] Starting daemon on node {} with {} local GPUs",
+        econfig.node_rank,
+        econfig.device_ids.as_ref().map(|d| d.len()).unwrap_or(1)
+    );
+
+    let engine = LLMEngine::new(econfig, dtype)?;
+
+    let mn_config = MultiNodeConfig {
+        num_nodes: econfig.num_nodes,
+        node_rank: econfig.node_rank,
+        master_addr: econfig.master_addr.clone().unwrap_or_default(),
+        master_port: econfig.master_port,
+        local_num_gpus: econfig.device_ids.as_ref().map(|d| d.len()).unwrap_or(1),
+    };
+
+    let mut master_stream = worker_connect_to_master(&mn_config)
+        .map_err(|e| candle_core::Error::Msg(format!("Failed to connect to master: {}", e)))?;
+
+    crate::log_info!("[Multi-Node Worker] Entering forward daemon loop...");
+
+    loop {
+        let data = match recv_tcp(&mut master_stream) {
+            Ok(d) => d,
+            Err(e) => {
+                if e.kind() == std::io::ErrorKind::UnexpectedEof {
+                    crate::log_info!("[Multi-Node Worker] Master disconnected, shutting down");
+                    break;
+                }
+                crate::log_error!("[Multi-Node Worker] TCP recv error: {:?}", e);
+                break;
+            }
+        };
+
+        let msg: MessageType = match bincode::deserialize(&data) {
+            Ok(m) => m,
+            Err(e) => {
+                crate::log_error!("[Multi-Node Worker] Failed to deserialize message: {:?}", e);
+                continue;
+            }
+        };
+
+        match msg {
+            MessageType::RunPrefill(_) | MessageType::RunDecode(_) => {
+                // Forward the command to all local runners and collect the first result
+                let runners = engine.read().runners.clone();
+                let response = {
+                    let mut guard = runners.write();
+                    match &mut *guard {
+                        RunnerType::Process(ref mut runner_streams) => {
+                            let cloned_streams: Vec<LocalStream> = runner_streams
+                                .iter_mut()
+                                .map(|s| s.try_clone().expect("clone failed"))
+                                .collect();
+
+                            let all_outputs: candle_core::Result<Vec<Vec<u32>>> = cloned_streams
+                                .into_par_iter()
+                                .map(|mut stream| {
+                                    let msg_clone = msg.clone();
+                                    send_local(&mut vec![stream.try_clone()?], &msg_clone, false)?;
+                                    let response = receive_local(&mut stream, false)?;
+                                    match response {
+                                        MessageType::RunResponse(output_ids) => Ok(output_ids),
+                                        other => {
+                                            candle_core::bail!("Unexpected response: {:?}", other)
+                                        }
+                                    }
+                                })
+                                .collect();
+
+                            match all_outputs {
+                                Ok(outputs) => {
+                                    let ids = outputs.into_iter().next().unwrap_or_default();
+                                    MessageType::RunResponse(ids)
+                                }
+                                Err(e) => {
+                                    crate::log_error!("[Multi-Node Worker] Forward error: {:?}", e);
+                                    MessageType::RunResponse(vec![])
+                                }
+                            }
+                        }
+                        _ => {
+                            crate::log_error!("[Multi-Node Worker] Expected Process runner type");
+                            MessageType::RunResponse(vec![])
+                        }
+                    }
+                };
+
+                let response_data =
+                    bincode::serialize(&response).expect("Failed to serialize response");
+                if let Err(e) = send_tcp(&mut master_stream, &response_data) {
+                    crate::log_error!("[Multi-Node Worker] Failed to send response: {:?}", e);
+                    break;
+                }
+            }
+            MessageType::FinishDecode(id) => {
+                let mut guard = engine.write();
+                let _ = guard.notify_runner_finished(id);
+            }
+            MessageType::Shutdown => {
+                crate::log_info!("[Multi-Node Worker] Received shutdown, exiting");
+                break;
+            }
+            _ => {
+                crate::log_warn!("[Multi-Node Worker] Ignoring unhandled message type");
+            }
+        }
+    }
+
+    crate::log_info!("[Multi-Node Worker] Daemon exited");
+    Ok(())
+}
+
+#[cfg(not(feature = "nccl"))]
+pub fn run_worker_daemon(
+    _econfig: &crate::utils::config::EngineConfig,
+    _dtype: candle_core::DType,
+) -> candle_core::Result<()> {
+    candle_core::bail!("Multi-node inference requires the `nccl` feature to be enabled");
+}

--- a/src/utils/multi_node.rs
+++ b/src/utils/multi_node.rs
@@ -1,6 +1,8 @@
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 
+const MAX_TCP_MESSAGE_BYTES: usize = 1024 * 1024 * 1024;
+
 #[cfg(feature = "nccl")]
 use crate::models::layers::distributed::Id;
 
@@ -175,15 +177,20 @@ impl MultiNodeConfig {
 
     /// Port used for forward-pass coordination TCP connections.
     /// Offset from master_port by 1 to avoid collision with NCCL ID exchange.
-    pub fn forward_coord_port(&self) -> u16 {
-        self.master_port + 1
+    pub fn forward_coord_port(&self) -> std::io::Result<u16> {
+        self.master_port.checked_add(1).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "--master-port must be less than 65535 for multi-node coordination",
+            )
+        })
     }
 }
 
 /// On the master node: accept TCP connections from worker nodes for
 /// forward-pass coordination. Returns one TcpStream per worker node.
 pub fn master_accept_worker_streams(config: &MultiNodeConfig) -> std::io::Result<Vec<TcpStream>> {
-    let bind_addr = format!("{}:{}", config.master_addr, config.forward_coord_port());
+    let bind_addr = format!("{}:{}", config.master_addr, config.forward_coord_port()?);
     crate::log_info!(
         "[Multi-Node] Master listening for forward coordination on {}...",
         bind_addr
@@ -211,7 +218,7 @@ pub fn master_accept_worker_streams(config: &MultiNodeConfig) -> std::io::Result
 
 /// On worker nodes: connect to master for forward-pass coordination.
 pub fn worker_connect_to_master(config: &MultiNodeConfig) -> std::io::Result<TcpStream> {
-    let addr = format!("{}:{}", config.master_addr, config.forward_coord_port());
+    let addr = format!("{}:{}", config.master_addr, config.forward_coord_port()?);
     crate::log_info!(
         "[Multi-Node] Worker node {} connecting to master for forward coordination at {}...",
         config.node_rank,
@@ -249,7 +256,12 @@ pub fn worker_connect_to_master(config: &MultiNodeConfig) -> std::io::Result<Tcp
 
 /// Send a length-prefixed bincode message over a TcpStream.
 pub fn send_tcp(stream: &mut TcpStream, data: &[u8]) -> std::io::Result<()> {
-    let len = data.len() as u32;
+    let len = u32::try_from(data.len()).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("TCP message too large: {} bytes", data.len()),
+        )
+    })?;
     stream.write_all(&len.to_le_bytes())?;
     stream.write_all(data)?;
     stream.flush()?;
@@ -261,9 +273,44 @@ pub fn recv_tcp(stream: &mut TcpStream) -> std::io::Result<Vec<u8>> {
     let mut len_buf = [0u8; 4];
     stream.read_exact(&mut len_buf)?;
     let len = u32::from_le_bytes(len_buf) as usize;
+    if len > MAX_TCP_MESSAGE_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("TCP message length {} exceeds limit", len),
+        ));
+    }
     let mut buf = vec![0u8; len];
     stream.read_exact(&mut buf)?;
     Ok(buf)
+}
+
+#[cfg(feature = "nccl")]
+fn forward_to_local_runners(
+    runner_streams: &mut Vec<interprocess::local_socket::Stream>,
+    msg: &crate::runner::MessageType,
+) -> candle_core::Result<crate::runner::MessageType> {
+    use crate::runner::{receive_local, send_local, MessageType};
+    use interprocess::local_socket::Stream as LocalStream;
+    use interprocess::TryClone;
+    use rayon::iter::{IntoParallelIterator, ParallelIterator};
+
+    let cloned_streams: Vec<LocalStream> = runner_streams
+        .iter_mut()
+        .map(|s| s.try_clone().expect("clone failed"))
+        .collect();
+
+    let responses: candle_core::Result<Vec<MessageType>> = cloned_streams
+        .into_par_iter()
+        .map(|mut stream| {
+            send_local(&mut vec![stream.try_clone()?], msg, false)?;
+            receive_local(&mut stream, false).map_err(candle_core::Error::wrap)
+        })
+        .collect();
+
+    responses?
+        .into_iter()
+        .next()
+        .ok_or_else(|| candle_core::Error::Msg("No response from local runners".to_string()))
 }
 
 /// Run the worker daemon on non-master nodes.
@@ -280,10 +327,7 @@ pub fn run_worker_daemon(
 ) -> candle_core::Result<()> {
     use crate::core::engine::LLMEngine;
     use crate::core::runner::RunnerType;
-    use crate::runner::{receive_local, send_local, MessageType};
-    use interprocess::local_socket::Stream as LocalStream;
-    use interprocess::TryClone;
-    use rayon::iter::{IntoParallelIterator, ParallelIterator};
+    use crate::runner::MessageType;
 
     crate::log_info!(
         "[Multi-Node Worker] Starting daemon on node {} with {} local GPUs",
@@ -328,47 +372,34 @@ pub fn run_worker_daemon(
         };
 
         match msg {
-            MessageType::RunPrefill(_) | MessageType::RunDecode(_) => {
-                // Forward the command to all local runners and collect the first result
+            MessageType::RunPrefill(_)
+            | MessageType::RunDecode(_)
+            | MessageType::RunEmbed(_)
+            | MessageType::KVCacheSwap(_)
+            | MessageType::CaptureMambaPrefixState(_)
+            | MessageType::HasMambaPrefixState(_)
+            | MessageType::RemoveMambaPrefixState(_)
+            | MessageType::TransferPrefill(_)
+            | MessageType::ReceivePrefill(_)
+            | MessageType::CheckPrefillStatus(_)
+            | MessageType::KvCacheSend(_)
+            | MessageType::KvCacheReceive(_)
+            | MessageType::KvCacheRelease(_)
+            | MessageType::CheckKvCacheRelease(_)
+            | MessageType::ClearBlocks(_) => {
                 let runners = engine.read().runners.clone();
                 let response = {
                     let mut guard = runners.write();
                     match &mut *guard {
                         RunnerType::Process(ref mut runner_streams) => {
-                            let cloned_streams: Vec<LocalStream> = runner_streams
-                                .iter_mut()
-                                .map(|s| s.try_clone().expect("clone failed"))
-                                .collect();
-
-                            let all_outputs: candle_core::Result<Vec<Vec<u32>>> = cloned_streams
-                                .into_par_iter()
-                                .map(|mut stream| {
-                                    let msg_clone = msg.clone();
-                                    send_local(&mut vec![stream.try_clone()?], &msg_clone, false)?;
-                                    let response = receive_local(&mut stream, false)?;
-                                    match response {
-                                        MessageType::RunResponse(output_ids) => Ok(output_ids),
-                                        other => {
-                                            candle_core::bail!("Unexpected response: {:?}", other)
-                                        }
-                                    }
-                                })
-                                .collect();
-
-                            match all_outputs {
-                                Ok(outputs) => {
-                                    let ids = outputs.into_iter().next().unwrap_or_default();
-                                    MessageType::RunResponse(ids)
-                                }
-                                Err(e) => {
-                                    crate::log_error!("[Multi-Node Worker] Forward error: {:?}", e);
-                                    MessageType::RunResponse(vec![])
-                                }
+                            match forward_to_local_runners(runner_streams, &msg) {
+                                Ok(response) => response,
+                                Err(e) => MessageType::Error(format!("{:?}", e)),
                             }
                         }
                         _ => {
                             crate::log_error!("[Multi-Node Worker] Expected Process runner type");
-                            MessageType::RunResponse(vec![])
+                            MessageType::Error("Expected Process runner type".to_string())
                         }
                     }
                 };

--- a/tests/preprocess_parity.rs
+++ b/tests/preprocess_parity.rs
@@ -69,6 +69,10 @@ fn build_econfig() -> EngineConfig {
         true,                                // disable_reasoning — deterministic prompt
         false,                               // disable_cuda_graph
         None,                                // prefill_chunk_size — default
+        1,                                   // num_nodes
+        0,                                   // node_rank
+        None,                                // master_addr
+        29500,                               // master_port
     )
 }
 


### PR DESCRIPTION

## Multi-Node Inference

Distribute inference across multiple machines using TCP-based NCCL bootstrap. No MPI required.

```bash
# Node 0 (master, 192.168.1.100): scheduler + API
xinfer --d 0,1,2,3 --m /data/DeepSeek-R1/ \
  --num-nodes 2 --node-rank 0 --master-addr 192.168.1.100 --ui-server

# Node 1 (worker, 192.168.1.101): forward-only daemon
xinfer --d 0,1,2,3 --m /data/DeepSeek-R1/ \
  --num-nodes 2 --node-rank 1 --master-addr 192.168.1.100
```

All nodes must have model weights locally and be TCP-reachable on `--master-port` (default 29500).