### PR TITLE
Support multi-GGUF shard loading & unified --m entry

### DIFF
--- a/ReadMe-CN.md
+++ b/ReadMe-CN.md
@@ -251,7 +251,7 @@ xinfer --m /path/Qwen3-4B --isq q6k
 
 ```bash
 # 多卡 GGUF（模型 ID + 子文件夹）
-xinfer --d 0,1,2,3 --m unsloth/GLM-5.2-GGUF --f UD-Q2_K_XL
+xinfer --d 0,1,2,3 --m unsloth/Qwen3.5-122B-A10B-GGUF --f Q3_K_M
 
 # 远程 GGUF — 单文件模型
 xinfer --m unsloth/Qwen3.5-27B-GGUF --f Qwen3.5-27B-Q4_K_M.gguf

--- a/ReadMe-CN.md
+++ b/ReadMe-CN.md
@@ -250,11 +250,17 @@ xinfer --m /path/Qwen3-4B --isq q6k
 <summary><b>GGUF 模型</b></summary>
 
 ```bash
-# 单卡 — GGUF
+# 多卡 GGUF（模型 ID + 子文件夹）
+xinfer --d 0,1,2,3 --m unsloth/GLM-5.2-GGUF --f UD-Q2_K_XL
+
+# 远程 GGUF — 单文件模型
 xinfer --m unsloth/Qwen3.5-27B-GGUF --f Qwen3.5-27B-Q4_K_M.gguf
 
-# 多卡 — GGUF
+# 本地 GGUF 文件（直接路径）
 xinfer --d 0,1 --m /path/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf
+
+# 本地 GGUF 文件夹
+xinfer --d 0,1,2,3 --m /path/to/model-GGUF/
 ```
 
 </details>
@@ -460,7 +466,7 @@ xinfer --m unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF \
 
 | 参数 | 说明 |
 |---|---|
-| `--m` | 模型来源：HuggingFace 模型 ID、本地 Safetensors 目录或本地 GGUF 文件 |
+| `--m` | 模型来源：HuggingFace 模型 ID、本地 Safetensors 目录、本地 GGUF 文件或包含 GGUF 文件的本地文件夹 |
 | `--w` | 本地 Safetensors 目录的旧别名；新命令优先使用 `--m <local_dir>` |
 | `--f` | 单独使用时为本地 GGUF 文件；配合 `--m <model_id>` 时为远程 GGUF 文件名 |
 | `--d` | 设备 ID（如 `--d 0,1`） |

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -252,7 +252,7 @@ xinfer --m /path/Qwen3-4B --isq q6k
 
 ```bash
 # Multi-GPU GGUF (model ID + subfolder)
-xinfer --d 0,1,2,3 --m unsloth/GLM-5.2-GGUF --f UD-Q2_K_XL
+xinfer --d 0,1,2,3 --m unsloth/Qwen3.5-122B-A10B-GGUF --f Q3_K_M
 
 # Remote GGUF — single-file model
 xinfer --m unsloth/Qwen3.5-27B-GGUF --f Qwen3.5-27B-Q4_K_M.gguf

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -251,11 +251,17 @@ xinfer --m /path/Qwen3-4B --isq q6k
 <summary><b>GGUF models</b></summary>
 
 ```bash
-# Single GPU — GGUF
+# Multi-GPU GGUF (model ID + subfolder)
+xinfer --d 0,1,2,3 --m unsloth/GLM-5.2-GGUF --f UD-Q2_K_XL
+
+# Remote GGUF — single-file model
 xinfer --m unsloth/Qwen3.5-27B-GGUF --f Qwen3.5-27B-Q4_K_M.gguf
 
-# Multi-GPU — GGUF
+# Local GGUF file (direct path)
 xinfer --d 0,1 --m /path/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf
+
+# Local GGUF folder
+xinfer --d 0,1,2,3 --m /path/to/model-GGUF/
 ```
 
 </details>
@@ -466,7 +472,7 @@ Constraint-based generation via llguidance — Lark grammars, regex, JSON Schema
 
 | Flag | Description |
 |---|---|
