### PR TITLE
Support new format AWQ/GPTQ MoE models

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["algorithms", "hardware-support", "science"]
 license = "MIT"
 
 [dependencies]
-candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "cafd231" }
-candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "cafd231" }
+candle-core = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "df058d8" }
+candle-nn = { git = "https://github.com/guoqingbao/candle.git", version = "0.8.3", rev = "df058d8" }
 serde = { version = "1.0.190", features = ["serde_derive"] }
 tokenizers = {version = "0.21.2", features = ["http"] }
 hf-hub = "0.4.1"
@@ -46,7 +46,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.6.5", rev = "942bcae" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.6.5", rev = "1d0491d" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.6.5", rev = "f59bb16" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.6.5", rev = "13b0e00" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.6.5", rev = "a97f519" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.6.5", rev = "f59bb16" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.6.5", rev = "13b0e00" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.6.5", rev = "942bcae" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"

--- a/ReadMe-CN.md
+++ b/ReadMe-CN.md
@@ -97,9 +97,10 @@ xinfer --w /home/Qwen3.6-35B-A3B --d 0,1 --ui-server --mtp 2
 | QwQ-32B | Q4_K_M | 32B | **46.02** tokens/s |
 | **Qwen3-30B-A3B** | NVFP4 | **30B (MoE)** | **197.29** tokens/s (**RTX 5090**) |
 | **Qwen3-30B-A3B** | NVFP4 | **30B (MoE)** | **72.86** tokens/s (**V100, Software FP4**) |
+| **Qwen3-Next-80B** | AWQ | **80B (MoE)** | **90** tokens/s (**Hopper**) |
 | **Qwen3.5-27B** (**多模态**) | Q4_K_M | **27B (Dense)** | **49.33** tokens/s |
 | **Qwen3.5-27B/Qwen3.6-27B** | FP8 | **27B (Dense)** | **45** tokens/s (**Hopper**) |
-| **Qwen3.6-35B-A3B** (**多模态**) | FP8 | **35B (MoE)** | **110** tokens/s (**Hopper**) |
+| **Qwen3.6-35B-A3B** (**多模态**) | FP8 | **35B (MoE)** | **120** tokens/s (**Hopper**) |
 | **GLM4.7 Flash** | NVFP4 | **30B (MoE)** | **79** tokens/s (**Hopper, Software FP4**) |
 | **Gemma4-31B** | ISQ (BF16→Q4K) | **31B (Dense)** | **47** tokens/s (**Hopper**) |
 | **Gemma4-26B-A4B** | NVFP4 | **26B (MoE)** | **137.23** tokens/s (**RTX 5090**) |
@@ -233,6 +234,9 @@ xinfer --i --m unsloth/Qwen3.5-27B-GGUF --f Qwen3.5-27B-Q4_K_M.gguf
 
 # Hopper 上加速 GDN 预填充，精度略有损失
 SM90_LOWER_PRECISION_GDN_PREFILL=1 xinfer --m Qwen/Qwen3.5-35B-A3B-FP8
+
+# AWQ (pack-quantized)
+xinfer --m cyankiwi/Qwen3-Coder-Next-AWQ-4bit
 
 # 多节点推理: GLM 5.2（DeepSeek V3.2 架构，FP8）
 # 主节点

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -98,9 +98,10 @@ Add `--kvcache-dtype` to compress KV cache and extend context length:
 | QwQ-32B | Q4_K_M | 32B | **46.02** tokens/s |
 | **Qwen3-30B-A3B** | NVFP4 | **30B (MoE)** | **197.29** tokens/s (**RTX 5090**) |
 | **Qwen3-30B-A3B** | NVFP4 | **30B (MoE)** | **72.86** tokens/s (**V100, Software FP4**) |
+| **Qwen3-Next-80B** | AWQ | **80B (MoE)** | **90** tokens/s (**Hopper**) |
 | **Qwen3.5-27B** (**Multimodal**) | Q4_K_M | **27B (Dense)** | **49.33** tokens/s |
 | **Qwen3.5-27B/Qwen3.6-27B** | FP8 | **27B (Dense)** | **45** tokens/s (**Hopper**) |
-| **Qwen3.6-35B-A3B** (**Multimodal**) | FP8 | **35B (MoE)** | **110** tokens/s (**Hopper**) |
+| **Qwen3.6-35B-A3B** (**Multimodal**) | FP8 | **35B (MoE)** | **120** tokens/s (**Hopper**) |
 | **GLM4.7 Flash** | NVFP4 | **30B (MoE)** | **79** tokens/s (**Hopper, Software FP4**) |
 | **Gemma4-31B** | ISQ (BF16→Q4K) | **31B (Dense)** | **47** tokens/s (**Hopper**) |
 | **Gemma4-26B-A4B** | NVFP4 | **26B (MoE)** | **137.23** tokens/s (**RTX 5090**) |
@@ -234,6 +235,9 @@ xinfer --i --m unsloth/Qwen3.5-27B-GGUF --f Qwen3.5-27B-Q4_K_M.gguf
 
 # Faster GDN prefill on Hopper with slight precision loss
 SM90_LOWER_PRECISION_GDN_PREFILL=1 xinfer --m Qwen/Qwen3.5-35B-A3B-FP8
+
+# AWQ (pack-quantized)
+xinfer --m cyankiwi/Qwen3-Coder-Next-AWQ-4bit
 
 # MultiNode: GLM 5.2 (DeepSeek V3.2 architecture, FP8)
 # Master node

