### PR TITLE
Optional online scale compute & higher precison gate for nvfp4 models

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ ahash = "0.8.11"
 reedline = "0.40.0"
 pyo3 = { version = "0.25.1", features = ["extension-module", "abi3-py38"], optional = true }
 parking_lot = "0.12.4"
-attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.6.6", rev = "2e0db42" }
+attention-rs = { git = "https://github.com/guoqingbao/attention.rs.git", version="0.6.6", rev = "e46d655" }
 once_cell = "1.21.3"
 tqdm = "0.8.0"
 futures = "0.3.31"

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -1597,7 +1597,7 @@ impl LLMEngine {
             .duration_since(UNIX_EPOCH)
             .expect("Time went backwards")
             .as_millis() as usize;
-        if cur_time - self.last_check_throughput_time < 5000 {
+        if cur_time - self.last_check_throughput_time < 10000 {
             return;
         }
         self.last_check_throughput_time = cur_time;

--- a/src/models/layers/deltanet.rs
+++ b/src/models/layers/deltanet.rs
@@ -540,11 +540,12 @@ impl GatedDeltaNet {
         }
 
         let is_quantized = config.quantization_config.is_some();
-        let gdn_dtype = if vb.is_qvar_builder() || config.is_f16_mode {
-            DType::F32
-        } else {
-            dtype
-        };
+        let gdn_dtype =
+            if vb.is_qvar_builder() || config.is_f16_mode || config.higher_precision_required() {
+                DType::F32
+            } else {
+                dtype
+            };
 
         let num_v_heads = num_v_heads_global / world_size;
         let num_k_heads = num_k_heads_global / world_size;

--- a/src/models/layers/linear.rs
+++ b/src/models/layers/linear.rs
@@ -560,6 +560,19 @@ impl LinearX {
             Self::LnNvfp4(_) => panic!("LnNvfp4 does not support indexed_moe_forward yet"),
         }
     }
+
+    /// Dtype of the weight used for matmul (for casting activations before forward).
+    pub fn weight_dtype(&self) -> DType {
+        match self {
+            Self::Linear(ln) => ln.weight().dtype(),
+            Self::QLinear(ln) => ln.dtype,
+            Self::LnFp8(_) | Self::LnMxfp4(_) | Self::LnNvfp4(_) => {
+                // Quantized linears accept BF16/F16 activations and handle
+                // dtype internally; callers should not promote to F32.
+                DType::BF16
+            }
+        }
+    }
 }
 
 impl LinearX {

--- a/src/models/layers/moe.rs
+++ b/src/models/layers/moe.rs
@@ -2819,25 +2819,39 @@ impl FusedMoeNvfp4 {
 
                 if has_packed_gate_up {
                     // Fused format: gate_up_proj [E, K/2, 2*N], down_proj [E, N/2, K]
-                    // Transpose per expert to [2*N, K/2] / [K, N/2], then split
-                    // gate_up into gate [N, K/2] + up [N, K/2] to reuse the
-                    // standard stack-then-cat assembly below.
+                    // Mirror BF16/FP8 packed MoE: shard the intermediate (dim 2 /
+                    // dim 1 after layout) — never dim 0 (experts).
                     let inter = moe_cfg.moe_intermediate_size;
                     let hidden = cfg.hidden_size;
-                    let sh0 = shard(0, comm.rank(), comm.world_size());
-                    let sh1 = shard(1, comm.rank(), comm.world_size());
+                    let world = comm.world_size().max(1);
+                    let rank = comm.rank();
                     let no_shard = Shard::default();
+                    let sh_gate = shard(2, rank, world * 2);
+                    let sh_up = shard(2, rank + world, world * 2);
+                    let sh_down = shard(1, rank, world);
 
-                    let gu_raw = vb.get_with_hints_dtype(
+                    let gu_gate = vb.get_with_hints_dtype(
                         (num_experts, hidden / 2, 2 * inter),
                         "gate_up_proj",
-                        sh0,
+                        sh_gate,
                         DType::U8,
                     )?;
-                    let gu_sc_raw = vb.get_with_hints_dtype(
+                    let gu_up = vb.get_with_hints_dtype(
+                        (num_experts, hidden / 2, 2 * inter),
+                        "gate_up_proj",
+                        sh_up,
+                        DType::U8,
+                    )?;
+                    let gu_sc_gate = vb.get_with_hints_dtype(
                         (num_experts, hidden / 16, 2 * inter),
                         "gate_up_proj_weight_scale",
-                        sh0,
+                        sh_gate,
+                        DType::U8,
+                    )?;
+                    let gu_sc_up = vb.get_with_hints_dtype(
+                        (num_experts, hidden / 16, 2 * inter),
+                        "gate_up_proj_weight_scale",
+                        sh_up,
                         DType::U8,
                     )?;
                     let gate_up_gscale = if vb.contains_tensor("gate_up_proj_weight_scale_2") {
@@ -2929,12 +2943,12 @@ impl FusedMoeNvfp4 {
                     };
 
                     for i in 0..num_experts {
-                        let gu = gu_raw.get(i)?.t()?.contiguous()?;
-                        let gs = gu_sc_raw.get(i)?.t()?.contiguous()?;
-                        gate_blocks_vec.push(gu.narrow(0, 0, inter)?.contiguous()?);
-                        up_blocks_vec.push(gu.narrow(0, inter, inter)?.contiguous()?);
-                        gate_scales_vec.push(gs.narrow(0, 0, inter)?.contiguous()?);
-                        up_scales_vec.push(gs.narrow(0, inter, inter)?.contiguous()?);
+                        // Each shard already holds local_inter along dim 2;
+                        // transpose to [local_inter, K/2] / [local_inter, K/16].
+                        gate_blocks_vec.push(gu_gate.get(i)?.t()?.contiguous()?);
+                        up_blocks_vec.push(gu_up.get(i)?.t()?.contiguous()?);
+                        gate_scales_vec.push(gu_sc_gate.get(i)?.t()?.contiguous()?);
+                        up_scales_vec.push(gu_sc_up.get(i)?.t()?.contiguous()?);
                         gate_gscales_vec.push(gate_up_gscale);
                         up_gscales_vec.push(gate_up_gscale);
                         gate_iscales_vec.push(gate_up_iscale);
@@ -2944,13 +2958,13 @@ impl FusedMoeNvfp4 {
                     let d_raw = vb.get_with_hints_dtype(
                         (num_experts, inter / 2, hidden),
                         "down_proj",
-                        sh1,
+                        sh_down,
                         DType::U8,
                     )?;
                     let d_sc_raw = vb.get_with_hints_dtype(
                         (num_experts, inter / 16, hidden),
                         "down_proj_weight_scale",
-                        sh1,
+                        sh_down,
                         DType::U8,
                     )?;
                     let down_gscale = if vb.contains_tensor("down_proj_weight_scale_2") {

--- a/src/models/qwen3_5_moe.rs
+++ b/src/models/qwen3_5_moe.rs
@@ -180,51 +180,52 @@ impl Qwen3_5MoEDecoderLayer {
         };
 
         // Shared experts (Qwen2 MoE style)
-        let (shared_gate, shared_expert) = if let Some(intermediate_size) =
-            moe_cfg.shared_expert_intermediate_size
-        {
-            if intermediate_size > 0 {
-                let ws = match &vb.0 {
-                    Either::Left(vb) => vb
-                        .pp("mlp.shared_expert_gate")
-                        .get((1, config.hidden_size), "weight")?,
-                    Either::Right(vb) => {
-                        let ws = vb
-                            .pp("ffn_gate_inp_shexp")
-                            .get((config.hidden_size,), "weight")?;
-                        ws.dequantize(&vb.device())?
-                            .reshape((1, config.hidden_size))?
+        let (shared_gate, shared_expert) =
+            if let Some(intermediate_size) = moe_cfg.shared_expert_intermediate_size {
+                if intermediate_size > 0 {
+                    let ws = match &vb.0 {
+                        Either::Left(vb) => vb
+                            .pp("mlp.shared_expert_gate")
+                            .get((1, config.hidden_size), "weight")?,
+                        Either::Right(vb) => {
+                            let ws = vb
+                                .pp("ffn_gate_inp_shexp")
+                                .get((config.hidden_size,), "weight")?;
+                            ws.dequantize(&vb.device())?
+                                .reshape((1, config.hidden_size))?
+                        }
                     }
-                }
-                .to_dtype(if is_qvar_builder || config.quant.is_some() {
-                    DType::F32
+                    .to_dtype(
+                        if is_qvar_builder || config.higher_precision_required() {
+                            DType::F32
+                        } else {
+                            dtype
+                        },
+                    )?;
+                    let shared_gate = Linear::new(ws, None, &None)?;
+                    let mlp = MLP::new(
+                        if is_qvar_builder {
+                            vb.clone()
+                        } else {
+                            vb.pp("mlp.shared_expert").clone()
+                        },
+                        comm.clone(),
+                        config.hidden_size,
+                        intermediate_size,
+                        &config.hidden_act,
+                        &config.quantization_config,
+                        &config.quant,
+                        false,
+                        dtype,
+                        if is_qvar_builder { "_shexp" } else { "" },
+                    )?;
+                    (Some(shared_gate), Some(mlp))
                 } else {
-                    dtype
-                })?;
-                let shared_gate = Linear::new(ws, None, &None)?;
-                let mlp = MLP::new(
-                    if is_qvar_builder {
-                        vb.clone()
-                    } else {
-                        vb.pp("mlp.shared_expert").clone()
-                    },
-                    comm.clone(),
-                    config.hidden_size,
-                    intermediate_size,
-                    &config.hidden_act,
-                    &config.quantization_config,
-                    &config.quant,
-                    false,
-                    dtype,
-                    if is_qvar_builder { "_shexp" } else { "" },
-                )?;
-                (Some(shared_gate), Some(mlp))
+                    (None, None)
+                }
             } else {
                 (None, None)
-            }
-        } else {
-            (None, None)
-        };
+            };
 
         let norm_dtype = if is_qvar_builder || config.higher_precision_required() {
             DType::F32
@@ -309,8 +310,21 @@ impl Qwen3_5MoEDecoderLayer {
         // Shared experts
         let shared_output = match (&self.shared_gate, &self.shared_expert) {
             (Some(shared_gate), Some(shared_expert)) => {
-                let gate = candle_nn::ops::sigmoid(&shared_gate.forward(&xs)?)?;
+                // Gate weights may be F32 under NVFP4/ISQ/GGUF while residual
+                // activations stay BF16 — cast like the MoE router path.
+                let gate_dtype = shared_gate.weight_dtype();
+                let gate_in = if xs.dtype() != gate_dtype {
+                    xs.to_dtype(gate_dtype)?
+                } else {
+                    xs.clone()
+                };
+                let gate = candle_nn::ops::sigmoid(&shared_gate.forward(&gate_in)?)?;
                 let shared_output = shared_expert.forward(&xs)?;
+                let gate = if gate.dtype() != shared_output.dtype() {
+                    gate.to_dtype(shared_output.dtype())?
+                } else {
+                    gate
+                };
                 Some(gate.broadcast_mul(&shared_output)?)
             }
             _ => None,

--- a/src/models/qwen3_5_mtp.rs
+++ b/src/models/qwen3_5_mtp.rs
@@ -147,8 +147,19 @@ impl MtpMlp {
             } => {
                 let shared_output = match (shared_gate, shared_expert) {
                     (Some(sg), Some(se)) => {
-                        let gate = candle_nn::ops::sigmoid(&sg.forward(xs)?)?;
+                        let gate_dtype = sg.weight_dtype();
+                        let gate_in = if xs.dtype() != gate_dtype {
+                            xs.to_dtype(gate_dtype)?
+                        } else {
+                            xs.clone()
+                        };
+                        let gate = candle_nn::ops::sigmoid(&sg.forward(&gate_in)?)?;
                         let shared_out = se.forward(xs)?;
+                        let gate = if gate.dtype() != shared_out.dtype() {
+                            gate.to_dtype(shared_out.dtype())?
+                        } else {
+                            gate
+                        };
                         Some(gate.broadcast_mul(&shared_out)?)
                     }
                     _ => None,
@@ -360,11 +371,13 @@ impl Qwen3_5MtpHead {
                             ws.dequantize(&vb.device())?.reshape((1, hidden_size))?
                         }
                     }
-                    .to_dtype(if is_qvar_builder {
-                        DType::F32
-                    } else {
-                        dtype
-                    })?;
+                    .to_dtype(
+                        if is_qvar_builder || mtp_config.higher_precision_required() {
+                            DType::F32
+                        } else {
+                            dtype
+                        },
+                    )?;
                     let shared_gate = Linear::new(ws, None, &None)?;
                     let shared_mlp = MLP::new(
                         if is_qvar_builder {

--- a/tests/probes/compare_gdn_probe.py
+++ b/tests/probes/compare_gdn_probe.py
@@ -51,7 +51,7 @@ def compare(name, got, gold, tol, failures):
         # This remains strict enough to catch state corruption or skipped
         # updates while allowing the expected reduction-order error.
         ok = report(name, got, gold, dtype=torch.float32, allowed_ulp=None,
-                    max_rel=3e-5, abs_tol=5e-4, rel_floor=0.1)
+                    max_rel=5e-5, abs_tol=5e-4, rel_floor=0.1)
     elif name.endswith("_out") or "rmsnorm" in name or name == "gdn_l2_norm":
         ok = report(name, got, gold, dtype=torch.bfloat16, allowed_ulp=1)
     else:


### PR DESCRIPTION
Optional online scale compute for nvfp4 models:

```
XINFER_NVFP4_ONLINE_SCALE=1 target/release/xinfer --m /data/GadflyII-GLM-4.7-Flash-NVFP4/  --ui-server
```