-| `--m` | Model source: HuggingFace model ID, local Safetensors directory, or local GGUF file |
+| `--m` | Model source: HuggingFace model ID, local Safetensors directory, local GGUF file, or local folder containing GGUF files |
 | `--w` | Legacy alias for local Safetensors directory; prefer `--m <local_dir>` |
 | `--f` | Local GGUF file when used alone; remote GGUF filename when paired with `--m <model_id>` |
 | `--d` | Device IDs (e.g. `--d 0,1`) |

--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -22,8 +22,13 @@ cargo build --release --features metal
 ## Model formats
 - **Safetensors (HF layout)**: `--m <hf_id>` for cached download, or `--m <local_dir>` for offline weights + configs. `--w <local_dir>` still works as a legacy alias.
 - **Safetensors (HF layout) + ISQ**: in-situ quantize into GGUF with args `--isq <q4k|q2k|q6k|...>`.
-- **GGUF**: `--m <local.gguf>` or `--f <local.gguf>` for a local file. Use `--m <hf_id> --f <remote_file.gguf>` for a GGUF file hosted in a Hugging Face repo.
-- **Vision-Language** (Qwen3-VL, Gemma3, Mistral3-VL): require image tokens; use `--ui-server` for uploads or send image_url/base64 in the request.
+- **GGUF**: multiple loading modes:
+  - `--m <local.gguf>` — load a single local GGUF file.
+  - `--m <local_dir>` — auto-detect the main GGUF file in a directory (picks the largest non-mmproj `.gguf`). Multi-shard files (`*-00001-of-00007.gguf`) and auxiliary files (`mmproj-*.gguf` for vision towers) are auto-discovered.
+  - `--f <local.gguf>` — load a single local GGUF file (alternative syntax).
+  - `--m <hf_id> --f <remote_file.gguf>` — download a GGUF file from a Hugging Face repo.
+  - `--m <hf_id> --f <subfolder>` — auto-detect all GGUF files in a HuggingFace repo subfolder (e.g. `--m unsloth/GLM-5.2-GGUF --f UD-Q2_K_XL`).
+- **Vision-Language** (Qwen3-VL, Qwen3.5-VL, Gemma3, Gemma4, Mistral3-VL): require image tokens; use `--ui-server` for uploads or send image_url/base64 in the request. For GGUF multimodal models, place the `mmproj-*.gguf` vision tower file in the same directory as the main model file — it will be auto-detected.
 
 
 ## 3) Run patterns (single host)
@@ -36,11 +41,19 @@ cargo build --release --features metal
   ```bash
   target/release/xinfer --m meta-llama/Llama-3-8b --max-model-len 32768 --ui-server
   ```
-- **GGUF quantized**  
+- **GGUF quantized (single file)**  
   ```bash
   target/release/xinfer --m /path/model-Q4_K_M.gguf --max-model-len 65536
   ```
-- **Remote GGUF quantized**  
+- **GGUF quantized (folder with auto-detection)**  
+  ```bash
+  target/release/xinfer --m /path/model-GGUF/ --ui-server
+  ```
+- **Remote GGUF quantized (multi-shard subfolder)**  
+  ```bash
+  target/release/xinfer --d 0,1,2,3 --m unsloth/GLM-5.2-GGUF --f UD-Q2_K_XL --ui-server
+  ```
+- **Remote GGUF quantized (single file)**  
   ```bash
   target/release/xinfer --m unsloth/Qwen3-0.6B-GGUF --f Qwen3-0.6B-Q4_K_M.gguf --ui-server
   ```

--- a/src/api.rs
+++ b/src/api.rs
@@ -125,9 +125,6 @@ impl EngineBuilder {
             ),
             ModelRepo::ModelPath(path) => (None, Some(path.to_owned()), None),
             ModelRepo::ModelFile(files) => {
-                if files.len() > 1 {
-                    crate::log_warn!("Multiple GGUF files provided, using the first one.");
-                }
                 let weight_file = files.into_iter().next().map(|f| f.to_owned());
                 (None, None, weight_file)
             }

