### PR TITLE
Fix correctness issues in scheduler, prefix cache, and error handling

### DIFF
--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -982,7 +982,10 @@ impl LLMEngine {
     pub fn prepare_step(&mut self) -> Result<Option<(Vec<usize>, bool, Vec<Sequence>)>> {
         let (scheduled_ids, is_prefill) = match self.scheduler.schedule() {
             Ok((ids, prefill)) => (ids, prefill),
-            Err(_) => (vec![], true),
+            Err(e) => {
+                crate::log_error!("[Scheduler] Schedule error: {:?}", e);
+                (vec![], true)
+            }
         };
         if scheduled_ids.is_empty() {
             return Ok(None);
@@ -1678,16 +1681,15 @@ impl LLMEngine {
             if let Some(ref l) = logger {
                 l.log_prompt(&pp.prompt);
             }
-            if let Ok((seq_id, prompt_length, rx)) = self.add_request_pretokenized(
+            let (seq_id, prompt_length, rx) = self.add_request_pretokenized(
                 &pp.params,
                 &pp.prompt,
                 pp.token_ids,
                 RequestType::Completion,
                 &images,
                 pp.image_idx,
-            ) {
-                receivers.push((seq_id, prompt_length, rx));
-            }
+            )?;
+            receivers.push((seq_id, prompt_length, rx));
         }
         Ok(receivers)
     }
@@ -2194,18 +2196,14 @@ impl LLMEngine {
                                 Ok(n) => task_processed = n,
                                 Err(e) => {
                                     crate::log_error!("[Engine Loop] Finish error: {:?}", e);
-                                    if !guard.cancel_all_with_reason(Some(e.to_string())) {
-                                        std::process::exit(1);
-                                    }
+                                    guard.cancel_all_with_reason(Some(e.to_string()));
                                 }
                             }
                         }
                         Err(e) => {
                             crate::log_error!("[Engine Loop] Forward error: {:?}", e);
                             let mut guard = engine.write();
-                            if !guard.cancel_all_with_reason(Some(e.to_string())) {
-                                std::process::exit(1);
-                            }
+                            guard.cancel_all_with_reason(Some(e.to_string()));
                         }
                     }
                 }

--- a/src/core/prefix_cache.rs
+++ b/src/core/prefix_cache.rs
@@ -34,6 +34,7 @@ struct PrefixEntry {
     block_id: usize,
     children: usize,
     access_id: u64,
+    content_hash: u64,
 }
 
 pub struct PrefixCache {
@@ -100,7 +101,11 @@ impl PrefixCache {
                 }
             }
             let hash = Self::hash_block(parent_hash, block_tokens);
-            if self.entries.contains_key(&hash) {
+            let fingerprint = Self::content_fingerprint(block_tokens);
+            if let Some(entry) = self.entries.get(&hash) {
+                if entry.content_hash != fingerprint {
+                    break;
+                }
                 matched += 1;
                 parent_hash = hash;
                 last_hash = Some(hash);
@@ -213,11 +218,17 @@ impl PrefixCache {
                 }
             }
             let hash = Self::hash_block(base, block_tokens);
+            let fingerprint = Self::content_fingerprint(block_tokens);
             if self.entries.contains_key(&hash) {
-                let access_id = self.next_access_id();
-                if let Some(entry) = self.entries.get_mut(&hash) {
-                    entry.access_id = access_id;
+                let content_match = self
+                    .entries
+                    .get(&hash)
+                    .map_or(false, |e| e.content_hash == fingerprint);
+                if !content_match {
+                    break;
                 }
+                let access_id = self.next_access_id();
+                self.entries.get_mut(&hash).unwrap().access_id = access_id;
                 self.touch_leaf(hash);
             } else {
                 if let Some(parent) = parent_hash {
@@ -236,6 +247,7 @@ impl PrefixCache {
                         block_id: *block_id,
                         children: 0,
                         access_id,
+                        content_hash: fingerprint,
                     },
                 );
                 self.leaf_set.insert(hash);
@@ -343,6 +355,13 @@ impl PrefixCache {
     fn hash_block(parent_hash: u64, tokens: &[u32]) -> u64 {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         parent_hash.hash(&mut hasher);
+        tokens.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    fn content_fingerprint(tokens: &[u32]) -> u64 {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        0xDEADBEEFu64.hash(&mut hasher);
         tokens.hash(&mut hasher);
         hasher.finish()
     }

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -917,10 +917,12 @@ impl Scheduler {
                     break;
                 }
 
-                let mut seq = self.cached.remove(i);
-                seq.status = SequenceStatus::Finished;
-                crate::log_error!("No KvCache left for swap in Seq {}!", seq.id);
-                self.running.push(seq);
+                let seq = self.cached.remove(i);
+                crate::log_error!(
+                    "No KvCache left for swap in Seq {} — cancelling request.",
+                    seq.id
+                );
+                self.cancel(seq.id);
                 break;
             }
 

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -917,12 +917,12 @@ impl Scheduler {
                     break;
                 }
 
-                let seq = self.cached.remove(i);
+                let seq_id = self.cached[i].id;
                 crate::log_error!(
                     "No KvCache left for swap in Seq {} — cancelling request.",
-                    seq.id
+                    seq_id
                 );
-                self.cancel(seq.id);
+                self.cancel(seq_id);
                 break;
             }
 


### PR DESCRIPTION
## Summary
- **Scheduler error visibility:** Log schedule errors instead of silently converting them to empty work, making allocation failures debuggable.
- **Prefix cache collision safety:** Add content fingerprint verification so hash collisions are detected and the entry is skipped rather than silently reusing wrong KV data.
- **Swap-in failure fix:** Cancel the request cleanly via `cancel()` instead of pushing a `Finished` sequence into the `running` queue (which led to undefined behavior).
- **generate_sync error propagation:** Failed `add_request_pretokenized` calls now return errors via `?` instead of being silently skipped.
- **Remove process::exit on transient errors:** Forward/finish errors cancel all affected requests and continue serving, rather than terminating the entire process.

## Test plan
- [x] Build with `--features cuda,nccl,flashinfer,cutlass`
- [x] Tested with Qwen3.5-35B-A3B-FP8 on single GPU
- [x] Verified model output quality (correct answers)
- [x] Performance benchmark: ~106.6 tokens/s (no regression)