### PR TITLE
Fix custom tokenizer config deserialization and propagate loading errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xinfer"
-version = "0.13.4"
+version = "0.13.5"
 edition = "2021"
 default-run = "xinfer"
 description = "xInfer — a minimal, high-performance large language model (LLM) inference engine in Rust."

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xinfer-ai",
-  "version": "0.13.4",
-  "assetVersion": "0.13.4",
+  "version": "0.13.5",
+  "assetVersion": "0.13.5",
   "description": "xInfer — a high-performance LLM inference engine in Rust with CUDA/Metal acceleration",
   "license": "MIT",
   "homepage": "https://github.com/guoqingbao/xinfer#readme",

--- a/pages/index.html
+++ b/pages/index.html
@@ -656,7 +656,7 @@ document.querySelectorAll('.cb').forEach(function(bl){
 });
 
 /* ═══ Download cards ═══ */
-var XINFER_VER='0.13.4';
+var XINFER_VER='0.13.5';
 var DL='https://github.com/guoqingbao/xinfer/releases/download/v'+XINFER_VER+'/';
 var archs=[
   {sm:'sm70',n:'70',name:'SM70',gpu:'V100',cuda:'CUDA 12',arch:'x64',d:0},

--- a/src/mcp/manager.rs
+++ b/src/mcp/manager.rs
@@ -219,7 +219,7 @@ impl McpClientManager {
                     let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
                     match StdioTransport::spawn_with_env(command, &args_refs, env) {
                         Ok(transport) => {
-                            let mut client = McpClient::new(transport, "xinfer", "0.13.4");
+                            let mut client = McpClient::new(transport, "xinfer", "0.13.5");
                             if let Err(err) = client.initialize() {
                                 crate::log_error!(
                                     "Failed to initialize MCP server {}: {:?}",
@@ -246,7 +246,7 @@ impl McpClientManager {
                 McpTransportType::Http { url, headers } => {
                     match super::transport::HttpTransport::new(url.clone(), headers.clone()) {
                         Ok(transport) => {
-                            let mut client = McpClient::new(transport, "xinfer", "0.13.4");
+                            let mut client = McpClient::new(transport, "xinfer", "0.13.5");
                             if let Err(err) = client.initialize() {
                                 crate::log_error!(
                                     "Failed to initialize remote MCP server {}: {:?}",

--- a/src/models/layers/mod.rs
+++ b/src/models/layers/mod.rs
@@ -79,10 +79,8 @@ impl VarBuilderX<'_> {
         );
         let weight_files = model_pathes.get_weight_filenames();
         if is_gguf {
-            let vb = crate::utils::gguf_varbuilder::VarBuilder::from_gguf_files(
-                &weight_files,
-                device,
-            )?;
+            let vb =
+                crate::utils::gguf_varbuilder::VarBuilder::from_gguf_files(&weight_files, device)?;
             let auxiliary_vb = model_pathes
                 .get_auxiliary_filenames()
                 .first()

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -665,13 +665,53 @@ impl EngineConfig {
     }
 }
 
+fn deserialize_token_field<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+    struct TokenVisitor;
+    impl<'de> de::Visitor<'de> for TokenVisitor {
+        type Value = Option<String>;
+        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            f.write_str("a string, an AddedToken object with 'content', or null")
+        }
+        fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+        fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+        fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+            Ok(Some(v.to_owned()))
+        }
+        fn visit_string<E: de::Error>(self, v: String) -> Result<Self::Value, E> {
+            Ok(Some(v))
+        }
+        fn visit_map<A: de::MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+            let mut content: Option<String> = None;
+            while let Some(key) = map.next_key::<String>()? {
+                if key == "content" {
+                    content = Some(map.next_value()?);
+                } else {
+                    let _ = map.next_value::<serde::de::IgnoredAny>()?;
+                }
+            }
+            Ok(content)
+        }
+    }
+    deserializer.deserialize_any(TokenVisitor)
+}
+
 #[derive(Clone, Debug, serde::Deserialize)]
 pub struct TokenizerConfig {
     pub model_max_length: Option<f64>,
     pub add_bos_token: Option<bool>,
     pub add_eos_token: Option<bool>,
     pub chat_template: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_token_field")]
     pub bos_token: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_token_field")]
     pub eos_token: Option<String>,
 }
 

--- a/src/utils/progress.rs
+++ b/src/utils/progress.rs
@@ -11,7 +11,9 @@ use std::sync::Arc;
 use std::thread::JoinHandle;
 use std::{thread, time};
 pub trait ProgressLike: Send + Sync {
-    fn get_progress(&mut self) -> Vec<(usize, usize)>;
+    /// Returns Ok with progress values, or Err if the connection is broken
+    /// (e.g. runner process crashed during model loading).
+    fn get_progress(&mut self) -> std::result::Result<Vec<(usize, usize)>, String>;
     fn set_progress(&mut self, p: usize);
 }
 
@@ -21,8 +23,8 @@ pub struct ProgressReporter {
 }
 
 impl ProgressLike for ProgressReporter {
-    fn get_progress(&mut self) -> Vec<(usize, usize)> {
-        vec![(self.rank, self.progress)]
+    fn get_progress(&mut self) -> std::result::Result<Vec<(usize, usize)>, String> {
+        Ok(vec![(self.rank, self.progress)])
     }
 
     fn set_progress(&mut self, p: usize) {
@@ -95,18 +97,22 @@ impl RemoteProgressReporter {
 }
 
 impl ProgressLike for RemoteProgressReporter {
-    fn get_progress(&mut self) -> Vec<(usize, usize)> {
+    fn get_progress(&mut self) -> std::result::Result<Vec<(usize, usize)>, String> {
         let mut progress_values = Vec::with_capacity(self.streams.len());
         for mut stream in &mut self.streams {
-            if let Ok(msg) = receive_local(&mut stream, false) {
-                if let MessageType::LoadingProgress((rank, progress)) = msg {
+            match receive_local(&mut stream, false) {
+                Ok(MessageType::LoadingProgress((rank, progress))) => {
                     progress_values.push((rank, progress));
                 }
-            } else {
-                panic!("Error when loading model!");
+                Ok(_) => {}
+                Err(e) => {
+                    return Err(format!(
+                        "Runner process disconnected during model loading: {e}"
+                    ));
+                }
             }
         }
-        progress_values
+        Ok(progress_values)
     }
 
     fn set_progress(&mut self, p: usize) {
@@ -190,19 +196,29 @@ pub fn progress_worker(
     let handle = thread::spawn(move || loop {
         {
             let _ = thread::sleep(time::Duration::from_millis(10 as u64));
-            let progress = reporter.write().get_progress();
-            for (rank, progress) in progress {
-                finished_map.insert(rank, progress);
-                if let Some(pb) = progress_bar.as_ref() {
-                    pb.update(rank, progress);
-                }
-            }
+            match reporter.write().get_progress() {
+                Ok(progress) => {
+                    for (rank, progress) in progress {
+                        finished_map.insert(rank, progress);
+                        if let Some(pb) = progress_bar.as_ref() {
+                            pb.update(rank, progress);
+                        }
+                    }
 
-            if finished_map.values().all(|v| v >= &length) {
-                if let Some(pb) = progress_bar.as_ref() {
-                    pb.finish();
+                    if finished_map.values().all(|v| v >= &length) {
+                        if let Some(pb) = progress_bar.as_ref() {
+                            pb.finish();
+                        }
+                        break;
+                    }
                 }
-                break;
+                Err(e) => {
+                    crate::log_error!("{}", e);
+                    if let Some(pb) = progress_bar.as_ref() {
+                        pb.finish();
+                    }
+                    break;
+                }
             }
         }
     });


### PR DESCRIPTION
## Summary

- **Fix tokenizer_config.json parsing**: Some models (e.g. certain LLaMA variants) represent `bos_token`/`eos_token` as AddedToken objects (`{"content": "<s>", "lstrip": false, ...}`) rather than plain strings. This caused deserialization failures. Added a custom serde deserializer (`deserialize_token_field`) that transparently handles both formats — plain strings, AddedToken objects with a `content` field, and null values.

- **Propagate model loading errors instead of panicking**: `RemoteProgressReporter::get_progress()` previously called `panic!("Error when loading model!")` when the runner process disconnected during loading. This crashed the entire main process with no useful diagnostics. Now returns `Result<Vec<(usize, usize)>, String>` so the progress worker can log the error and exit cleanly.

### Changes

| File | Lines | Change |
|------|-------|--------|
| `src/utils/config.rs` | +40 | Add `deserialize_token_field()` custom deserializer; annotate `bos_token`/`eos_token` fields |
| `src/utils/progress.rs` | +56 / -20 | Change `get_progress()` return type to `Result`; handle errors gracefully in progress worker |

## Test plan

- [ ] Load a model with AddedToken-style tokenizer config (e.g. LLaMA 2)
- [ ] Load a model with plain string tokenizer config (e.g. Qwen)
- [ ] Verify runner crash during loading no longer panics the main process