### PR TITLE
Optimize decode performance: remove redundant sync and block alloc scan

### DIFF
--- a/src/core/block_manager.rs
+++ b/src/core/block_manager.rs
@@ -116,7 +116,6 @@ impl BlockManager {
         let block = &mut self.blocks[block_id];
         assert_eq!(block.ref_count, 0);
         block.reset();
-        self.free_block_ids.retain(|&id| id != block_id);
         self.used_block_ids.insert(block_id);
         block
     }

--- a/src/utils/graph.rs
+++ b/src/utils/graph.rs
@@ -298,7 +298,6 @@ where
     fn replay(&self, bs: usize) -> Result<()> {
         if let Some(&next_bs) = self.captured_bs.iter().find(|&&x| x >= bs) {
             if let Some(graph) = self.captured_graphs.get(&next_bs) {
-                self.sync_stream()?;
                 graph.replay()?;
                 self.sync_stream()
             } else {


### PR DESCRIPTION
## Summary
- Remove pre-replay `cuStreamSynchronize` in CUDA graph replay path (`src/utils/graph.rs`). Stream ordering already guarantees prior GPU work completes before graph launch; the post-replay sync is sufficient for sampling. Eliminates one CPU-GPU round-trip per decode step.
- Remove redundant O(n) `free_block_ids.retain()` in `allocate_block()` (`src/core/block_manager.rs`). Every caller already removes the block ID via `pop_front()` before calling `allocate_block`, making the linear scan a no-op that wasted cycles proportional to the number of free blocks.

## Test plan
- [x] Build with `--features cuda,nccl,flashinfer,cutlass`
- [x] Tested with Qwen3.5-35B-A3B-FP8 on single GPU
- [x] Verified model output quality (correct answers, proper code generation)
- [x] Performance benchmark: ~107 tokens/s on 908-token input / 1024-token output (matches baseline)