--- a/src/models/gemma4.rs
+++ b/src/models/gemma4.rs
@@ -3,7 +3,7 @@ use crate::models::layers::distributed::{Comm, ReplicatedLinear, VocabParallelLi
 use crate::models::layers::mask::get_attention_causal_mask;
 use crate::models::layers::mlp::MLP;
 use crate::models::layers::moe::{
-    FusedMoe, FusedMoeGGUF, FusedMoeISQ, FusedMoeMxfp4, FusedMoeNvfp4,
+    FusedMoe, FusedMoeGGUF, FusedMoeISQ, FusedMoeMxfp4, FusedMoeNvfp4, FusedMoeWNA16,
 };
 use crate::models::layers::others::{embedding, rms_norm, NormX};
 use crate::models::layers::rotary_emb::{ApplyRotaryEmbedding, RotaryEmbedding};
@@ -120,6 +120,7 @@ enum Gemma4MoE {
     FusedMoeISQ(FusedMoeISQ),
     FusedMoeMxfp4(FusedMoeMxfp4),
     FusedMoeNvfp4(FusedMoeNvfp4),
+    FusedMoeWNA16(FusedMoeWNA16),
 }
 
 impl Gemma4MoE {
@@ -130,6 +131,7 @@ impl Gemma4MoE {
             Self::FusedMoeISQ(m) => m.forward(xs, is_prefill),
             Self::FusedMoeMxfp4(m) => m.forward(xs, is_prefill),
             Self::FusedMoeNvfp4(m) => m.forward(xs, is_prefill),
+            Self::FusedMoeWNA16(m) => m.forward(xs, is_prefill),
         }
     }
 
@@ -143,6 +145,9 @@ impl Gemma4MoE {
         match self {
             Self::FusedMoe(m) => m.forward_with_routing(xs, topk_weights, topk_ids, is_prefill),
             Self::FusedMoeNvfp4(m) => {
+                m.forward_with_routing(xs, topk_weights, topk_ids, is_prefill)
+            }
+            Self::FusedMoeWNA16(m) => {
                 m.forward_with_routing(xs, topk_weights, topk_ids, is_prefill)
             }
             _ => self.forward(xs, is_prefill),
@@ -308,6 +313,17 @@ impl Gemma4DecoderLayer {
                         vb.pp("experts").clone(),
                         comm.clone(),
                         dtype,
+                    )?)
+                } else if quant_config.is_compressed_tensors || quant_config.quant_method == "gptq"
+                {
+                    Gemma4MoE::FusedMoeWNA16(FusedMoeWNA16::new_with_gate(
+                        config,
+                        vb.pp("router").pp("proj").clone(),
+                        vb.pp("experts").clone(),
+                        &vb,
+                        comm.clone(),
+                        dtype,
+                        quant_config,
                     )?)
                 } else {
                     panic!(

--- a/src/models/layers/deltanet.rs
+++ b/src/models/layers/deltanet.rs
@@ -95,6 +95,7 @@ impl GatedDeltaNet {
                 (has_packed && has_scale) || (has_nvfp4_second_scale && has_scale) || is_mlx_nvfp4
             }
             "gptq" | "awq" => vb.has_key("qweight") || vb.has_key("B"),
+            "compressed-tensors" => vb.has_key("weight_packed") && vb.has_key("weight_scale"),
             _ => true,
         }
     }

--- a/src/models/layers/linear.rs
+++ b/src/models/layers/linear.rs
@@ -695,6 +695,15 @@ pub fn linear_x(
                     return Ok(LinearX::LnNvfp4(ln));
                 }
 
+                // compressed-tensors configs may deliberately leave dense
+                // projections in BF16/F16 (for example Qwen3Next's linear
+                // attention and shared expert).  Only enter WNA16 when the
+                // module actually contains packed weights.
+                if cfg.is_compressed_tensors && !vb.contains_tensor("weight_packed") {
+                    let ln = linear(in_dim, out_dim, vb.clone(), shards, dtype)?;
+                    return Ok(LinearX::Linear(ln));
+                }
+
                 let wna16 = WNA16::new(
                     in_dim,
                     out_dim,
@@ -835,6 +844,11 @@ pub fn linear_no_bias_x(
                         LnNvfp4::load(in_dim, out_dim, vb.clone(), shards, false)?
                     };
                     return Ok(LinearX::LnNvfp4(ln));
+                }
+
+                if cfg.is_compressed_tensors && !vb.contains_tensor("weight_packed") {
+                    let ln = linear_no_bias(in_dim, out_dim, vb.clone(), shards, dtype)?;
+                    return Ok(LinearX::Linear(ln));
                 }
 
                 let wna16 = WNA16::new(

--- a/src/models/layers/moe.rs
+++ b/src/models/layers/moe.rs
@@ -596,7 +596,8 @@ This usually means packed down_proj / gate_up_proj layout was interpreted incorr
     }
 }
 
-/// MoE WNA16 loader for compressed-tensors `pack-quantized` checkpoints.
+/// MoE WNA16 loader for compressed-tensors `pack-quantized` and symmetric
+/// classic GPTQ checkpoints.
 ///
 /// The checkpoint stores each expert projection independently as
 /// `weight_packed` (`[out, in / pack_factor]`) and `weight_scale`