--- a/src/models/layers/mod.rs
+++ b/src/models/layers/mod.rs
@@ -79,8 +79,8 @@ impl VarBuilderX<'_> {
         );
         let weight_files = model_pathes.get_weight_filenames();
         if is_gguf {
-            let vb = crate::utils::gguf_varbuilder::VarBuilder::from_gguf(
-                weight_files[0].clone(),
+            let vb = crate::utils::gguf_varbuilder::VarBuilder::from_gguf_files(
+                weight_files,
                 device,
             )?;
             let auxiliary_vb = model_pathes

--- a/src/models/layers/mod.rs
+++ b/src/models/layers/mod.rs
@@ -80,7 +80,7 @@ impl VarBuilderX<'_> {
         let weight_files = model_pathes.get_weight_filenames();
         if is_gguf {
             let vb = crate::utils::gguf_varbuilder::VarBuilder::from_gguf_files(
-                weight_files,
+                &weight_files,
                 device,
             )?;
             let auxiliary_vb = model_pathes

--- a/src/utils/downloader.rs
+++ b/src/utils/downloader.rs
@@ -191,6 +191,60 @@ impl Downloader {
         })
     }
 
+    fn find_split_gguf_shards(main_file: &Path) -> Vec<PathBuf> {
+        let file_name = main_file.file_name().and_then(|f| f.to_str()).unwrap_or("");
+        let re = regex::Regex::new(r"^(.+)-(\d{5})-of-(\d{5})\.gguf$").unwrap();
+        let Some(caps) = re.captures(file_name) else {
+            return vec![main_file.to_path_buf()];
+        };
+        let prefix = &caps[1];
+        let total: usize = caps[3].parse().unwrap_or(1);
+        let dir = main_file.parent().unwrap_or(Path::new("."));
+
+        let mut shards: Vec<PathBuf> = (1..=total)
+            .map(|i| dir.join(format!("{}-{:05}-of-{:05}.gguf", prefix, i, total)))
+            .filter(|p| p.exists())
+            .collect();
+
+        if shards.len() != total {
+            crate::log_warn!(
+                "Expected {} GGUF shards but found {}; using only the main file",
+                total,
+                shards.len()
+            );
+            return vec![main_file.to_path_buf()];
+        }
+
+        shards.sort();
+        crate::log_info!("Found {} split GGUF shards for {}", shards.len(), prefix);
+        shards
+    }
+
+    /// Scan a directory for the main GGUF file (excludes mmproj auxiliary files).
+    /// Returns the path to the best candidate, preferring the largest non-mmproj
+    /// `.gguf` file (or the first split shard alphabetically).
+    fn find_main_gguf_in_dir(dir: &Path) -> Option<PathBuf> {
+        let entries = std::fs::read_dir(dir).ok()?;
+        let mut candidates: Vec<(PathBuf, u64)> = Vec::new();
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_file() || !Self::has_gguf_extension(&path) {
+                continue;
+            }
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            if Self::is_mmproj_filename(name) {
+                continue;
+            }
+            let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
+            candidates.push((path, size));
+        }
+        if candidates.is_empty() {
+            return None;
+        }
+        candidates.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        Some(candidates[0].0.clone())
+    }
+
     fn local_gguf_model(main_file: &Path) -> Result<ModelPaths> {
         if !main_file.exists() {
             candle_core::bail!("Model file not found: {}", main_file.display());
@@ -201,6 +255,8 @@ impl Downloader {
                 main_file.display()
             );
         }
+
+        let filenames = Self::find_split_gguf_shards(main_file);
 
         let auxiliary_filenames = Self::find_local_mmproj_file(main_file)
             .map(|path| {
@@ -216,7 +272,7 @@ impl Downloader {
             tokenizer_filename: PathBuf::new(),
             tokenizer_config_filename: PathBuf::new(),
             config_filename: PathBuf::new(),
-            filenames: vec![main_file.to_path_buf()],
+            filenames,
             auxiliary_filenames,
             generation_config_filename: "".into(),
             chat_template_filename: None,
@@ -286,8 +342,22 @@ impl Downloader {
             &self.weight_path,
             &self.weight_file,
         ) {
-            //model in a folder (safetensor format, huggingface folder structure)
-            (None, Some(path), None) => (Self::local_safetensors_model(path)?, false),
+            (None, Some(path), None) => {
+                let p = Path::new(path.as_str());
+                if p.is_dir() {
+                    if let Some(main_gguf) = Self::find_main_gguf_in_dir(p) {
+                        crate::log_info!(
+                            "Auto-detected main GGUF file in directory: {}",
+                            main_gguf.display()
+                        );
+                        (Self::local_gguf_model(&main_gguf)?, true)
+                    } else {
+                        (Self::local_safetensors_model(path)?, false)
+                    }
+                } else {
+                    (Self::local_safetensors_model(path)?, false)
+                }
+            }
             //model in a quantized file (gguf/ggml format)
             (None, path, Some(file)) => {
                 let path = path.clone().unwrap_or_default();
@@ -298,7 +368,15 @@ impl Downloader {
             (Some(model), None, None) if Path::new(model).exists() => {
                 let path = Path::new(model);
                 if path.is_dir() {
-                    (Self::local_safetensors_model(model)?, false)
+                    if let Some(main_gguf) = Self::find_main_gguf_in_dir(path) {
+                        crate::log_info!(
+                            "Auto-detected main GGUF file in directory: {}",
+                            main_gguf.display()
+                        );
+                        (Self::local_gguf_model(&main_gguf)?, true)
+                    } else {
+                        (Self::local_safetensors_model(model)?, false)
+                    }
                 } else if path.is_file() {
                     (Self::local_gguf_model(path)?, true)
                 } else {
@@ -588,6 +666,38 @@ impl Downloader {
         })
     }
 
+    fn discover_remote_gguf_shards(
+        filename: &str,
+        remote_files: &std::collections::HashSet<String>,
+    ) -> Vec<String> {
+        let re = regex::Regex::new(r"^(.+)-(\d{5})-of-(\d{5})\.gguf$").unwrap();
+        let Some(caps) = re.captures(filename) else {
+            return vec![filename.to_string()];
+        };
+        let prefix = &caps[1];
+        let total: usize = caps[3].parse().unwrap_or(1);
+
+        let mut shards: Vec<String> = (1..=total)
+            .map(|i| format!("{}-{:05}-of-{:05}.gguf", prefix, i, total))
+            .filter(|name| remote_files.contains(name))
+            .collect();
+
+        if shards.len() != total {
+            crate::log_warn!(
+                "Expected {} remote GGUF shards but found {} in repo; using only the main file",
+                total,
+                shards.len()
+            );
+            return vec![filename.to_string()];
+        }
+        shards.sort();
+        crate::log_info!(
+            "Discovered {} split GGUF shards in remote repo",
+            shards.len()
+        );
+        shards
+    }
+
     pub fn download_gguf_model(&self, revision: Option<String>) -> Result<ModelPaths> {
         assert!(self.model_id.is_some(), "No model id provided!");
         crate::log_info!(
@@ -595,7 +705,7 @@ impl Downloader {
             self.weight_file.as_ref().unwrap(),
             self.model_id.as_ref().unwrap(),
         );
-        let filename = self.weight_file.clone().unwrap();
+        let mut filename = self.weight_file.clone().unwrap();
         let mut filenames = vec![];
         let api = hf_hub::api::sync::Api::new().unwrap();
         let revision = revision.unwrap_or("main".to_string());
@@ -605,17 +715,60 @@ impl Downloader {
             revision.to_string(),
         ));
         let repo_info = repo.info().map_err(candle_core::Error::wrap)?;
-        let mmproj_name = Self::pick_mmproj_filename(
-            repo_info.siblings.iter().map(|s| s.rfilename.as_str()),
-            Some(&filename),
-        );
+        let remote_files: std::collections::HashSet<String> = repo_info
+            .siblings
+            .iter()
+            .map(|s| s.rfilename.clone())
+            .collect();
+
+        // If --f is a subfolder (no .gguf extension), discover GGUF files in it
+        if !filename.ends_with(".gguf") {
+            let subfolder = filename.trim_end_matches('/').to_string();
+            let prefix = format!("{}/", subfolder);
+            let mut gguf_files: Vec<String> = remote_files
+                .iter()
+                .filter(|f| f.starts_with(&prefix) && f.ends_with(".gguf"))
+                .cloned()
+                .collect();
+            gguf_files.sort();
+            if gguf_files.is_empty() {
+                candle_core::bail!(
+                    "No GGUF files found in subfolder '{}' of repo {}. \
+                     Available files: {:?}",
+                    subfolder,
+                    self.model_id.as_ref().unwrap(),
+                    remote_files.iter().take(20).collect::<Vec<_>>()
+                );
+            }
+            crate::log_info!(
+                "Subfolder '{}' contains {} GGUF file(s); using '{}' as primary",
+                subfolder,
+                gguf_files.len(),
+                gguf_files[0]
+            );
+            filename = gguf_files[0].clone();
+        }
+
+        let mmproj_name =
+            Self::pick_mmproj_filename(remote_files.iter().map(|s| s.as_str()), Some(&filename));
+
+        let shard_names = Self::discover_remote_gguf_shards(&filename, &remote_files);
 
         let mut auxiliary_filenames = Vec::new();
         if let Some(cache_path) = self.check_cache() {
-            let cached_gguf_file = cache_path.join(&filename);
-            if cached_gguf_file.exists() {
-                crate::log_warn!("Found cache: {}", cached_gguf_file.display());
-                filenames.push(cached_gguf_file.clone());
+            let mut all_cached = true;
+            for shard_name in &shard_names {
+                let cached_file = cache_path.join(shard_name);
+                if cached_file.exists() {
+                    crate::log_warn!("Found cache: {}", cached_file.display());
+                    filenames.push(cached_file);
+                } else {
+                    all_cached = false;
+                    break;
+                }
+            }
+            if !all_cached {
+                filenames.clear();
             }
 
             if let Some(mmproj_name) = &mmproj_name {
@@ -640,10 +793,15 @@ impl Downloader {
         }
 
         if filenames.is_empty() {
-            let filename = repo
-                .get(filename.as_str())
-                .map_err(candle_core::Error::wrap)?;
-            filenames.push(filename);
+            for shard_name in &shard_names {
+                let downloaded = self.hf_get_with_retry(
+                    &repo,
+                    shard_name,
+                    5,
+                    std::time::Duration::from_secs(5),
+                )?;
+                filenames.push(downloaded);
+            }
         }
 
         if auxiliary_filenames.is_empty() {

--- a/src/utils/gguf_varbuilder.rs
+++ b/src/utils/gguf_varbuilder.rs
@@ -1,15 +1,19 @@
-use candle::quantized::QTensor;
+use candle::quantized::{GgmlDType, QTensor};
 use candle::{Device, Result, Shape};
 use candle_core as candle;
 use std::fs::File;
 use std::sync::Arc;
 use std::sync::Mutex;
-// light-cached qvarbuilder
+
+struct GgufShard {
+    content: candle_core::quantized::gguf_file::Content,
+    file: File,
+}
 
 #[derive(Clone)]
 pub struct VarBuilder {
-    content: Arc<candle_core::quantized::gguf_file::Content>,
-    file: Arc<std::sync::Mutex<File>>,
+    shards: Arc<Mutex<Vec<GgufShard>>>,
+    tensor_to_shard: Arc<std::collections::HashMap<String, usize>>,
     cache: Arc<Mutex<Option<(String, Arc<QTensor>)>>>,
     path: Vec<String>,
     device: Device,
@@ -18,12 +22,35 @@ pub struct VarBuilder {
 
 impl VarBuilder {
     pub fn from_gguf<P: AsRef<std::path::Path>>(p: P, device: &Device) -> Result<Self> {
-        let file_path = p.as_ref().to_string_lossy().to_string();
-        let mut file = File::open(&p)?;
-        let content = candle_core::quantized::gguf_file::Content::read(&mut file)?;
+        Self::from_gguf_files(&[p.as_ref().to_path_buf()], device)
+    }
+
+    pub fn from_gguf_files(paths: &[std::path::PathBuf], device: &Device) -> Result<Self> {
+        assert!(!paths.is_empty(), "No GGUF files provided!");
+        let file_path = paths[0].to_string_lossy().to_string();
+        let mut shards = Vec::with_capacity(paths.len());
+        let mut tensor_to_shard = std::collections::HashMap::new();
+
+        for (shard_idx, path) in paths.iter().enumerate() {
+            let mut file = File::open(path)?;
+            let content = candle_core::quantized::gguf_file::Content::read(&mut file)?;
+            for name in content.tensor_infos.keys() {
+                tensor_to_shard.insert(name.clone(), shard_idx);
+            }
+            shards.push(GgufShard { content, file });
+        }
+
+        if paths.len() > 1 {
+            crate::log_info!(
+                "Loaded {} GGUF shards with {} total tensors",
+                paths.len(),
+                tensor_to_shard.len()
+            );
+        }
+
         Ok(Self {
-            content: Arc::new(content),
-            file: Arc::new(std::sync::Mutex::new(file)),
+            shards: Arc::new(Mutex::new(shards)),
+            tensor_to_shard: Arc::new(tensor_to_shard),
             cache: Arc::new(Mutex::new(None)),
             path: Vec::new(),
             device: device.clone(),
@@ -39,8 +66,8 @@ impl VarBuilder {
         let mut path = self.path.clone();
         path.push(s.to_string());
         Self {
-            content: self.content.clone(),
-            file: self.file.clone(),
+            shards: self.shards.clone(),
+            tensor_to_shard: self.tensor_to_shard.clone(),
             cache: self.cache.clone(),
             path,
             device: self.device.clone(),
@@ -56,15 +83,24 @@ impl VarBuilder {
         }
     }
 
+    fn resolve_shard(&self, tensor_path: &str) -> Result<usize> {
+        self.tensor_to_shard
+            .get(tensor_path)
+            .copied()
+            .ok_or_else(|| {
+                candle::Error::Msg(format!(
+                    "cannot find tensor {tensor_path} in any GGUF shard"
+                ))
+            })
+    }
+
     pub fn get<S: Into<Shape>>(&self, s: S, name: &str) -> Result<Arc<QTensor>> {
         let path = self.path(name);
 
-        // Check cache
         {
             let cache_guard = self.cache.lock().unwrap();
             if let Some((ref cached_name, ref cached_tensor)) = *cache_guard {
                 if cached_name == &path {
-                    // Return cached tensor
                     let shape = s.into();
                     if cached_tensor.shape() != &shape {
                         candle::bail!(
@@ -77,10 +113,11 @@ impl VarBuilder {
             }
         }
 
-        let mut file = self.file.lock().unwrap();
-        let tensor = self.content.tensor(&mut *file, &path, &self.device)?;
+        let shard_idx = self.resolve_shard(&path)?;
+        let mut shards = self.shards.lock().unwrap();
+        let shard = &mut shards[shard_idx];
+        let tensor = shard.content.tensor(&mut shard.file, &path, &self.device)?;
         let tensor = Arc::new(tensor);
-        // Update cache
         *self.cache.lock().unwrap() = Some((path.clone(), tensor.clone()));
 
         let shape = s.into();
@@ -122,10 +159,17 @@ impl VarBuilder {
         let mut shard_shape = shape.dims().to_vec();
         shard_shape[dim] /= world_size;
 
-        let mut file = self.file.lock().unwrap();
-        let Some(tensor) =
-            self.content
-                .tensor_shard(&mut *file, &path, dim, rank, world_size, &self.device)?
+        let shard_idx = self.resolve_shard(&path)?;
+        let mut shards = self.shards.lock().unwrap();
+        let shard = &mut shards[shard_idx];
+        let Some(tensor) = shard.content.tensor_shard(
+            &mut shard.file,
+            &path,
+            dim,
+            rank,
+            world_size,
+            &self.device,
+        )?
         else {
             return Ok(None);
         };
@@ -140,10 +184,11 @@ impl VarBuilder {
     }
 
     pub fn get_no_shape(&self, name: &str) -> Result<Arc<QTensor>> {
-        let mut file = self.file.lock().unwrap();
-        let tensor = self
-            .content
-            .tensor(&mut *file, &self.path(name), &self.device)?;
+        let path = self.path(name);
+        let shard_idx = self.resolve_shard(&path)?;
+        let mut shards = self.shards.lock().unwrap();
+        let shard = &mut shards[shard_idx];
+        let tensor = shard.content.tensor(&mut shard.file, &path, &self.device)?;
         Ok(Arc::new(tensor))
     }
 
@@ -156,13 +201,36 @@ impl VarBuilder {
     }
 
     pub fn contains_key(&self, key: &str) -> bool {
-        self.content.tensor_infos.contains_key(&self.path(key))
+        let path = self.path(key);
+        self.tensor_to_shard.contains_key(&path)
     }
 
     pub fn tensor_shape(&self, key: &str) -> Option<Vec<usize>> {
-        self.content
+        let path = self.path(key);
+        let shard_idx = self.tensor_to_shard.get(&path)?;
+        let shards = self.shards.lock().unwrap();
+        shards[*shard_idx]
+            .content
             .tensor_infos
-            .get(&self.path(key))
+            .get(&path)
             .map(|info| info.shape.dims().to_vec())
+    }
+
+    pub fn tensor_dtype(&self, key: &str) -> Option<GgmlDType> {
+        let path = self.path(key);
+        let shard_idx = self.tensor_to_shard.get(&path)?;
+        let shards = self.shards.lock().unwrap();
+        shards[*shard_idx]
+            .content
+            .tensor_infos
+            .get(&path)
+            .map(|info| info.ggml_dtype)
+    }
+
+    pub fn first_content_metadata(
+        &self,
+    ) -> std::collections::HashMap<String, candle_core::quantized::gguf_file::Value> {
+        let shards = self.shards.lock().unwrap();
+        shards[0].content.metadata.clone()
     }
 }


### PR DESCRIPTION
## Summary

- **Unified `--m` entry**: When `--m` points to a local directory containing GGUF files, auto-detect and load the main GGUF file without requiring `--f`. This works for both `--m <dir>` and `--w <dir>` paths.
- **Multi-GGUF shard support**: Automatically discover and load split GGUF shards (e.g. `model-00001-of-00003.gguf`) for both local and remote (HuggingFace) models. All shards are loaded into a unified `VarBuilder` with per-tensor shard routing.
- **Subfolder discovery**: When `--f` specifies a subfolder (not a `.gguf` file) in a remote repo, scan the subfolder for GGUF files automatically.
- **VarBuilder refactor**: Refactored `gguf_varbuilder::VarBuilder` from a single-file architecture to multi-shard, with `tensor_to_shard` index for O(1) tensor lookup across shards. Added `tensor_dtype()` and `first_content_metadata()` helpers.

### Files changed

| File | Change |
|------|--------|
| `src/utils/downloader.rs` | `find_split_gguf_shards()`, `find_main_gguf_in_dir()`, `discover_remote_gguf_shards()`; updated download routing and `download_gguf_model()` |
| `src/utils/gguf_varbuilder.rs` | Multi-shard `VarBuilder` with `GgufShard` struct, `from_gguf_files()`, `resolve_shard()`, `tensor_dtype()`, `first_content_metadata()` |
| `src/models/layers/mod.rs` | Use `from_gguf_files()` instead of `from_gguf()` for weight loading |
| `src/api.rs` | Remove obsolete "Multiple GGUF files" warning |

### Usage examples

```bash
# Before: needed --m and --f separately for local GGUF
xinfer --m /path/to/model --f model.gguf

# After: just point --m at the directory
xinfer --m /path/to/model

# Split shards auto-detected (local)
xinfer --m /path/to/model-00001-of-00003.gguf
# -> automatically loads all 3 shards

# Split shards auto-detected (remote)
xinfer --m org/repo --f model-00001-of-00003.gguf
# -> downloads and loads all 3 shards

# Subfolder in remote repo
xinfer --m org/repo --f Q4_K_M/
# -> discovers GGUF files in Q4_K_M/ subfolder
```

## Test plan

- [ ] Verify single GGUF file loading still works (backward compatible)
- [ ] Test `--m <dir>` with a directory containing a single GGUF file
- [ ] Test `--m <dir>` with a directory containing split GGUF shards
- [ ] Test remote GGUF download with split shards
- [ ] Test `--f subfolder/` with a remote repo