@@ -617,6 +618,7 @@ pub struct FusedMoeWNA16 {
     bits: usize,
     group_size: usize,
     gate_dtype: DType,
+    legacy_gptq: bool,
 }
 
 impl FusedMoeWNA16 {
@@ -650,14 +652,32 @@ impl FusedMoeWNA16 {
         let moe_cfg = cfg.moe_cfg.as_ref().expect("MoE config is not available!");
         let num_experts = moe_cfg.num_experts.unwrap();
         let bits = quant_cfg.bits;
-        let group_size = quant_cfg.group_size as usize;
-        if !matches!(bits, 4 | 8) || group_size == 0 {
+        let legacy_gptq = quant_cfg.quant_method == "gptq";
+        if !matches!(bits, 4 | 8) || quant_cfg.group_size <= 0 {
             candle_core::bail!(
-                "compressed-tensors WNA16 MoE requires 4/8 bits and a positive group size, got bits={bits}, group_size={group_size}"
+                "WNA16 MoE requires 4/8 bits and a positive group size, got bits={bits}, group_size={}",
+                quant_cfg.group_size
+            );
+        }
+        let group_size = quant_cfg.group_size as usize;
+        let pack_factor = 32 / bits;
+        if cfg.hidden_size % pack_factor != 0
+            || moe_cfg.moe_intermediate_size % pack_factor != 0
+            || cfg.hidden_size % group_size != 0
+            || moe_cfg.moe_intermediate_size % group_size != 0
+        {
+            candle_core::bail!(
+                "WNA16 MoE dimensions must be divisible by pack_factor/group_size: hidden_size={}, moe_intermediate_size={}, pack_factor={}, group_size={group_size}",
+                cfg.hidden_size,
+                moe_cfg.moe_intermediate_size,
+                pack_factor
             );
         }
         if quant_cfg.sym == Some(false) {
-            candle_core::bail!("asymmetric compressed-tensors WNA16 MoE is not supported yet");
+            candle_core::bail!("asymmetric WNA16 MoE is not supported yet");
+        }
+        if legacy_gptq && quant_cfg.desc_act == Some(true) {
+            candle_core::bail!("classic GPTQ WNA16 MoE with desc_act/g_idx is not supported yet");
         }
 
         let gate_dtype = if cfg.higher_precision_required() {
@@ -675,7 +695,6 @@ impl FusedMoeWNA16 {
             gate_dtype,
         )?;
 
-        let pack_factor = 32 / bits;
         let mut gate_weights = Vec::with_capacity(num_experts);
         let mut gate_scales = Vec::with_capacity(num_experts);
         let mut up_weights = Vec::with_capacity(num_experts);
@@ -689,42 +708,146 @@ impl FusedMoeWNA16 {
             let up_vb = expert.pp(up_name);
             let down_vb = expert.pp(down_name);
 
-            gate_weights.push(gate_vb.get_with_hints_dtype(
-                (moe_cfg.moe_intermediate_size, cfg.hidden_size / pack_factor),
-                "weight_packed",
-                shard(0, comm.rank(), comm.world_size()),
-                DType::U32,
-            )?);
-            gate_scales.push(gate_vb.get_with_hints_dtype(
-                (moe_cfg.moe_intermediate_size, cfg.hidden_size / group_size),
-                "weight_scale",
-                shard(0, comm.rank(), comm.world_size()),
-                dtype,
-            )?);
-            up_weights.push(up_vb.get_with_hints_dtype(
-                (moe_cfg.moe_intermediate_size, cfg.hidden_size / pack_factor),
-                "weight_packed",
-                shard(0, comm.rank(), comm.world_size()),
-                DType::U32,
-            )?);
-            up_scales.push(up_vb.get_with_hints_dtype(
-                (moe_cfg.moe_intermediate_size, cfg.hidden_size / group_size),
-                "weight_scale",
-                shard(0, comm.rank(), comm.world_size()),
-                dtype,
-            )?);
-            down_weights.push(down_vb.get_with_hints_dtype(
-                (cfg.hidden_size, moe_cfg.moe_intermediate_size / pack_factor),
-                "weight_packed",
-                shard(1, comm.rank(), comm.world_size()),
-                DType::U32,
-            )?);
-            down_scales.push(down_vb.get_with_hints_dtype(
-                (cfg.hidden_size, moe_cfg.moe_intermediate_size / group_size),
-                "weight_scale",
-                shard(1, comm.rank(), comm.world_size()),
-                dtype,
-            )?);
+            let (gate_weight, gate_scale, up_weight, up_scale, down_weight, down_scale) =
+                if legacy_gptq {
+                    // Classic GPTQ stores qweight=[K/pack,N] and scales=[K/group,N].
+                    // The grouped WNA16 kernels consume [N,K/pack] and [N,K/group].
+                    for (name, vb) in [
+                        ("gate_proj", &gate_vb),
+                        ("up_proj", &up_vb),
+                        ("down_proj", &down_vb),
+                    ] {
+                        if !vb.has_key("qzeros") {
+                            candle_core::bail!(
+                                "classic GPTQ MoE projection {name} is missing qzeros"
+                            );
+                        }
+                    }
+                    let gate_weight = gate_vb
+                        .get_with_hints_dtype(
+                            (cfg.hidden_size / pack_factor, moe_cfg.moe_intermediate_size),
+                            "qweight",
+                            shard(1, comm.rank(), comm.world_size()),
+                            DType::U32,
+                        )?
+                        .t()?
+                        .contiguous()?;
+                    let gate_scale = gate_vb
+                        .get_with_hints_dtype(
+                            (cfg.hidden_size / group_size, moe_cfg.moe_intermediate_size),
+                            "scales",
+                            shard(1, comm.rank(), comm.world_size()),
+                            dtype,
+                        )?
+                        .t()?
+                        .contiguous()?;
+                    let up_weight = up_vb
+                        .get_with_hints_dtype(
+                            (cfg.hidden_size / pack_factor, moe_cfg.moe_intermediate_size),
+                            "qweight",
+                            shard(1, comm.rank(), comm.world_size()),
+                            DType::U32,
+                        )?
+                        .t()?
+                        .contiguous()?;
+                    let up_scale = up_vb
+                        .get_with_hints_dtype(
+                            (cfg.hidden_size / group_size, moe_cfg.moe_intermediate_size),
+                            "scales",
+                            shard(1, comm.rank(), comm.world_size()),
+                            dtype,
+                        )?
+                        .t()?
+                        .contiguous()?;
+                    let down_weight = down_vb
+                        .get_with_hints_dtype(
+                            (moe_cfg.moe_intermediate_size / pack_factor, cfg.hidden_size),
+                            "qweight",
+                            shard(0, comm.rank(), comm.world_size()),
+                            DType::U32,
+                        )?
+                        .t()?
+                        .contiguous()?;
+                    let down_scale = down_vb
+                        .get_with_hints_dtype(
+                            (moe_cfg.moe_intermediate_size / group_size, cfg.hidden_size),
+                            "scales",
+                            shard(0, comm.rank(), comm.world_size()),
+                            dtype,
+                        )?
+                        .t()?
+                        .contiguous()?;
+                    (
+                        gate_weight,
+                        gate_scale,
+                        up_weight,
+                        up_scale,
+                        down_weight,
+                        down_scale,
+                    )
+                } else {
+                    for (name, vb) in [
+                        ("gate_proj", &gate_vb),
+                        ("up_proj", &up_vb),
+                        ("down_proj", &down_vb),
+                    ] {
+                        if vb.has_key("weight_g_idx") {
+                            candle_core::bail!(
+                                "compressed-tensors WNA16 MoE projection {name} has unsupported weight_g_idx"
+                            );
+                        }
+                    }
+                    let gate_weight = gate_vb.get_with_hints_dtype(
+                        (moe_cfg.moe_intermediate_size, cfg.hidden_size / pack_factor),
+                        "weight_packed",
+                        shard(0, comm.rank(), comm.world_size()),
+                        DType::U32,
+                    )?;
+                    let gate_scale = gate_vb.get_with_hints_dtype(
+                        (moe_cfg.moe_intermediate_size, cfg.hidden_size / group_size),
+                        "weight_scale",
+                        shard(0, comm.rank(), comm.world_size()),
+                        dtype,
+                    )?;
+                    let up_weight = up_vb.get_with_hints_dtype(
+                        (moe_cfg.moe_intermediate_size, cfg.hidden_size / pack_factor),
+                        "weight_packed",
+                        shard(0, comm.rank(), comm.world_size()),
+                        DType::U32,
+                    )?;
+                    let up_scale = up_vb.get_with_hints_dtype(
+                        (moe_cfg.moe_intermediate_size, cfg.hidden_size / group_size),
+                        "weight_scale",
+                        shard(0, comm.rank(), comm.world_size()),
+                        dtype,
+                    )?;
+                    let down_weight = down_vb.get_with_hints_dtype(
+                        (cfg.hidden_size, moe_cfg.moe_intermediate_size / pack_factor),
+                        "weight_packed",
+                        shard(1, comm.rank(), comm.world_size()),
+                        DType::U32,
+                    )?;
+                    let down_scale = down_vb.get_with_hints_dtype(
+                        (cfg.hidden_size, moe_cfg.moe_intermediate_size / group_size),
+                        "weight_scale",
+                        shard(1, comm.rank(), comm.world_size()),
+                        dtype,
+                    )?;
+                    (
+                        gate_weight,
+                        gate_scale,
+                        up_weight,
+                        up_scale,
+                        down_weight,
+                        down_scale,
+                    )
+                };
+            gate_weights.push(gate_weight);
+            gate_scales.push(gate_scale);
+            up_weights.push(up_weight);
+            up_scales.push(up_scale);
+            down_weights.push(down_weight);
+            down_scales.push(down_scale);
         }
 
         let gate_up_packed = Tensor::cat(
@@ -765,11 +888,11 @@ impl FusedMoeWNA16 {
             bits,
             group_size,
             gate_dtype,
+            legacy_gptq,
         })
     }
 
     pub fn forward(&self, xs: &Tensor, is_prefill: bool) -> Result<Tensor> {
-        let (num_tokens, hidden_dim) = xs.dims2()?;
         let gate_input = if xs.dtype() != self.gate_dtype {
             std::borrow::Cow::Owned(xs.to_dtype(self.gate_dtype)?)
         } else {
@@ -777,6 +900,18 @@ impl FusedMoeWNA16 {
         };
         let router_logits = self.gate.forward(&gate_input)?.to_dtype(DType::F32)?;
         let (topk_weights, topk_ids) = self.routing.route(&router_logits, is_prefill)?;
+
+        self.forward_with_routing(xs, topk_weights, topk_ids, is_prefill)
+    }
+
+    pub fn forward_with_routing(
+        &self,
+        xs: &Tensor,
+        topk_weights: Tensor,
+        topk_ids: Tensor,
+        is_prefill: bool,
+    ) -> Result<Tensor> {
+        let (num_tokens, hidden_dim) = xs.dims2()?;
         let (expert_ids, sorted_token_ids) = sort_expert_assignments(&topk_ids, is_prefill)?;
 
         let gate_up = moe::moe_gemm_wna16(
@@ -790,6 +925,7 @@ impl FusedMoeWNA16 {
             self.bits,
             self.group_size,
             is_prefill,
+            self.legacy_gptq,
         )?;
         let down_inputs = gated_activation(&gate_up, self.w_size_n, &self.act)?;
         let mut ys = moe::moe_gemm_wna16(
@@ -803,6 +939,7 @@ impl FusedMoeWNA16 {
             self.bits,
             self.group_size,
             is_prefill,
+            self.legacy_gptq,
         )?
         .reshape((num_tokens, (), hidden_dim))?
         .sum(D::Minus2)?;

--- a/src/models/layers/moe.rs
+++ b/src/models/layers/moe.rs
@@ -596,6 +596,223 @@ This usually means packed down_proj / gate_up_proj layout was interpreted incorr
     }
 }
 
+/// MoE WNA16 loader for compressed-tensors `pack-quantized` checkpoints.
+///
+/// The checkpoint stores each expert projection independently as
+/// `weight_packed` (`[out, in / pack_factor]`) and `weight_scale`
+/// (`[out, in / group_size]`).  The packed tensors stay packed on device and
+/// are consumed by attention.rs' grouped WNA16 kernel.
+pub struct FusedMoeWNA16 {
+    gate: Linear,
+    gate_up_packed: Tensor,
+    gate_up_scales: Tensor,
+    down_packed: Tensor,
+    down_scales: Tensor,
+    w_size_n: usize,
+    act: Activation,
+    routing: MoeRouting,
+    all_reduce: AllReduce,
+    world_size: usize,
+    dtype: DType,
+    bits: usize,
+    group_size: usize,
+    gate_dtype: DType,
+}
+
+impl FusedMoeWNA16 {
+    pub fn new(
+        cfg: &Config,
+        vb: VarBuilderX,
+        comm: Rc<Comm>,
+        dtype: DType,
+        quant_cfg: &QuantConfig,
+    ) -> Result<Self> {
+        Self::new_with_gate(
+            cfg,
+            vb.pp("gate"),
+            vb.pp("experts"),
+            &vb,
+            comm,
+            dtype,
+            quant_cfg,
+        )
+    }
+
+    pub fn new_with_gate(
+        cfg: &Config,
+        gate_vb: VarBuilderX,
+        experts_vb: VarBuilderX,
+        bias_vb: &VarBuilderX,
+        comm: Rc<Comm>,
+        dtype: DType,
+        quant_cfg: &QuantConfig,
+    ) -> Result<Self> {
+        let moe_cfg = cfg.moe_cfg.as_ref().expect("MoE config is not available!");
+        let num_experts = moe_cfg.num_experts.unwrap();
+        let bits = quant_cfg.bits;
+        let group_size = quant_cfg.group_size as usize;
+        if !matches!(bits, 4 | 8) || group_size == 0 {
+            candle_core::bail!(
+                "compressed-tensors WNA16 MoE requires 4/8 bits and a positive group size, got bits={bits}, group_size={group_size}"
+            );
+        }
+        if quant_cfg.sym == Some(false) {
+            candle_core::bail!("asymmetric compressed-tensors WNA16 MoE is not supported yet");
+        }
+
+        let gate_dtype = if cfg.higher_precision_required() {
+            DType::F32
+        } else {
+            dtype
+        };
+        let gate = linear_no_bias(
+            cfg.hidden_size,
+            num_experts,
+            gate_vb,
+            Shard::default(),
+            &None,
+            &None,
+            gate_dtype,
+        )?;
+
+        let pack_factor = 32 / bits;
+        let mut gate_weights = Vec::with_capacity(num_experts);
+        let mut gate_scales = Vec::with_capacity(num_experts);
+        let mut up_weights = Vec::with_capacity(num_experts);
+        let mut up_scales = Vec::with_capacity(num_experts);
+        let mut down_weights = Vec::with_capacity(num_experts);
+        let mut down_scales = Vec::with_capacity(num_experts);
+        for expert_id in 0..num_experts {
+            let expert = experts_vb.pp(expert_id.to_string().as_str());
+            let (gate_name, up_name, down_name) = resolve_expert_proj_prefix_x(&expert);
+            let gate_vb = expert.pp(gate_name);
+            let up_vb = expert.pp(up_name);
+            let down_vb = expert.pp(down_name);
+
+            gate_weights.push(gate_vb.get_with_hints_dtype(
+                (moe_cfg.moe_intermediate_size, cfg.hidden_size / pack_factor),
+                "weight_packed",
+                shard(0, comm.rank(), comm.world_size()),
+                DType::U32,
+            )?);
+            gate_scales.push(gate_vb.get_with_hints_dtype(
+                (moe_cfg.moe_intermediate_size, cfg.hidden_size / group_size),
+                "weight_scale",
+                shard(0, comm.rank(), comm.world_size()),
+                dtype,
+            )?);
+            up_weights.push(up_vb.get_with_hints_dtype(
+                (moe_cfg.moe_intermediate_size, cfg.hidden_size / pack_factor),
+                "weight_packed",
+                shard(0, comm.rank(), comm.world_size()),
+                DType::U32,
+            )?);
+            up_scales.push(up_vb.get_with_hints_dtype(
+                (moe_cfg.moe_intermediate_size, cfg.hidden_size / group_size),
+                "weight_scale",
+                shard(0, comm.rank(), comm.world_size()),
+                dtype,
+            )?);
+            down_weights.push(down_vb.get_with_hints_dtype(
+                (cfg.hidden_size, moe_cfg.moe_intermediate_size / pack_factor),
+                "weight_packed",
+                shard(1, comm.rank(), comm.world_size()),
+                DType::U32,
+            )?);
+            down_scales.push(down_vb.get_with_hints_dtype(
+                (cfg.hidden_size, moe_cfg.moe_intermediate_size / group_size),
+                "weight_scale",
+                shard(1, comm.rank(), comm.world_size()),
+                dtype,
+            )?);
+        }
+
+        let gate_up_packed = Tensor::cat(
+            &[
+                &Tensor::stack(&gate_weights, 0)?,
+                &Tensor::stack(&up_weights, 0)?,
+            ],
+            1,
+        )?
+        .contiguous()?;
+        let gate_up_scales = Tensor::cat(
+            &[
+                &Tensor::stack(&gate_scales, 0)?,
+                &Tensor::stack(&up_scales, 0)?,
+            ],
+            1,
+        )?
+        .contiguous()?;
+        let down_packed = Tensor::stack(&down_weights, 0)?.contiguous()?;
+        let down_scales = Tensor::stack(&down_scales, 0)?.contiguous()?;
+        let w_size_n = gate_up_packed.dim(1)? / 2;
+
+        Ok(Self {
+            gate,
+            gate_up_packed,
+            gate_up_scales,
+            down_packed,
+            down_scales,
+            w_size_n,
+            act: cfg.hidden_act,
+            routing: MoeRouting::from_moe_cfg(
+                moe_cfg,
+                try_load_e_score_correction_bias(bias_vb, num_experts),
+            ),
+            all_reduce: AllReduce::new(comm.clone()),
+            world_size: comm.world_size(),
+            dtype,
+            bits,
+            group_size,
+            gate_dtype,
+        })
+    }
+
+    pub fn forward(&self, xs: &Tensor, is_prefill: bool) -> Result<Tensor> {
+        let (num_tokens, hidden_dim) = xs.dims2()?;
+        let gate_input = if xs.dtype() != self.gate_dtype {
+            std::borrow::Cow::Owned(xs.to_dtype(self.gate_dtype)?)
+        } else {
+            std::borrow::Cow::Borrowed(xs)
+        };
+        let router_logits = self.gate.forward(&gate_input)?.to_dtype(DType::F32)?;
+        let (topk_weights, topk_ids) = self.routing.route(&router_logits, is_prefill)?;
+        let (expert_ids, sorted_token_ids) = sort_expert_assignments(&topk_ids, is_prefill)?;
+
+        let gate_up = moe::moe_gemm_wna16(
+            xs,
+            &self.gate_up_packed,
+            &self.gate_up_scales,
+            &None,
+            &sorted_token_ids,
+            &expert_ids,
+            self.routing.num_experts_per_tok,
+            self.bits,
+            self.group_size,
+            is_prefill,
+        )?;
+        let down_inputs = gated_activation(&gate_up, self.w_size_n, &self.act)?;
+        let mut ys = moe::moe_gemm_wna16(
+            &down_inputs,
+            &self.down_packed,
+            &self.down_scales,
+            &Some(topk_weights),
+            &sorted_token_ids,
+            &expert_ids,
+            self.routing.num_experts_per_tok,
+            self.bits,
+            self.group_size,
+            is_prefill,
+        )?
+        .reshape((num_tokens, (), hidden_dim))?
+        .sum(D::Minus2)?;
+        if self.world_size > 1 {
+            ys = self.all_reduce.apply(&ys)?;
+        }
+        Ok(ys.to_dtype(self.dtype)?)
+    }
+}
+
 pub struct FusedMoeGGUF {
     gate: Linear,
     gate_experts: Arc<QTensor>,

--- a/src/models/minimax.rs
+++ b/src/models/minimax.rs
@@ -2,7 +2,7 @@ use crate::models::layers::attention::Attention;
 use crate::models::layers::distributed::{Comm, VocabParallelLinear};
 use crate::models::layers::mask::get_attention_causal_mask;
 use crate::models::layers::moe::{
-    FusedMoe, FusedMoeFp8, FusedMoeGGUF, FusedMoeISQ, FusedMoeMxfp4, FusedMoeNvfp4,
+    FusedMoe, FusedMoeFp8, FusedMoeGGUF, FusedMoeISQ, FusedMoeMxfp4, FusedMoeNvfp4, FusedMoeWNA16,
 };
 use crate::models::layers::others::{embedding, rms_norm, NormX};
 use crate::models::layers::rotary_emb::{ApplyRotaryEmbedding, ScalingRotaryEmbedding};
@@ -36,6 +36,7 @@ enum MoeVariant {
     FusedMoeFp8(FusedMoeFp8),
     FusedMoeMxfp4(FusedMoeMxfp4),
     FusedMoeNvfp4(FusedMoeNvfp4),
+    FusedMoeWNA16(FusedMoeWNA16),
 }
 
 impl MoeVariant {
@@ -47,6 +48,7 @@ impl MoeVariant {
             Self::FusedMoeFp8(m) => m.forward(xs, is_prefill),
             Self::FusedMoeMxfp4(m) => m.forward(xs, is_prefill),
             Self::FusedMoeNvfp4(m) => m.forward(xs, is_prefill),
+            Self::FusedMoeWNA16(m) => m.forward(xs, is_prefill),
         }
     }
 }
@@ -115,8 +117,18 @@ impl MiniMaxDecoderLayer {
                     comm.clone(),
                     dtype,
                 )?)
+            } else if quant_config.is_compressed_tensors {
+                MoeVariant::FusedMoeWNA16(FusedMoeWNA16::new_with_gate(
+                    config,
+                    moe_vb.pp("gate"),
+                    moe_vb.pp("experts"),
+                    &moe_vb,
+                    comm.clone(),
+                    dtype,
+                    quant_config,
+                )?)
             } else {
-                panic!("Unsupported quantization for MiniMax (use unquantized, gguf, fp8, mxfp4 or nvfp4)!");
+                panic!("Unsupported quantization for MiniMax (use unquantized, gguf, compressed WNA16, fp8, mxfp4 or nvfp4)!");
             }
         } else if config.quant.is_some() {
             MoeVariant::FusedMoeISQ(FusedMoeISQ::new_with_gate(

--- a/src/models/qwen3_5_moe.rs
+++ b/src/models/qwen3_5_moe.rs
@@ -152,7 +152,7 @@ impl Qwen3_5MoEDecoderLayer {
                     comm.clone(),
                     dtype,
                 )?)
-            } else if quant_config.is_compressed_tensors {
+            } else if quant_config.is_compressed_tensors || quant_config.quant_method == "gptq" {
                 MoeOrMlp::FusedMoeWNA16(FusedMoeWNA16::new(
                     config,
                     vb.pp("mlp").clone(),

--- a/src/models/qwen3_5_moe.rs
+++ b/src/models/qwen3_5_moe.rs
@@ -7,7 +7,7 @@ use crate::models::layers::linear::LinearX as Linear;
 use crate::models::layers::mask::get_attention_causal_mask;
 use crate::models::layers::mlp::MLP;
 use crate::models::layers::moe::{
-    FusedMoe, FusedMoeFp8, FusedMoeGGUF, FusedMoeISQ, FusedMoeMxfp4, FusedMoeNvfp4,
+    FusedMoe, FusedMoeFp8, FusedMoeGGUF, FusedMoeISQ, FusedMoeMxfp4, FusedMoeNvfp4, FusedMoeWNA16,
 };
 use crate::models::layers::others::{embedding, rms_norm, NormX};
 use crate::models::layers::rotary_emb::{ApplyRotaryEmbedding, ScalingRotaryEmbedding};
@@ -37,6 +37,7 @@ enum MoeOrMlp {
     FusedMoeFp8(FusedMoeFp8),
     FusedMoeMxfp4(FusedMoeMxfp4),
     FusedMoeNvfp4(FusedMoeNvfp4),
+    FusedMoeWNA16(FusedMoeWNA16),
 }
 
 impl MoeOrMlp {
@@ -48,6 +49,7 @@ impl MoeOrMlp {
             Self::FusedMoeFp8(m) => m.forward(xs, is_prefill),
             Self::FusedMoeMxfp4(m) => m.forward(xs, is_prefill),
             Self::FusedMoeNvfp4(m) => m.forward(xs, is_prefill),
+            Self::FusedMoeWNA16(m) => m.forward(xs, is_prefill),
         }
     }
 }
@@ -149,6 +151,14 @@ impl Qwen3_5MoEDecoderLayer {
                     vb.pp("mlp").clone(),
                     comm.clone(),
                     dtype,
+                )?)
+            } else if quant_config.is_compressed_tensors {
+                MoeOrMlp::FusedMoeWNA16(FusedMoeWNA16::new(
+                    config,
+                    vb.pp("mlp").clone(),
+                    comm.clone(),
+                    dtype,
+                    quant_config,
                 )?)
             } else {
                 panic!("Unsupported quant method for MoE (use unquantized, gguf, fp8, mxfp4 or nvfp4)!");

--- a/src/models/qwen3_5_mtp.rs
+++ b/src/models/qwen3_5_mtp.rs
@@ -126,6 +126,7 @@ fn mtp_quant_config(
         mode: None,
         quantized_layers: None,
         is_mlx_nvfp4: false,
+        is_compressed_tensors: false,
     });
     cfg.quant_method = method.to_string();
     // MTP FP8 checkpoints use the standard 128x128 block layout even when

--- a/src/models/qwen3_moe.rs
+++ b/src/models/qwen3_moe.rs
@@ -121,7 +121,8 @@ impl Qwen3DecoderLayer {
                         comm.clone(),
                         dtype,
                     )?)
-                } else if quant_config.is_compressed_tensors {
+                } else if quant_config.is_compressed_tensors || quant_config.quant_method == "gptq"
+                {
                     MoeOrMlp::FusedMoeWNA16(FusedMoeWNA16::new(
                         config,
                         vb.pp("mlp").clone(),

--- a/src/models/qwen3_moe.rs
+++ b/src/models/qwen3_moe.rs
@@ -5,7 +5,7 @@ use crate::models::layers::linear::LinearX as Linear;
 use crate::models::layers::mask::get_attention_causal_mask;
 use crate::models::layers::mlp::MLP;
 use crate::models::layers::moe::{
-    FusedMoe, FusedMoeFp8, FusedMoeGGUF, FusedMoeISQ, FusedMoeMxfp4, FusedMoeNvfp4,
+    FusedMoe, FusedMoeFp8, FusedMoeGGUF, FusedMoeISQ, FusedMoeMxfp4, FusedMoeNvfp4, FusedMoeWNA16,
 };
 use crate::models::layers::others::{embedding, rms_norm, NormX};
 use crate::models::layers::rotary_emb::{ApplyRotaryEmbedding, ScalingRotaryEmbedding};
@@ -30,6 +30,7 @@ enum MoeOrMlp {
     FusedMoeFp8(FusedMoeFp8),
     FusedMoeMxfp4(FusedMoeMxfp4),
     FusedMoeNvfp4(FusedMoeNvfp4),
+    FusedMoeWNA16(FusedMoeWNA16),
     Mlp(MLP),
 }
 
@@ -43,6 +44,7 @@ impl MoeOrMlp {
             Self::FusedMoeFp8(m) => m.forward(xs, is_prefill),
             Self::FusedMoeMxfp4(m) => m.forward(xs, is_prefill),
             Self::FusedMoeNvfp4(m) => m.forward(xs, is_prefill),
+            Self::FusedMoeWNA16(m) => m.forward(xs, is_prefill),
         }
     }
 }
@@ -118,6 +120,14 @@ impl Qwen3DecoderLayer {
                         vb.pp("mlp").clone(),
                         comm.clone(),
                         dtype,
+                    )?)
+                } else if quant_config.is_compressed_tensors {
+                    MoeOrMlp::FusedMoeWNA16(FusedMoeWNA16::new(
+                        config,
+                        vb.pp("mlp").clone(),
+                        comm.clone(),
+                        dtype,
+                        quant_config,
                     )?)
                 } else {
                     panic!("This feature is under developement (use unquantized, gguf, fp8, mxfp4 or nvfp4 instead)!");

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -939,6 +939,7 @@ impl ModelType {
             "Qwen3MoEForCausalLM" => Some(ModelType::Qwen3MoE),
             "Qwen3_5ForCausalLM" => Some(ModelType::Qwen3_5),
             "Qwen3_5MoEForCausalLM" => Some(ModelType::Qwen3_5MoE),
+            "Qwen3NextForCausalLM" => Some(ModelType::Qwen3_5MoE),
             "LlamaForCausalLM" => Some(ModelType::LLaMa),
             "GemmaForCausalLM" => Some(ModelType::Gemma),
             "Gemma3ForConditionalGeneration" => Some(ModelType::Gemma3),
@@ -1037,6 +1038,10 @@ pub struct QuantConfig {
     /// an MLX-style `"mode": "nvfp4"` config is detected.
     #[serde(default)]
     pub is_mlx_nvfp4: bool,
+    /// compressed-tensors `pack-quantized` WNA16 weights.  This format is
+    /// algorithm-neutral (AWQ/GPTQ recipes use the same packed tensors).
+    #[serde(default)]
+    pub is_compressed_tensors: bool,
 }
 
 impl QuantConfig {
@@ -1136,7 +1141,37 @@ impl QuantConfig {
         if is_mxfp4 {
             self.quant_method = "mxfp4".to_string();
             self.extract_compressed_tensors_params();
+            return;
         }
+
+        // llm-compressor's AWQ/GPTQ WNA16 checkpoints use the generic
+        // compressed-tensors `pack-quantized` format.  Unlike legacy AWQ and
+        // GPTQ files they contain weight_packed/weight_scale/weight_shape
+        // (and optionally weight_zero_point), so preserve that distinction
+        // for the loaders while exposing the common WNA16 parameters.
+        if format_str == "pack-quantized" || self.detect_pack_quantized_from_config_groups() {
+            self.quant_method = "compressed-tensors".to_string();
+            self.is_compressed_tensors = true;
+            self.extract_compressed_tensors_params();
+            if self.sym.is_none() {
+                self.sym = Some(true);
+            }
+        }
+    }
+
+    fn detect_pack_quantized_from_config_groups(&self) -> bool {
+        let groups = match &self.config_groups {
+            Some(v) => v,
+            None => return false,
+        };
+        groups.as_object().is_some_and(|obj| {
+            obj.values().any(|group| {
+                group
+                    .get("format")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|fmt| fmt == "pack-quantized")
+            })
+        })
     }
 
     fn detect_nvfp4_from_config_groups(&self) -> bool {
@@ -1280,6 +1315,7 @@ impl fmt::Debug for QuantConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("QuantConfig")
             .field("quant_method", &self.quant_method)
+            .field("is_compressed_tensors", &self.is_compressed_tensors)
             .field("bits", &self.bits)
             .field("group_size", &self.group_size)
             .field("sym", &self.sym)

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -358,10 +358,24 @@ impl Config {
     pub fn higher_precision_required(&self) -> bool {
         self.is_f16_mode
             || self.quant.is_some()
-            || self
-                .quantization_config
-                .as_ref()
-                .is_some_and(|cfg| matches!(cfg.quant_method.as_str(), "mxfp4" | "nvfp4"))
+            || self.quantization_config.as_ref().is_some_and(|cfg| {
+                // Weight-only AWQ/GPTQ and compressed-tensors WNA16
+                // models are especially sensitive to low-precision norm
+                // statistics. Keep norm weights/reductions and Q/K
+                // preparation in F32 while retaining the configured
+                // activation dtype for the surrounding matmuls.
+                cfg.is_compressed_tensors
+                    || matches!(
+                        cfg.quant_method.as_str(),
+                        "awq"
+                            | "gptq"
+                            | "awq_marlin"
+                            | "gptq_marlin"
+                            | "compressed-tensors"
+                            | "mxfp4"
+                            | "nvfp4"
+                    )
+            })
     }
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1504,13 +1504,17 @@ pub fn init_config_tokenizer(
             assert!(
                 qcfg.quant_method == "gptq"
                     || qcfg.quant_method == "awq"
+                    || qcfg.quant_method == "compressed-tensors"
                     || qcfg.quant_method == "fp8"
                     || qcfg.quant_method == "mxfp4"
                     || qcfg.quant_method == "nvfp4",
-                "Invalid quantization format! Only `gptq`, `awq`, `fp8`, `mxfp4` and `nvfp4` supported, got `{}`",
+                "Invalid quantization format! Only `gptq`, `awq`, `compressed-tensors`, `fp8`, `mxfp4` and `nvfp4` supported, got `{}`",
                 qcfg.quant_method
             );
-            if qcfg.quant_method == "gptq" || qcfg.quant_method == "awq" {
+            if qcfg.quant_method == "gptq"
+                || qcfg.quant_method == "awq"
+                || qcfg.quant_method == "compressed-tensors"
+            {
                 assert!(
                     (qcfg.bits == 4 || qcfg.bits == 8),
                     "Only 4-bit and 8-bit gptq or awq models supported!"


### PR DESCRIPTION
Support new format of AWQ/GPTQ MoE models (compressed with `llm-compressor`, `autoround` compatible), tested cases:

**Hardware:** Hopper 80G
**Model:** cyankiwi/Qwen3-Coder-Next-AWQ-4bit
**Input context:** 16K
**Prefill speed:** 2.2 k tokens/s
**Decoding speed:** 87 tokens/s
**Batch decoding (bs=4):** 242 tokens/s

Running command:

```
cargo run --release --features cuda,nccl,flashinfer,cutlass -- --m cyankiwi/Qwen3-Coder-Next-AWQ-4bit --ui-server
```

_TODO: optimize prefill speed._